### PR TITLE
enable subdir-objects to access subdirectory for build/debian.sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,8 +14,7 @@ AC_SUBST(LIBTOOL_VERSION_RELEASE)
 
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE
-
+AM_INIT_AUTOMAKE([foreign subdir-objects])
 m4_pattern_forbid([^PKG_])
 
 AC_CANONICAL_HOST


### PR DESCRIPTION
This is an attempt to enable automake: subdir-objects option required by build/debian.sh.