### PR TITLE
Fixed issue with DUM ServerInviteSession not automatically re-issuing an INVITE after received a 491. Also added tfdum test.

### DIFF
--- a/resip/dum/ServerInviteSession.cxx
+++ b/resip/dum/ServerInviteSession.cxx
@@ -933,6 +933,10 @@ ServerInviteSession::dispatch(const DumTimeout& timeout)
          mDialog.makeRequest(*mLastLocalSessionModification, UPDATE);  // increments CSeq
          send(mLastLocalSessionModification);
       }
+      else
+      {
+         InviteSession::dispatch(timeout);
+      }
    }
    else
    {


### PR DESCRIPTION
A ServerInviteSession receiving a 491 for a re-INVITE it just sent will not automatically resend the re-INVITE as per RFC 3261, Section 14.1.

The same scenario works fine in the case of a ClientInviteSession. It looks like there was a missing "else" statement in ServerInviteSession that is present in ClientInviteSession for the default handling of the DumTimeout::Glare timeout.

This patch adds the "else" statement to ServerInviteSession.cxx and also adds a tfdum automated test suite that should test both Client/Server cases.

I have mostly tested the patch with re-INVITE and not UPDATE and/or PRACK, but all test suites seem to be OK.

Could you please review if this makes sense? Let me know if you would like me to test more with UPDATE/PRACK/...

Thanks!