### PR TITLE
update gloox parameters from v0.9.9.8 to v1.0.16

### DIFF
--- a/apps/ichat-gw/jabberconnector/IChatUser.cxx
+++ b/apps/ichat-gw/jabberconnector/IChatUser.cxx
@@ -28,7 +28,7 @@ IChatUser::updateResourceInfo(const std::string& resourceId, const gloox::Presen
    bool originalUnavailability = isUnavailable();
    if(resourceId.empty())
    {
-      if(presence == gloox::PresenceUnavailable)
+      if(presence.presence() == gloox::Presence::Unavailable)
       {
 	     // All resources are unanavaiable
          ResourceMap::iterator it = mResources.begin();
@@ -48,7 +48,7 @@ IChatUser::updateResourceInfo(const std::string& resourceId, const gloox::Presen
       ResourceMap::iterator it = mResources.find(resourceId);
       if(it != mResources.end())
       {
-         if(presence == gloox::PresenceUnavailable)
+         if(presence.presence() == gloox::Presence::Unavailable)
          {
             delete it->second;
             mResources.erase(it);
@@ -62,9 +62,9 @@ IChatUser::updateResourceInfo(const std::string& resourceId, const gloox::Presen
       }
       else
       {
-         if(presence != gloox::PresenceUnavailable)
+         if(presence.presence() != gloox::Presence::Unavailable)
          {
-            mResources[resourceId] = new ResourceInfo(presence, priority, avAvail);
+            mResources[resourceId] = new ResourceInfo(presence, mJID, priority, avAvail);
 		 }
       }
    }
@@ -101,11 +101,11 @@ IChatUser::getMostAvailableResourceItr()
          }
          else
          {
-            if(it->second->mPresence < itBestResource->second->mPresence)
+            if(it->second->mPresence.presence() < itBestResource->second->mPresence.presence())
             {
                itBestResource=it;
             }
-            else if(it->second->mPresence == itBestResource->second->mPresence)
+            else if(it->second->mPresence.presence() == itBestResource->second->mPresence.presence())
             {
                if(it->second->mPriority < itBestResource->second->mPriority)
                {
@@ -145,7 +145,7 @@ IChatUser::getMostAvailableResourceList(std::list<std::string>& resourceList)
       for(;it!=mResources.end();it++)
       {
          if(it->second->mAvAvail && 
-            it->second->mPresence == itBestResource->second->mPresence &&
+            it->second->mPresence.presence() == itBestResource->second->mPresence.presence() &&
             it->second->mPriority == itBestResource->second->mPriority)
          {
             resourceList.push_back(it->first);

--- a/apps/ichat-gw/jabberconnector/IChatUser.hxx
+++ b/apps/ichat-gw/jabberconnector/IChatUser.hxx
@@ -26,8 +26,8 @@ class JabberComponent;
 class ResourceInfo
 {
 public:
-   ResourceInfo(const gloox::Presence& presence, int priority, bool avAvail) :
-      mPresence(presence), mPriority(priority), mAvAvail(avAvail) {}
+   ResourceInfo(const gloox::Presence& presence, const std::string& jid, int priority, bool avAvail) :
+      mPresence(presence.presence(), jid), mPriority(priority), mAvAvail(avAvail) {}
    ~ResourceInfo() {}
 
    gloox::Presence mPresence;

--- a/apps/ichat-gw/jabberconnector/JabberComponent.hxx
+++ b/apps/ichat-gw/jabberconnector/JabberComponent.hxx
@@ -108,7 +108,7 @@ public:
 
 private:
    void probePresence(const std::string& to);
-   void sendPresenceForRequest(gloox::Stanza* stanza);
+   void sendPresenceForRequest(const gloox::Presence& presence);
    void sendPresence(const std::string& to, const std::string& from, bool advertiseIChatSupport, bool available);
    void sendSubscriptionResponse(const std::string& to, const std::string& from, bool success);
 
@@ -129,14 +129,14 @@ private:
    virtual void onConnect();
    virtual void onDisconnect(gloox::ConnectionError e);
    virtual bool onTLSConnect(const gloox::CertInfo& info);
-   virtual void handleSubscription(gloox::Stanza *stanza);
-   virtual void handlePresence(gloox::Stanza *stanza);
-   virtual void handleMessage(gloox::Stanza* stanza, gloox::MessageSession* session = 0);
-   virtual bool handleIq(gloox::Stanza *stanza);
-   virtual bool handleIqID(gloox::Stanza *stanza, int context);
-   virtual gloox::StringList handleDiscoNodeFeatures(const std::string& node);
-   virtual gloox::StringMap handleDiscoNodeIdentities(const std::string& node, std::string& name);
-   virtual gloox::DiscoNodeItemList handleDiscoNodeItems(const std::string& node);
+   virtual void handleSubscription(const gloox::Subscription& subscription);
+   virtual void handlePresence(const gloox::Presence& presence);
+   virtual void handleMessage(const gloox::Message& msg, gloox::MessageSession* session = 0);
+   virtual bool handleIq(const gloox::IQ& iq);
+   virtual void handleIqID(const gloox::IQ& iq, int context);
+   virtual gloox::StringList handleDiscoNodeFeatures(const gloox::JID& from, const std::string& node);
+   virtual gloox::Disco::IdentityList handleDiscoNodeIdentities(const gloox::JID& from, const std::string& node);
+   virtual gloox::Disco::ItemList handleDiscoNodeItems(const gloox::JID& from, const gloox::JID& to, const std::string& node);
 
    virtual void thread();
 
@@ -152,17 +152,17 @@ private:
    std::string makeVCRequestKey(const std::string& bareTo, const std::string& bareFrom);
 
    IChatCallRequestMap mOutstandingClientIChatCallRequests;
-   gloox::Mutex mOutstandingClientIChatCallRequestsMutex;
+   gloox::util::Mutex mOutstandingClientIChatCallRequestsMutex;
    IChatCallRequestMap::iterator findOutstandingClientIChatCallRequest(const std::string& bareTo, const std::string& bareFrom);
    void failOutstandingClientIChatCallRequest(const std::string& bareTo, const std::string& bareFrom, unsigned int code);
    void failOutstandingClientIChatCallRequest(const std::string& bareTo, unsigned int code);
 
    IChatCallRequestMap mOutstandingServerIChatCallRequests;
-   gloox::Mutex mOutstandingServerIChatCallRequestsMutex;
+   gloox::util::Mutex mOutstandingServerIChatCallRequestsMutex;
    IChatCallRequestMap::iterator findOutstandingServerIChatCallRequest(const std::string& bareTo, const std::string& bareFrom);
    void cancelOutstandingServerIChatCallRequest(const std::string& bareTo, const std::string& bareFrom);
 
-   gloox::Mutex mIChatUserMutex;
+   gloox::util::Mutex mIChatUserMutex;
    typedef std::map<std::string, IChatUser*> IChatUserMap;
    IChatUserMap mIChatUsers;
    void storeIChatSubscribedUser(const std::string& user, const std::string& subscribedJID);


### PR DESCRIPTION
This patch upgrades support to the latest build of gloox library to-date, v1.0.16. 
To fix, registerIqHandler warning for apple::iq variables. This does not effect the working on other systems.