### PR TITLE
ignore jitsi messages of typing user, processing only text/plain messages

### DIFF
--- a/apps/telepathy/Connection.cxx
+++ b/apps/telepathy/Connection.cxx
@@ -489,6 +489,12 @@ tr::Connection::onMessageReceived(const resip::SipMessage& message)
       return;
    }
 
+   if ( message.header(h_ContentType) != Mime("text", "plain") )
+   {
+      qWarning() << "Ignoring a message of type " << message.header(h_ContentType).type().c_str() << "/" << message.header(h_ContentType).subType().c_str();
+      return;
+   }
+   
    TextChannelPtr textChannel = TextChannelPtr::dynamicCast(channel->interface(TP_QT_IFACE_CHANNEL_TYPE_TEXT));
 
    if ( !textChannel )


### PR DESCRIPTION
Ignoring messages with Content-Type different from text/plain. For example, when a user is typing a message at Jitsi, Jitsi sends a message with Content-Type = application/im-iscomposing+xml.