### PR TITLE
Remove ambiguity in ichat-gw.cxx, minor bugs in IPCThread.cxx and Ser…

### DIFF
--- a/apps/ichat-gw/IPCThread.cxx
+++ b/apps/ichat-gw/IPCThread.cxx
@@ -7,6 +7,7 @@
 #include <WS2tcpip.h>
 #else
 #include <sys/fcntl.h>
+#include <unistd.h>
 #endif
 
 #include "IPCThread.hxx"

--- a/apps/ichat-gw/Server.cxx
+++ b/apps/ichat-gw/Server.cxx
@@ -751,7 +751,7 @@ Server::checkSubscription(const std::string& to, const std::string& from)
    msg.addArg("sendSubscriptionResponse");
    msg.addArg(from.c_str());
    msg.addArg(to.c_str());   
-   msg.addArg(Data((unsigned long)success).c_str());   
+   msg.addArg(Data((UInt32)success).c_str());   
    mIPCThread->sendIPCMsg(msg);
 }
 

--- a/apps/ichat-gw/ichat-gw.cxx
+++ b/apps/ichat-gw/ichat-gw.cxx
@@ -16,15 +16,6 @@ using namespace std;
 
 #define RESIPROCATE_SUBSYSTEM AppSubsystem::GATEWAY
 
-void sleepSeconds(unsigned int seconds)
-{
-#ifdef WIN32
-   Sleep(seconds*1000);
-#else
-   sleep(seconds);
-#endif
-}
-
 static bool finished = false;
 
 static void


### PR DESCRIPTION
Removed an Ambiguous function definition from ichat-gw.cxx.
Add unistd header to support close() in IPCThread.cxx.
Correct typecast in Server.cxx.
This Commit is compatible with gloox v0.9.9.8. Commit made prior to updating support to current stable release of gloox (v1.0.16).
