### PR TITLE
Qualify bind to prevent clang from using std::bind

### DIFF
--- a/rutil/stun/Udp.cxx
+++ b/rutil/stun/Udp.cxx
@@ -64,7 +64,7 @@ openPort( unsigned short port, unsigned int interfaceIp, bool verbose )
       }
    }
 	
-   if ( bind( fd,(struct sockaddr*)&addr, sizeof(addr)) != 0 )
+   if ( ::bind( fd,(struct sockaddr*)&addr, sizeof(addr)) != 0 )
    {
       int e = getErrno();
         


### PR DESCRIPTION
Because of the "using namespace std", clang tries to use std::bind
for a bind() call instead of ::bind.

Signed-off-by: Gregor Jasny <Gregor.Jasny@citrix.com>