### PR TITLE
Ignore trailing null bytes in SIP keepalives

### DIFF
--- a/resip/stack/ConnectionBase.cxx
+++ b/resip/stack/ConnectionBase.cxx
@@ -148,6 +148,12 @@ ConnectionBase::preparseNewBytes(int bytesRead)
             mBufferPos += 4;
             bytesRead -= 4;
             onDoubleCRLF();
+            // skip trailing null bytes
+            while (bytesRead && mBuffer[mBufferPos] == '\0')
+            {
+               mBufferPos++;
+               bytesRead--;
+            }
             if (bytesRead)
             {
                goto start;
@@ -165,6 +171,12 @@ ConnectionBase::preparseNewBytes(int bytesRead)
             mBufferPos += 2;
             bytesRead -= 2;
             onSingleCRLF();
+            // skip trailing null bytes
+            while (bytesRead && mBuffer[mBufferPos] == '\0')
+            {
+               mBufferPos++;
+               bytesRead--;
+            }
             if (bytesRead)
             {
                goto start;


### PR DESCRIPTION
New versions of Asterisk (12+, based on pjsip stack) send keep alive packets as '\r\n\0' instead of '\r\n\r\n'. Ignoring the fact that these are treated as "pong" packets, the trailing null byte mess up the preprocessor state such that any subsequent SIP message cannot be parsed properly and the stack sends 400 error.
This change makes the "ping" and "pong" packet processing ignore trailing null bytes.
