### PR TITLE
Move c-ares wrapper to FdPollItemIf interface

### DIFF
--- a/rutil/FdPoll.hxx
+++ b/rutil/FdPoll.hxx
@@ -90,9 +90,6 @@ class FdPollGrp
       virtual void modPollItem(FdPollItemHandle handle, FdPollEventMask newMask) = 0;
       virtual void delPollItem(FdPollItemHandle handle) = 0;
 
-      virtual void registerFdSetIOObserver(FdSetIOObserver& observer) = 0;
-      virtual void unregisterFdSetIOObserver(FdSetIOObserver& observer) = 0;
-
       /// Wait at most {ms} milliseconds. If any file activity has
       /// already occurs or occurs before {ms} expires, then
       /// FdPollItem will be informed (via cb method) and this method will

--- a/rutil/dns/AresDns.hxx
+++ b/rutil/dns/AresDns.hxx
@@ -1,7 +1,7 @@
 #if !defined(RESIP_ARES_DNS_HXX)
 #define RESIP_ARES_DNS_HXX
 
-#include "rutil/FdSetIOObserver.hxx"
+#include "rutil/HashMap.hxx"
 #include "rutil/GenericIPAddress.hxx"
 #include "rutil/dns/ExternalDns.hxx"
 
@@ -22,7 +22,7 @@ namespace resip
 class AresDnsPollItem;
 class FdPollGrp;
 
-class AresDns : public ExternalDns, public FdSetIOObserver
+class AresDns : public ExternalDns
 {
    friend class AresDnsPollItem;
    public:
@@ -35,7 +35,8 @@ class AresDns : public ExternalDns, public FdSetIOObserver
       virtual int init(int dnsTimeout = 0, int dnsTries = 0, unsigned int features = 0);
 
       int internalInit(const std::vector<GenericIPAddress>& additionalNameservers,
-                       AfterSocketCreationFuncPtr socketfunc, unsigned int features=0, ares_channeldata** channel = 0, int timeout=0, int tries=0);
+                       AfterSocketCreationFuncPtr socketfunc, unsigned int features=0,
+                       ares_channeldata** channel = 0, int timeout=0, int tries=0, bool useStateFunc=false);
 
       virtual bool checkDnsChange();
 
@@ -68,6 +69,7 @@ class AresDns : public ExternalDns, public FdSetIOObserver
       // time_t mNow;
 
    private:
+      void clearPollItems();
 
       typedef std::pair<ExternalDnsHandler*, void*> Payload;
       static ExternalDnsRawResult makeRawResult(void *arg, int status, unsigned char *abuf, int alen);
@@ -79,8 +81,8 @@ class AresDns : public ExternalDns, public FdSetIOObserver
       volatile static bool mHostFileLookupOnlyMode;
 
       FdPollGrp*	mPollGrp;
-      typedef std::vector<std::pair<AresDnsPollItem*, AresDnsPollItem*> > PollItems;
-      PollItems mPollItems;  // first item is for UDP socket, 2nd is for TCP socket
+      typedef HashMap<int, AresDnsPollItem*> PollItemsMap;
+      PollItemsMap mPollItems;
 
 };
 

--- a/rutil/dns/ExternalDns.hxx
+++ b/rutil/dns/ExternalDns.hxx
@@ -54,6 +54,7 @@ class ExternalDns
       //redefine FD_SETSIZE befor each inclusion of winsock2.h, so make sure
       //external libraries have been properly configured      
       // MUST not be called when pollGrp (below) is active
+      // uses only in tests now
       virtual void buildFdSet(fd_set& read, fd_set& write, int& size) = 0;
       virtual void process(fd_set& read, fd_set& write) = 0;
 


### PR DESCRIPTION
Move c-ares implementation of AresDns class on FdPollItemIf  interface, remove registerFdSetIOObserver/unregisterFdSetIOObserver from FdPollGrp and all its implementation.