### PR TITLE
the SHA1 hash needs to be 5 chunks 32 bits each

### DIFF
--- a/rutil/Sha1.hxx
+++ b/rutil/Sha1.hxx
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <string>
 #include "Data.hxx"
+#include <stdint.h>
 
 namespace resip
 {
@@ -43,13 +44,14 @@ public:
     static std::string from_file(const std::string &filename);
 
 private:
-    typedef unsigned long int uint32;   /* just needs to be at least 32bit */
-    typedef unsigned long long uint64;  /* just needs to be at least 64bit */
+    typedef uint32_t uint32;
+    typedef uint64_t uint64;
 
     static const unsigned int DIGEST_INTS = 5;  /* number of 32bit integers per SHA1 digest */
     static const unsigned int BLOCK_INTS = 16;  /* number of 32bit integers per SHA1 block */
     static const unsigned int BLOCK_BYTES = BLOCK_INTS * 4;
 
+    // the SHA1 digest is 160 bits split into 5 chunks, each chunk needs to be exactly 32 bits
     uint32 digest[DIGEST_INTS];
     std::string buffer;
     uint64 transforms;

--- a/rutil/test/Makefile.am
+++ b/rutil/test/Makefile.am
@@ -31,6 +31,7 @@ TESTS = \
 	testParseBuffer \
 	testRandomHex \
 	testRandomThread \
+	testSHA1Stream \
 	testThreadIf \
 	testXMLCursor
 
@@ -53,6 +54,7 @@ check_PROGRAMS = \
 	testParseBuffer \
 	testRandomHex \
 	testRandomThread \
+	testSHA1Stream \
 	testThreadIf \
 	testXMLCursor
 
@@ -74,6 +76,7 @@ testNetNs_SOURCES = testNetNs.cxx
 testParseBuffer_SOURCES = testParseBuffer.cxx
 testRandomHex_SOURCES = testRandomHex.cxx
 testRandomThread_SOURCES = testRandomThread.cxx
+testSHA1Stream_SOURCES = testSHA1Stream.cxx
 testThreadIf_SOURCES = testThreadIf.cxx
 testXMLCursor_SOURCES = testXMLCursor.cxx
 


### PR DESCRIPTION
unsigned long int is 64 bits on a 64 bit machine. This was resulting in an incorrect SHA1 hash.