### PR TITLE
Make DNS cache lookup case insensitive

### DIFF
--- a/rutil/dns/RRCache.hxx
+++ b/rutil/dns/RRCache.hxx
@@ -67,7 +67,7 @@ class RRCache
                }
                else
                {
-                  return lhs->key() < rhs->key();
+                  return (Data(lhs->key())).lowercase() < (Data(rhs->key())).lowercase();
                }
             }
       };


### PR DESCRIPTION
Make DNS cache lookup case insensitive to prevent multiple DNS requests when casing is different in SIP messaging then that which is returned by the DNS server.