### PR TITLE
Initialize pointer to NULL

### DIFF
--- a/rutil/dns/ares/ares_init.c
+++ b/rutil/dns/ares/ares_init.c
@@ -167,6 +167,7 @@ int ares_init_options_with_socket_function(ares_channel *channelptr, struct ares
   channel->ndomains = -1;
   channel->nsort = -1;
   channel->lookups = NULL;
+  channel->servers = NULL;
 
   /* Initialize configuration by each of the four sources, from highest
    * precedence to lowest.


### PR DESCRIPTION
Prevents a crash freeing unallocated memory in ares_destroy_internal if the servers pointer is never populated. This is the case on Android if no network is available on boot.