### PR TITLE
Don't use SHA-1 for SSL certificates.

### DIFF
--- a/resip/certs/Readme.txt
+++ b/resip/certs/Readme.txt
@@ -36,8 +36,8 @@ openssl smime -verify -in bar.msg -signer fluffy.pem -CAfile root.pem
 
 
 -- Generating a self signed cert and key -- 
-openssl genrsa -out id_key.pem 512
-openssl req -x509 -new -config extn.cnf -sha1 -key id_key.pem -days 500 -out id.pem 
+openssl genrsa -out id_key.pem 2048
+openssl req -x509 -new -config extn.cnf -sha256 -key id_key.pem -days 500 -out id.pem 
 
 
 --- Generating a cert for TLS use --- 

--- a/resip/certs/makeCA
+++ b/resip/certs/makeCA
@@ -106,7 +106,7 @@ EOF
 # 
 #openssl req -newkey rsa:2048 -passin pass:password \
 #     -passout pass:password \
-#     -sha1 -x509 -keyout demoCA/private/cakey.pem \
+#     -sha256 -x509 -keyout demoCA/private/cakey.pem \
 #     -out demoCA/cacert.pem -days 3650 <<EOF
 #US
 #California

--- a/resip/certs/makeCert
+++ b/resip/certs/makeCert
@@ -37,7 +37,7 @@ export ALTNAME
 
 openssl genrsa  -out ${ADDR}_key.pem 2048
 openssl req -new  -config openssl.cnf -reqexts cj_req \
-        -sha1 -key ${ADDR}_key.pem \
+        -sha256 -key ${ADDR}_key.pem \
         -out ${ADDR}.csr -days ${DAYS} <<EOF
 US
 California
@@ -53,14 +53,14 @@ EOF
 if [ $DAYS == 0 ]; then
 openssl ca -extensions cj_cert -config openssl.cnf \
     -passin pass:password -policy policy_anything \
-    -md sha1 -batch -notext -out ${ADDR}_cert.pem \
+    -md sha256 -batch -notext -out ${ADDR}_cert.pem \
     -startdate 990101000000Z \
     -enddate 000101000000Z \
      -infiles ${ADDR}.csr
 else
 openssl ca -extensions cj_cert -config openssl.cnf \
     -passin pass:password -policy policy_anything \
-    -md sha1 -days ${DAYS} -batch -notext -out ${ADDR}_cert.pem \
+    -md sha256 -days ${DAYS} -batch -notext -out ${ADDR}_cert.pem \
      -infiles ${ADDR}.csr
 fi
 

--- a/resip/stack/ssl/Security.cxx
+++ b/resip/stack/ssl/Security.cxx
@@ -1417,7 +1417,7 @@ BaseSecurity::generateUserCert (const Data& pAor, int expireDays, int keyLen )
    }
    
    // Make sure that necessary algorithms exist:
-   resip_assert(EVP_sha1());
+   resip_assert(EVP_sha256());
 
 #if OPENSSL_VERSION_NUMBER < 0x00908000l
    RSA* rsa = RSA_generate_key(keyLen, RSA_F4, NULL, NULL);
@@ -1499,7 +1499,7 @@ BaseSecurity::generateUserCert (const Data& pAor, int expireDays, int keyLen )
    
    // TODO add extensions NID_subject_key_identifier and NID_authority_key_identifier
    
-   ret = X509_sign(cert, privkey, EVP_sha1());
+   ret = X509_sign(cert, privkey, EVP_sha256());
    resip_assert(ret);
    
    addCertX509( UserCert, aor, cert, true /* write */ );
@@ -1513,7 +1513,7 @@ BaseSecurity::sign(const Data& senderAor, Contents* contents)
 
    // form the multipart
    MultipartSignedContents* multi = new MultipartSignedContents;
-   multi->header(h_ContentType).param( p_micalg ) = "sha1";
+   multi->header(h_ContentType).param( p_micalg ) = "sha256";
    multi->header(h_ContentType).param( p_protocol ) = "application/pkcs7-signature";
 
    // add the main body to it
@@ -1776,7 +1776,7 @@ BaseSecurity::computeIdentity( const Data& signerDomain, const Data& in ) const
    DebugLog( << "hash of string is 0x" << hashRes.hex() );
 
 #if 1
-   int r = RSA_sign(NID_sha1, (unsigned char *)hashRes.data(), (unsigned int)hashRes.size(),
+   int r = RSA_sign(NID_sha256, (unsigned char *)hashRes.data(), (unsigned int)hashRes.size(),
                     result, (unsigned int*)( &resultSize ),
             rsa);
    if( r != 1 )
@@ -1864,7 +1864,7 @@ BaseSecurity::checkIdentity( const Data& signerDomain, const Data& in, const Dat
    RSA* rsa = EVP_PKEY_get1_RSA(pKey);
 
 #if 1
-   int ret = RSA_verify(NID_sha1, (unsigned char *)hashRes.data(),
+   int ret = RSA_verify(NID_sha256, (unsigned char *)hashRes.data(),
                         (unsigned int)hashRes.size(), (unsigned char*)sig.data(), (unsigned int)sig.size(),
                         rsa);
 #else


### PR DESCRIPTION
SHA-1 should not be used anymore in SSL certificates.

https://wiki.mozilla.org/CA:Problematic_Practices#SHA-1_Certificates
https://blog.mozilla.org/security/2014/09/23/phasing-out-certificates-with-sha-1-based-signature-algorithms/
http://blogs.technet.com/b/pki/archive/2013/11/12/sha1-deprecation-policy.aspx