### PR TITLE
Fix for a buffer management bug in parsing frames from a websocket.

### DIFF
--- a/resip/stack/WsFrameExtractor.cxx
+++ b/resip/stack/WsFrameExtractor.cxx
@@ -83,18 +83,18 @@ WsFrameExtractor::processBytes(UInt8 *input, Data::size_type len, bool& dropConn
             return ret;
          }
 
-         Data::size_type takeBytes = len - pos;
-         if(takeBytes > mPayloadLength)
-         {
-            takeBytes = mPayloadLength;
-         }
-
          if(mPayload == 0)
          {
             StackLog(<<"starting new frame buffer");
             // Include an extra byte at the end for null terminator
             mPayload = (UInt8*)new char[mPayloadLength + 1];
             mPayloadPos = 0;
+         }
+
+         Data::size_type takeBytes = len - pos;
+         if(takeBytes > mPayloadLength - mPayloadPos)
+         {
+            takeBytes = mPayloadLength - mPayloadPos;
          }
 
          if(mMasked)


### PR DESCRIPTION
In buffer management/parsing, turns out that if you had a piece of a SIP
packet in the previous buffer (input), and in the current one the remainder
of that packet and another one, it will just copy until the end of input,
instead of just the needed length.

The calculations were also done at the wrong place, they had to be done after
the allocation of the new buffer.

The bug meant that:
- Some packets were getting eaten, resulting in random disconnections and
other dropped events;
- Sometimes repro would crash;
- Or, if compiled with ASAN, it would always crash.

Also, it was more pronounced with TLS.

A way to reproduce this on the original repro is to create a stream with the HTTP upgrade request in the beginning and some SIP  packets after that (I did it with 20k file), and just sending it with something like
cat req | (sleep 2; telnet repro 5066)
would crash the server.