### PR TITLE
Allow building resiprocate from an external directory

### DIFF
--- a/b2bua/Makefile.am
+++ b/b2bua/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST = README.txt
 SUBDIRS = . 
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 lib_LTLIBRARIES = libb2bua.la
 

--- a/p2p/Makefile.am
+++ b/p2p/Makefile.am
@@ -1,7 +1,7 @@
 # $Id$
 
 #AM_CXXFLAGS = -DUSE_ARES 
-AM_CXXFLAGS = -I./s2c
+AM_CXXFLAGS = -I $(top_srcdir) -I $(top_srcdir)/p2p/s2c
 
 lib_LTLIBRARIES = libp2p.la
 

--- a/presSvr/Makefile.am
+++ b/presSvr/Makefile.am
@@ -1,6 +1,7 @@
 # $Id$
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 sbin_PROGRAMS = presSvr
 presSvr_SOURCES = presSvr.cpp \

--- a/reTurn/Makefile.am
+++ b/reTurn/Makefile.am
@@ -15,6 +15,7 @@ SUBDIRS += test
 SUBDIRS += client
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 sbin_PROGRAMS = reTurnServer
 reTurnServer_SOURCES = reTurnServer.cxx \

--- a/reTurn/test/Makefile.am
+++ b/reTurn/test/Makefile.am
@@ -4,6 +4,7 @@ EXTRA_DIST = stunTestVectors_10_0.vcxproj stunTestVectors_10_0.vcxproj.filters
 EXTRA_DIST += *.vcproj
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 LDADD = ../client/libreTurnClient.la
 LDADD += ../../rutil/librutil.la

--- a/reflow/Makefile.am
+++ b/reflow/Makefile.am
@@ -8,6 +8,7 @@ SUBDIRS = .
 #SUBDIRS += dtls_wrapper/test
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 lib_LTLIBRARIES = libreflow.la
 libreflow_la_LIBADD = ../reTurn/client/libreTurnClient.la

--- a/repro/Makefile.am
+++ b/repro/Makefile.am
@@ -20,6 +20,7 @@ EXTRA_DIST += genUsers.cxx
 SUBDIRS = . test reprocmd accountingconsumers
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 sbin_PROGRAMS = repro
 repro_SOURCES = repro.cxx

--- a/repro/accountingconsumers/Makefile.am
+++ b/repro/accountingconsumers/Makefile.am
@@ -4,6 +4,7 @@ EXTRA_DIST = *.vcxproj *.vcxproj.filters
 EXTRA_DIST += *.vcproj
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 sbin_PROGRAMS = queuetostream
 queuetostream_SOURCES = queuetostream.cpp

--- a/repro/reprocmd/Makefile.am
+++ b/repro/reprocmd/Makefile.am
@@ -4,6 +4,7 @@ EXTRA_DIST = reprocmd_10_0.vcxproj reprocmd_10_0.vcxproj.filters
 EXTRA_DIST += *.vcproj
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 sbin_PROGRAMS = reprocmd
 reprocmd_SOURCES = reprocmd.cpp

--- a/repro/test/Makefile.am
+++ b/repro/test/Makefile.am
@@ -3,6 +3,7 @@
 EXTRA_DIST = reg.py
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 LDADD = ../librepro.la
 LDADD += ../../resip/dum/libdum.la

--- a/resip/dum/Makefile.am
+++ b/resip/dum/Makefile.am
@@ -8,6 +8,7 @@ EXTRA_DIST += doc
 SUBDIRS = . test
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 lib_LTLIBRARIES = libdum.la
 

--- a/resip/dum/test/Makefile.am
+++ b/resip/dum/test/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST += *.vcproj
 EXTRA_DIST += fullHeaders.bytes
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 LDADD = ../libdum.la
 LDADD += ../../stack/libresip.la

--- a/resip/stack/Makefile.am
+++ b/resip/stack/Makefile.am
@@ -19,6 +19,8 @@ EXTRA_DIST += ssl/WinSecurity.cxx
 
 SUBDIRS = . test
 
+AM_CXXFLAGS = -I $(top_srcdir)
+
 # 
 # make chokes on the filenames under doc/ because some of them have spaces
 # in them.  The content needs to be reviewed and renamed appropriately

--- a/resip/stack/test/Makefile.am
+++ b/resip/stack/test/Makefile.am
@@ -26,6 +26,7 @@ EXTRA_DIST += testTFSM-serverinvite
 EXTRA_DIST += testTFSM-servernoninvite
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 LDADD = ../libresip.la
 LDADD += ../../../rutil/librutil.la

--- a/rutil/Makefile.am
+++ b/rutil/Makefile.am
@@ -16,6 +16,10 @@ EXTRA_DIST += WinCompat.cxx
 EXTRA_DIST += dns/LocalDns.cxx
 
 #AM_CXXFLAGS = -I../contrib/ares -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir) 
+if USE_ARES
+AM_CXXFLAGS += -I $(top_srcdir)/rutil/dns/ares
+endif
 
 lib_LTLIBRARIES = librutil.la
 

--- a/rutil/test/Makefile.am
+++ b/rutil/test/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST += runtests.sh
 EXTRA_DIST += sweepRandom.sh
 
 #AM_CXXFLAGS = -DUSE_ARES
+AM_CXXFLAGS = -I $(top_srcdir)
 
 LDADD = ../librutil.la
 #LDADD += ../../contrib/ares/libares.a

--- a/tfm/Makefile.am
+++ b/tfm/Makefile.am
@@ -15,6 +15,8 @@ SUBDIRS = .
 SUBDIRS += repro
 SUBDIRS += tfdum
 
+AM_CXXFLAGS = -I $(top_srcdir)
+
 lib_LTLIBRARIES = libtfm.la
 
 libtfm_la_LDFLAGS = @LIBTOOL_VERSION_RELEASE@ -export-dynamic

--- a/tfm/repro/Makefile.am
+++ b/tfm/repro/Makefile.am
@@ -3,6 +3,8 @@ EXTRA_DIST = sanityTests.vcproj
 
 TESTS = sanityTests
 
+AM_CXXFLAGS = -I $(top_srcdir)
+
 check_PROGRAMS = sanityTests
 
 sanityTests_LDADD = ../libtfm.la


### PR DESCRIPTION
...ource top dir.   This patch allows building from an external directory so that object files and other files generated by automake and autoconf do not pollute the source tree.

Example:
git clone https://github.com/resiprocate/resiprocate
cd resiprocate
autoreconf -if
cd ..
mkdir BUILD
cd BUILD
../resiprocate/configure --prefix=`pwd`/build
make && make install
