### PR TITLE
Fix for signed types on iOS/MacOS

### DIFF
--- a/rutil/compat.hxx
+++ b/rutil/compat.hxx
@@ -144,7 +144,7 @@ typedef char           Int8;
 typedef short          Int16;
 typedef int            Int32;
 #else
-# On Apple platforms, MacTypes.h should provide the types:
+// On Apple platforms, MacTypes.h should provide the types:
 #include <MacTypes.h>
 #endif
 

--- a/rutil/compat.hxx
+++ b/rutil/compat.hxx
@@ -146,6 +146,9 @@ typedef int            Int32;
 #else
 // On Apple platforms, MacTypes.h should provide the types:
 #include <MacTypes.h>
+typedef SInt8          Int8;
+typedef SInt16         Int16;
+typedef SInt32         Int32;
 #endif
 
 #if defined( TARGET_OS_IPHONE )


### PR DESCRIPTION
On iOS/MacOS (at least with current SDKs), `MacTypes.h`  does declare `UInt8`/`UInt16`/etc for unsigned types.  But, for signed types, `MacTypes.h` defines them as `SInt8`/etc, rather than the `Int8` that the rest of the codebase expects.  This simply adds some typedefs for the signed types.

(Also, there was a minor error in the same block with a comment that accidentally was prefixed with `#`, so the preprocessor was attempting to pick it up)