### PR TITLE
Implement server error conditions

### DIFF
--- a/resip/stack/Connection.cxx
+++ b/resip/stack/Connection.cxx
@@ -32,15 +32,17 @@ volatile bool Connection::mEnablePostConnectSocketFuncCall = false;
 #define RESIPROCATE_SUBSYSTEM Subsystem::TRANSPORT
 
 Connection::Connection(Transport* transport,const Tuple& who, Socket socket,
-                       Compression &compression)
+                       Compression &compression,
+                       bool isServer)
    : ConnectionBase(transport,who,compression),
      mFirstWriteAfterConnectedPending(false),
      mInWritable(false),
      mFlowTimerEnabled(false),
-     mPollItemHandle(0)
+     mPollItemHandle(0),
+     mIsServer(isServer)
 {
    mWho.mFlowKey=(FlowKey)socket;
-   InfoLog (<< "Connection::Connection: new connection created to who: " << mWho);
+   InfoLog (<< "Connection::Connection: new connection created to who: " << mWho << ", is server = " << mIsServer);
 
    if(transport && isWebSocket(transport->transport()))
    {
@@ -537,6 +539,8 @@ Connection::processPollEvent(FdPollEventMask mask) {
       performReads();
    }
 }
+
+bool Connection::isServer()const{ return mIsServer; }
 
 /* ====================================================================
  * The Vovida Software License, Version 1.0 

--- a/resip/stack/Connection.hxx
+++ b/resip/stack/Connection.hxx
@@ -43,7 +43,7 @@ class Connection : public ConnectionBase,
       friend EncodeStream& operator<<(EncodeStream& strm, const resip::Connection& c);
 
    public:
-      Connection(Transport* transport,const Tuple& who, Socket socket, Compression &compression);
+      Connection(Transport* transport,const Tuple& who, Socket socket, Compression &compression, bool isServer);
       virtual ~Connection();
       
       /*!
@@ -103,7 +103,7 @@ class Connection : public ConnectionBase,
       bool mFirstWriteAfterConnectedPending;
       static volatile bool mEnablePostConnectSocketFuncCall;
       static void setEnablePostConnectSocketFuncCall(bool enabled = true) { mEnablePostConnectSocketFuncCall = enabled; }
-
+      bool isServer()const;
    protected:
       /// pure virtual, but need concrete Connection for book-ends of lists
       virtual int read(char* /* buffer */, const int /* count */) { return 0; }
@@ -128,6 +128,7 @@ class Connection : public ConnectionBase,
       /// no value semantics
       Connection(const Connection&);
       Connection& operator=(const Connection&);
+      bool mIsServer;
 };
 
 EncodeStream& 

--- a/resip/stack/ConnectionManager.cxx
+++ b/resip/stack/ConnectionManager.cxx
@@ -24,7 +24,7 @@ UInt64 ConnectionManager::MinimumGcHeadroom = 0;
 bool ConnectionManager::EnableAgressiveGc = false;
 
 ConnectionManager::ConnectionManager() : 
-   mHead(0,Tuple(),0,Compression::Disabled),
+   mHead(0,Tuple(),0,Compression::Disabled, false),
    mWriteHead(ConnectionWriteList::makeList(&mHead)),
    mReadHead(ConnectionReadList::makeList(&mHead)),
    mLRUHead(ConnectionLruList::makeList(&mHead)),
@@ -214,7 +214,7 @@ ConnectionManager::addConnection(Connection* connection)
 void
 ConnectionManager::removeConnection(Connection* connection)
 {
-   //DebugLog (<< "ConnectionManager::removeConnection()");
+   DebugLog (<< "ConnectionManager::removeConnection()");
 
    mIdMap.erase(connection->mWho.mFlowKey);
    mAddrMap.erase(connection->mWho);

--- a/resip/stack/TcpBaseTransport.cxx
+++ b/resip/stack/TcpBaseTransport.cxx
@@ -186,8 +186,15 @@ TcpBaseTransport::processListen()
          mSocketFunc(sock, transport(), __FILE__, __LINE__);
       }
 
-      if(!mConnectionManager.findConnection(tuple))
+      Connection* c = mConnectionManager.findConnection(tuple);
+      if(!c)
       {
+         createConnection(tuple, sock, true);
+      }
+      else if(false == c->isServer())
+      {
+         InfoLog( << "Have client connection for " << tuple << ", but got server one, recreate connection" );
+         delete c;
          createConnection(tuple, sock, true);
       }
       else

