### PR TITLE
Client support for TLS SNI extension

### DIFF
--- a/resip/stack/ssl/TlsConnection.cxx
+++ b/resip/stack/ssl/TlsConnection.cxx
@@ -206,6 +206,11 @@ TlsConnection::checkState()
       else
       {
          InfoLog( << "TLS handshake starting (client mode)" );
+         /* OpenSSL version < 0.9.8f does not support SSL_set_tlsext_host_name() */
+         #if defined(SSL_set_tlsext_host_name)
+            SSL_set_tlsext_host_name(mSsl,who().getTargetDomain().c_str()); // set the SNI hostname
+            DebugLog ( << "TLS SNI extension in Client Hello: " << who().getTargetDomain().c_str());
+         #endif
          SSL_set_connect_state(mSsl);
          mTlsState = Handshaking;
       }

--- a/resip/stack/ssl/TlsConnection.cxx
+++ b/resip/stack/ssl/TlsConnection.cxx
@@ -207,10 +207,10 @@ TlsConnection::checkState()
       {
          InfoLog( << "TLS handshake starting (client mode)" );
          /* OpenSSL version < 0.9.8f does not support SSL_set_tlsext_host_name() */
-         #if defined(SSL_set_tlsext_host_name)
+#if defined(SSL_set_tlsext_host_name)
+            DebugLog ( << "TLS SNI extension in Client Hello: " << who().getTargetDomain();
             SSL_set_tlsext_host_name(mSsl,who().getTargetDomain().c_str()); // set the SNI hostname
-            DebugLog ( << "TLS SNI extension in Client Hello: " << who().getTargetDomain().c_str());
-         #endif
+#endif
          SSL_set_connect_state(mSsl);
          mTlsState = Handshaking;
       }

--- a/resip/stack/ssl/TlsConnection.cxx
+++ b/resip/stack/ssl/TlsConnection.cxx
@@ -208,7 +208,7 @@ TlsConnection::checkState()
          InfoLog( << "TLS handshake starting (client mode)" );
          /* OpenSSL version < 0.9.8f does not support SSL_set_tlsext_host_name() */
 #if defined(SSL_set_tlsext_host_name)
-            DebugLog ( << "TLS SNI extension in Client Hello: " << who().getTargetDomain();
+            DebugLog ( << "TLS SNI extension in Client Hello: " << who().getTargetDomain());
             SSL_set_tlsext_host_name(mSsl,who().getTargetDomain().c_str()); // set the SNI hostname
 #endif
          SSL_set_connect_state(mSsl);


### PR DESCRIPTION
Server Name Indication (SNI) is an extension to the TLS networking protocol by which a client indicates which hostname it is attempting to connect to at the start of the handshaking process.
In this pull request I am enabling client support for TLS SNI extension.
Here are some screenshots:
Client Hello without SNI supported: https://i.imgsafe.org/54bf8257b4.png 
Client Hello with SNI supported: https://i.imgsafe.org/54c253a037.png 
