### PR TITLE
Correction in variable name for TLS Domain

### DIFF
--- a/apps/ichat-gw/ichat-gw.config
+++ b/apps/ichat-gw/ichat-gw.config
@@ -28,7 +28,7 @@ UDPTCPPort = 5070
 TLSPort = 5071
 
 # TLS domain name for this server (note: domain cert for this domain must be present)
-TLSDomainName =   
+TLSDomain =   
 
 # Enable/Disable TCP/UDP CRLFCRLF keepalive packets for SIP endpoints
 # 1|true|on|enable to enable, 0|false|off|disable to disable


### PR DESCRIPTION
TLSDomain is the actual parameter used in other parts of the code not TLSDomainName.