### PR TITLE
Switch to qt5 and fix package detection

### DIFF
--- a/apps/telepathy/Makefile.am
+++ b/apps/telepathy/Makefile.am
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-SUBDIRS = .
+SUBDIRS = . data
 
 EXTRA_DIST = playback_prompt.wav
 EXTRA_DIST += record_prompt.wav
@@ -23,7 +23,7 @@ EXTRA_DIST += resiprocate.manager
 EXTRA_DIST += resiprocate.service
 
 #AM_CXXFLAGS = -DUSE_ARES
-AM_CPPFLAGS = -fPIC
+AM_CPPFLAGS = -fPIC $(QT5_CFLAGS) $(TP_QT5_CFLAGS)
 
 bin_PROGRAMS = telepathy-resiprocate
 telepathy_resiprocate_LDADD = ../../resip/recon/librecon.la
@@ -32,8 +32,7 @@ telepathy_resiprocate_LDADD += -lsipXsdp -lsipXmediaProcessing -lsipXmedia -lsip
 telepathy_resiprocate_LDADD += ../../resip/dum/libdum.la
 telepathy_resiprocate_LDADD += ../../resip/stack/libresip.la
 telepathy_resiprocate_LDADD += ../../rutil/librutil.la
-telepathy_resiprocate_LDADD += -ltelepathy-qt4 -ltelepathy-qt4-service
-telepathy_resiprocate_LDADD += -lQtDBus -lQtNetwork -lQtCore
+telepathy_resiprocate_LDADD += $(TP_QT5_LIBS) $(QT5_LIBS)
 telepathy_resiprocate_LDADD += @LIBSSL_LIBADD@ @LIBPTHREAD_LIBADD@
 
 telepathy_resiprocate_SOURCES = Common.cxx \
@@ -50,8 +49,7 @@ telepathy_resiprocate_SOURCES = Common.cxx \
 	TelepathyParameters.cxx \
 	telepathy-resiprocate.cxx
 
-telepathy_resiprocateincludedir = $(includedir)/telepathy-resiprocate
-nobase_telepathy_resiprocateinclude_HEADERS = Common.hxx \
+noinst_HEADERS = Common.hxx \
 	Connection.hxx \
 	TextChannel.hxx \
 	MyConversationManager.hxx \

--- a/apps/telepathy/data/Makefile.am
+++ b/apps/telepathy/data/Makefile.am
@@ -1,0 +1,13 @@
+# Dbus service file
+BUILT_FILES = $(service_in_files:.service.in=.service)
+
+servicedir = $(datadir)/dbus-1/services
+service_in_files = org.freedesktop.Telepathy.ConnectionManager.resiprocate.service.in
+service_DATA = $(BUILT_FILES)
+CLEANFILES = $(BUILT_FILES)
+
+EXTRA_DIST = $(service_in_files)
+
+# Rule to make the service file with libexecdir expanded
+$(service_DATA): $(service_in_files) Makefile
+	@sed -e "s|\@bindir\@|$(bindir)|" $< > $@

--- a/apps/telepathy/data/org.freedesktop.Telepathy.ConnectionManager.resiprocate.service.in
+++ b/apps/telepathy/data/org.freedesktop.Telepathy.ConnectionManager.resiprocate.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.freedesktop.Telepathy.ConnectionManager.resiprocate
+Exec=@bindir@/telepathy-resiprocate

--- a/build/debian.sh
+++ b/build/debian.sh
@@ -17,19 +17,10 @@ fi
 
 autoreconf --install
 
-# Qt libraries are required for the Telepathy Connection Manager
-QT_VERSION=qt4
-QT_LIB_PREFIX="/usr/include/${QT_VERSION}"
-QT_LIBS="-I${QT_LIB_PREFIX}"
-for lib in QtCore QtNetwork QtDBus ;
-do
-  QT_LIBS="${QT_LIBS} -I${QT_LIB_PREFIX}/${lib}"
-done
-
-CFLAGS='-g -O0 -fPIE -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security' \
-CPPFLAGS="-D_FORTIFY_SOURCE=2 -I/usr/include/telepathy-qt4 ${QT_LIBS} -I/usr/include/postgresql -I/usr/include/sipxtapi -I/usr/include/gloox -D__pingtel_on_posix__ -D_linux_ -D_REENTRANT -D_FILE_OFFS -DDEFAULT_BRIDGE_MAX_IN_OUTPUTS=20 -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" \
-CXXFLAGS='-g -O0 -fPIE -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fpermissive' \
-LDFLAGS='-fPIE -pie -Wl,-z,relro -Wl,-z,now -lcares' \
+CFLAGS='-g -O0 -fPIC -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security' \
+CPPFLAGS="-D_FORTIFY_SOURCE=2 -I/usr/include/postgresql -I/usr/include/sipxtapi -I/usr/include/gloox -D__pingtel_on_posix__ -D_linux_ -D_REENTRANT -D_FILE_OFFS -DDEFAULT_BRIDGE_MAX_IN_OUTPUTS=20 -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS" \
+CXXFLAGS='-g -O0 -fPIC -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fpermissive' \
+LDFLAGS='-fPIC -pie -Wl,-z,relro -Wl,-z,now -lcares' \
   ./configure --disable-maintainer-mode --disable-dependency-tracking --with-popt --enable-ipv6 --enable-dtls $RADIUS_LIB --with-ssl \
               --enable-assert-syslog \
               --with-c-ares \

--- a/configure.ac
+++ b/configure.ac
@@ -284,7 +284,9 @@ AM_CONDITIONAL(BUILD_TELEPATHY_CM, false)
 AC_ARG_WITH(telepathy,
 [  --with-telepathy        Build the Telepathy Connection Manager],
  [AC_DEFINE_UNQUOTED(BUILD_TELEPATHY_CM, , BUILD_TELEPATHY_CM)
- AM_CONDITIONAL(BUILD_TELEPATHY_CM, true)], )
+ AM_CONDITIONAL(BUILD_TELEPATHY_CM, true)
+ PKG_CHECK_MODULES([QT5], [Qt5Core, Qt5DBus Qt5Network])
+ PKG_CHECK_MODULES([TP_QT5], [TelepathyQt5, TelepathyQt5Service])])
 
 AM_CONDITIONAL(BUILD_RECON, false)
 AC_ARG_WITH(recon,
@@ -359,6 +361,7 @@ AC_OUTPUT(Makefile \
 	apps/ichat-gw/jabberconnector/Makefile \
 	apps/sipdial/Makefile \
 	apps/telepathy/Makefile \
+	apps/telepathy/data/Makefile \
 	resiprocate.spec \
 	reTurn/Makefile \
 	reTurn/test/Makefile \


### PR DESCRIPTION
Change telepathy-resiprocate to use Qt5 by default and change the build system
to detect Qt5 and Telepathy-Qt5 using pkgconfig.
Also add a service file to have telepathy-resiprocate working with dbus activation.