### PR TITLE
Allow to add location of ichat-gw-jc from config file

### DIFF
--- a/apps/ichat-gw/ConfigParser.cxx
+++ b/apps/ichat-gw/ConfigParser.cxx
@@ -366,6 +366,10 @@ ConfigParser::processOption(const Data& name, const Data& value)
    {
       mTLSPrivateKeyPassPhrase = value;
    }
+   else if(name == "ichatjabberconnectorpath")
+   {
+      mIchatJabberConnectorPath = value;
+   }
    else
    {
       result = false;

--- a/apps/ichat-gw/ConfigParser.hxx
+++ b/apps/ichat-gw/ConfigParser.hxx
@@ -60,6 +60,9 @@ public:
    resip::Data mTLSPrivateKey;
    resip::Data mTLSPrivateKeyPassPhrase;
 
+   // iChat Jabber Connector file path
+   resip::Data mIchatJabberConnectorPath;
+   
 private:
    void parseCommandLine(int argc, char** argv);
    void parseConfigFile(const resip::Data& filename);

--- a/apps/ichat-gw/Server.cxx
+++ b/apps/ichat-gw/Server.cxx
@@ -283,7 +283,7 @@ Server::Server(int argc, char** argv) :
    // Start the Jabber Connector Process
 #ifdef _WIN32
    intptr_t result = _spawnl(_P_NOWAIT, 
-                             mIchatJabberConnectorPath.c_str().".exe", 
+                             mIchatJabberConnectorPath.c_str(), 
                              "ichat-gw",                               // argv[0]   Jabber connector uses this to check if launched from here or not
                              Data(mJabberConnectorIPCPort).c_str(),    // argv[1]   JabberConnector IPC Port
                              Data(mGatewayIPCPort).c_str(),            // argv[2]   Gateway IPC Port

--- a/apps/ichat-gw/Server.cxx
+++ b/apps/ichat-gw/Server.cxx
@@ -283,7 +283,7 @@ Server::Server(int argc, char** argv) :
    // Start the Jabber Connector Process
 #ifdef _WIN32
    intptr_t result = _spawnl(_P_NOWAIT, 
-                             "ichat-gw-jc.exe", 
+                             mIchatJabberConnectorPath.c_str().".exe", 
                              "ichat-gw",                               // argv[0]   Jabber connector uses this to check if launched from here or not
                              Data(mJabberConnectorIPCPort).c_str(),    // argv[1]   JabberConnector IPC Port
                              Data(mGatewayIPCPort).c_str(),            // argv[2]   Gateway IPC Port
@@ -322,7 +322,7 @@ Server::Server(int argc, char** argv) :
    args[10] = mLogLevel.c_str();
    args[11] = 0;
    int result = posix_spawn(&pid,
-                            "ichat-gw-jc",
+                            mIchatJabberConnectorPath.c_str(),
                             NULL /* file actions */,
                             NULL /* attr pointer */,
                             (char* const*)args /* argv */,

--- a/apps/ichat-gw/ichat-gw.config
+++ b/apps/ichat-gw/ichat-gw.config
@@ -148,4 +148,7 @@ TLSPrivateKeyPassPhrase =
 ########################################################
 
 # Path to iChat jabber connector (ichat-gw-jc) executable
-IchatJabberConnectorPath = "ichat-gw-jc"
+IchatJabberConnectorPath = ichat-gw-jc
+
+#For Windows
+#IchatJabberConnectorPath = ichat-gw-jc.exe

--- a/apps/ichat-gw/ichat-gw.config
+++ b/apps/ichat-gw/ichat-gw.config
@@ -143,4 +143,9 @@ TLSPrivateKey =
 # Pass phrase of private key file (can be left blank)
 TLSPrivateKeyPassPhrase =
 
+########################################################
+# iChat Jabber Connector Settings
+########################################################
 
+# Path to iChat jabber connector (ichat-gw-jc) executable
+IchatJabberConnectorPath = "ichat-gw-jc"


### PR DESCRIPTION
This is to allow the user to add the path to the ichat-gw-jc from config file rather than directly editing the code.