### PR TITLE
ifdef out SSL_OP_NO_TLSv1_1 and SSL_OP_NO_TLSv1_2

### DIFF
--- a/resip/stack/ssl/Security.cxx
+++ b/resip/stack/ssl/Security.cxx
@@ -2805,14 +2805,18 @@ BaseSecurity::parseOpenSSLCTXOption(const Data& optionName)
    {
       return SSL_OP_NO_TLSv1;
    }
+#ifdef SSL_OP_NO_TLSv1_1
    if(optionName == "SSL_OP_NO_TLSv1_1")
    {
       return SSL_OP_NO_TLSv1_1;
    }
+#endif
+#ifdef SSL_OP_NO_TLSv1_2
    if(optionName == "SSL_OP_NO_TLSv1_2")
    {
       return SSL_OP_NO_TLSv1_2;
    }
+#endif
    if(optionName == "SSL_OP_PKCS1_CHECK_1")
    {
       return SSL_OP_PKCS1_CHECK_1;


### PR DESCRIPTION
Support older versions of openssl (as in CentOS/RHEL6, older openSUSE etc)