### PR TITLE
Update the Wants and After details for the repro service

### DIFF
--- a/repro/pkg/fedora/repro.service
+++ b/repro/pkg/fedora/repro.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=reSIProcate repro SIP proxy daemon
+After=network-online.target
 After=syslog.target
-After=network.target
+Wants=network-online.target
 
 [Service]
 ExecStart=/usr/sbin/repro /etc/repro/repro.config --Daemonize=false


### PR DESCRIPTION
Service fails to begin on Fedora 21, this seems to work around the problem.  I started a conversation with Daniel Pocock via the repro-users distribution list and he asked that I provide a pull request so that people can discuss the pros and cons of this particular solution in the pull request.