--- a/resip/stack/TcpConnection.cxx
+++ b/resip/stack/TcpConnection.cxx
@@ -12,8 +12,8 @@ using namespace resip;
 #define RESIPROCATE_SUBSYSTEM Subsystem::TRANSPORT
 
 TcpConnection::TcpConnection(Transport* transport,const Tuple& who, Socket fd,
-                             Compression &compression) 
-  : Connection(transport,who, fd, compression)
+                             Compression &compression, bool isServer)
+  : Connection(transport,who, fd, compression, isServer)
 {
    DebugLog (<< "Creating TCP connection " << who << " on " << fd);
 }

--- a/resip/stack/TcpConnection.hxx
+++ b/resip/stack/TcpConnection.hxx
@@ -11,7 +11,7 @@ class Tuple;
 class TcpConnection : public Connection
 {
    public:
-      TcpConnection( Transport* transport, const Tuple& who, Socket fd, Compression &compression);
+      TcpConnection( Transport* transport, const Tuple& who, Socket fd, Compression &compression, bool isServer);
       
       int read( char* buf, const int count );
       int write( const char* buf, const int count );

--- a/resip/stack/TcpTransport.cxx
+++ b/resip/stack/TcpTransport.cxx
@@ -50,7 +50,7 @@ Connection*
 TcpTransport::createConnection(const Tuple& who, Socket fd, bool server)
 {
    resip_assert(this);
-   Connection* conn = new TcpConnection(this, who, fd, mCompression);
+   Connection* conn = new TcpConnection(this, who, fd, mCompression, server);
    return conn;
 }
 

--- a/resip/stack/WsConnection.cxx
+++ b/resip/stack/WsConnection.cxx
@@ -11,8 +11,9 @@ using namespace resip;
 WsConnection::WsConnection(Transport* transport,
                            const Tuple& who, Socket fd,
                            Compression &compression,
-                           SharedPtr<WsConnectionValidator> wsConnectionValidator)
-  : TcpConnection(transport,who, fd, compression), WsConnectionBase(wsConnectionValidator)
+                           SharedPtr<WsConnectionValidator> wsConnectionValidator,
+                           bool isServer)
+  : TcpConnection(transport,who, fd, compression, isServer), WsConnectionBase(wsConnectionValidator)
 {
    DebugLog (<< "Creating WS connection " << who << " on " << fd);
 }

--- a/resip/stack/WsConnection.hxx
+++ b/resip/stack/WsConnection.hxx
@@ -18,7 +18,8 @@ class WsConnection :  public TcpConnection, public WsConnectionBase
       WsConnection(Transport* transport,
                    const Tuple& who, Socket fd,
                    Compression &compression,
-                   SharedPtr<WsConnectionValidator> wsConnectionValidator);
+                   SharedPtr<WsConnectionValidator> wsConnectionValidator,
+                   bool isServer);
 
    private:
       /// No default c'tor

--- a/resip/stack/WsTransport.cxx
+++ b/resip/stack/WsTransport.cxx
@@ -45,7 +45,7 @@ Connection*
 WsTransport::createConnection(const Tuple& who, Socket fd, bool server)
 {
    resip_assert(this);
-   Connection* conn = new WsConnection(this,who, fd, mCompression, mConnectionValidator);
+   Connection* conn = new WsConnection(this,who, fd, mCompression, mConnectionValidator, server);
    return conn;
 }
 

--- a/resip/stack/ssl/TlsConnection.cxx
+++ b/resip/stack/ssl/TlsConnection.cxx
@@ -57,7 +57,7 @@ TlsConnection::TlsConnection( Transport* transport, const Tuple& tuple,
                               Socket fd, Security* security, 
                               bool server, Data domain,  SecurityTypes::SSLType sslType ,
                               Compression &compression) :
-   Connection(transport,tuple, fd, compression),
+   Connection(transport,tuple, fd, compression, server),
    mServer(server),
    mSecurity(security),
    mSslType( sslType ),


### PR DESCRIPTION
* implement  http://tools.ietf.org/html/rfc3261#section-18.1.1, paragraph 8
Under error conditions, the
   server may attempt to open a new connection to send the response.  To
   handle this case, the transport layer MUST also be prepared to
   receive an incoming connection on the source IP address from which
   the request was sent and port number in the "sent-by" field.