### PR TITLE
Corrected call to ErrLog macro on MacOS/iOS

### DIFF
--- a/rutil/Socket.cxx
+++ b/rutil/Socket.cxx
@@ -70,8 +70,7 @@ resip::configureConnectedSocket(Socket fd)
    if ( ::setsockopt ( fd, SOL_SOCKET, SO_NOSIGPIPE, (const char*)&on, sizeof(on)) )
    {
       int e = getErrno();
-      ErrorLog (<< "Couldn't set sockoption SO_NOSIGPIPE: " << strerror(e));
-      error(e);
+      ErrLog (<< "Couldn't set sockoption SO_NOSIGPIPE: " << strerror(e));
       return false;
    }
 #endif


### PR DESCRIPTION
There is one specific case that only occurs on iOS/MacOS (as far as I can tell), where there is a compile-time error in an attempt to log a message.  (This corrects that :))

I didn't see an immediate definition or pattern for the `error(e)` call in the surrounding code, so I am assuming at this point that the `ErrLog` call is sufficient.