### PR TITLE
MessageWaitingContents: skip body lines which do not match rfc 3842.

### DIFF
--- a/resip/stack/MessageWaitingContents.cxx
+++ b/resip/stack/MessageWaitingContents.cxx
@@ -361,6 +361,14 @@ MessageWaitingContents::parse(ParseBuffer& pb)
       }
       resip_assert(ht != -1);
 
+      const char* bol = pb.position();
+      pb.skipToChars("essage");
+      if (pb.position() == bol)
+      {
+	pb.skipChars(Symbols::CRLF);
+	continue;
+      }
+
       pb.skipToOneOf(ParseBuffer::Whitespace, Symbols::COLON);
       pb.skipWhitespace();
       pb.skipChar(Symbols::COLON[0]);
@@ -404,7 +412,7 @@ MessageWaitingContents::parse(ParseBuffer& pb)
          }
          mHeaders[ht] = new Header(numNew, numOld, numUrgentNew, numUrgentOld);
       }
-      
+
       pb.skipChars(Symbols::CRLF);
    }
 


### PR DESCRIPTION
If the line matches /^[fmnptv/i but does not match /^\w+-Message:/
it is skiped.

This ignores lines like /^Voicemail: \d+/\d+$/ from before rfc 3842
which some software still send for backward compatibility.

Signed-off-by: James Cloos <cloos@jhcloos.com>