### PR TITLE
Add OpenSSL 1.1 compatibility

### DIFF
--- a/reTurn/AsyncTlsSocketBase.cxx
+++ b/reTurn/AsyncTlsSocketBase.cxx
@@ -231,9 +231,9 @@ AsyncTlsSocketBase::validateServerCertificateHostname()
          ASN1_STRING*	s = X509_NAME_ENTRY_get_data(entry);
          resip_assert( s );
    
-         int t = M_ASN1_STRING_type(s);
-         int l = M_ASN1_STRING_length(s);
-         unsigned char* d = M_ASN1_STRING_data(s);
+         int t = ASN1_STRING_type(s);
+         int l = ASN1_STRING_length(s);
+         unsigned char* d = ASN1_STRING_data(s);
          resip::Data name(d,l);
          DebugLog( << "got x509 string type=" << t << " len="<< l << " data=" << d );
          resip_assert( name.size() == (unsigned)l );

--- a/reTurn/client/TurnTlsSocket.cxx
+++ b/reTurn/client/TurnTlsSocket.cxx
@@ -176,9 +176,9 @@ TurnTlsSocket::validateServerCertificateHostname(const std::string& hostname)
          ASN1_STRING*	s = X509_NAME_ENTRY_get_data(entry);
          resip_assert( s );
    
-         int t = M_ASN1_STRING_type(s);
-         int l = M_ASN1_STRING_length(s);
-         unsigned char* d = M_ASN1_STRING_data(s);
+         int t = ASN1_STRING_type(s);
+         int l = ASN1_STRING_length(s);
+         unsigned char* d = ASN1_STRING_data(s);
          resip::Data name(d,l);
          DebugLog( << "got x509 string type=" << t << " len="<< l << " data=" << d );
          resip_assert( name.size() == (unsigned)l );

--- a/reflow/Makefile.am
+++ b/reflow/Makefile.am
@@ -29,7 +29,7 @@ libreflow_la_SOURCES = FakeSelectSocketDescriptor.cxx \
         dtls_wrapper/DtlsTimer.cxx \
         dtls_wrapper/DtlsSocket.cxx \
         dtls_wrapper/DtlsFactory.cxx \
-        dtls_wrapper/bf_dwrap.c
+        dtls_wrapper/bf_dwrap.cxx
 
 reflowincludedir = $(includedir)/reflow
 nobase_reflowinclude_HEADERS = ErrorCode.hxx \
@@ -44,7 +44,7 @@ nobase_reflowinclude_HEADERS = ErrorCode.hxx \
 	HEPRTCPEventLoggingHandler.hxx \
 	MediaStream.hxx \
 	RTCPEventLoggingHandler.hxx \
-	dtls_wrapper/bf_dwrap.h \
+	dtls_wrapper/bf_dwrap.hxx \
 	dtls_wrapper/DtlsFactory.hxx \
 	dtls_wrapper/DtlsSocket.hxx \
 	dtls_wrapper/DtlsTimer.hxx \

--- a/reflow/dtls_wrapper/DtlsSocket.cxx
+++ b/reflow/dtls_wrapper/DtlsSocket.cxx
@@ -242,15 +242,6 @@ DtlsSocket::getSrtpSessionKeys()
    resip_assert(mHandshakeCompleted);
 
    SrtpSessionKeys keys;
-   memset(&keys, 0x00, sizeof(keys));
-   keys.clientMasterKey = new unsigned char[SRTP_MASTER_KEY_KEY_LEN];
-   keys.clientMasterKeyLen = 0;
-   keys.clientMasterSalt = new unsigned char[SRTP_MASTER_KEY_SALT_LEN];
-   keys.clientMasterSaltLen = 0;
-   keys.serverMasterKey = new unsigned char[SRTP_MASTER_KEY_KEY_LEN];
-   keys.serverMasterKeyLen = 0;
-   keys.serverMasterSalt = new unsigned char[SRTP_MASTER_KEY_SALT_LEN];
-   keys.serverMasterSaltLen = 0;
 
    unsigned char material[SRTP_MASTER_KEY_LEN << 1];
    if (!SSL_export_keying_material(
@@ -264,18 +255,14 @@ DtlsSocket::getSrtpSessionKeys()
 
    size_t offset = 0;
 
-   memcpy(keys.clientMasterKey, &material[offset], SRTP_MASTER_KEY_KEY_LEN);
-   offset += SRTP_MASTER_KEY_KEY_LEN;
-   memcpy(keys.serverMasterKey, &material[offset], SRTP_MASTER_KEY_KEY_LEN);
-   offset += SRTP_MASTER_KEY_KEY_LEN;
-   memcpy(keys.clientMasterSalt, &material[offset], SRTP_MASTER_KEY_SALT_LEN);
-   offset += SRTP_MASTER_KEY_SALT_LEN;
-   memcpy(keys.serverMasterSalt, &material[offset], SRTP_MASTER_KEY_SALT_LEN);
-   offset += SRTP_MASTER_KEY_SALT_LEN;
-   keys.clientMasterKeyLen = SRTP_MASTER_KEY_KEY_LEN;
-   keys.serverMasterKeyLen = SRTP_MASTER_KEY_KEY_LEN;
-   keys.clientMasterSaltLen = SRTP_MASTER_KEY_SALT_LEN;
-   keys.serverMasterSaltLen = SRTP_MASTER_KEY_SALT_LEN;
+   keys.clientMasterKey.assign(material + offset, material + offset + SRTP_MASTER_KEY_KEY_LEN);
+   offset += keys.clientMasterKey.size();
+   keys.serverMasterKey.assign(material + offset, material + offset + SRTP_MASTER_KEY_KEY_LEN);
+   offset += keys.serverMasterKey.size();
+   keys.clientMasterSalt.assign(material + offset, material + offset + SRTP_MASTER_KEY_SALT_LEN);
+   offset += keys.clientMasterSalt.size();
+   keys.serverMasterSalt.assign(material + offset, material + offset + SRTP_MASTER_KEY_SALT_LEN);
+   offset += keys.serverMasterSalt.size();
 
    return keys;   
 }
@@ -338,19 +325,19 @@ DtlsSocket::createSrtpSessionPolicies(srtp_policy_t& outboundPolicy, srtp_policy
    SrtpSessionKeys srtp_key = getSrtpSessionKeys();   
    /* set client_write key */  
    client_policy.key = client_master_key_and_salt;
-   if (srtp_key.clientMasterKeyLen != key_len)
+   if (srtp_key.clientMasterKey.size() != key_len)
    {
       cout << "error: unexpected client key length" << endl;
       resip_assert(0);
    }
-   if (srtp_key.clientMasterSaltLen != salt_len)
+   if (srtp_key.clientMasterSalt.size() != salt_len)
    {
       cout << "error: unexpected client salt length" << endl;
       resip_assert(0);      
    }
 
-   memcpy(client_master_key_and_salt, srtp_key.clientMasterKey, key_len);
-   memcpy(client_master_key_and_salt + key_len, srtp_key.clientMasterSalt, salt_len);
+   memcpy(client_master_key_and_salt, &srtp_key.clientMasterKey.front(), key_len);
+   memcpy(client_master_key_and_salt + key_len, &srtp_key.clientMasterSalt.front(), salt_len);
 
    //cout << "client master key and salt: " << 
    //   octet_string_hex_string(client_master_key_and_salt, key_len + salt_len) << endl;
@@ -366,19 +353,19 @@ DtlsSocket::createSrtpSessionPolicies(srtp_policy_t& outboundPolicy, srtp_policy
    /* set server_write key */
    server_policy.key = server_master_key_and_salt;
 
-   if (srtp_key.serverMasterKeyLen != key_len)
+   if (srtp_key.serverMasterKey.size() != key_len)
    {
       cout << "error: unexpected server key length" << endl;
       resip_assert(0);
    }
-   if (srtp_key.serverMasterSaltLen != salt_len)
+   if (srtp_key.serverMasterSalt.size() != salt_len)
    {
       cout << "error: unexpected salt length" << endl;
       resip_assert(0);      
    }
 
-   memcpy(server_master_key_and_salt, srtp_key.serverMasterKey, key_len);
-   memcpy(server_master_key_and_salt + key_len, srtp_key.serverMasterSalt, salt_len);
+   memcpy(server_master_key_and_salt, &srtp_key.serverMasterKey.front(), key_len);
+   memcpy(server_master_key_and_salt + key_len, &srtp_key.serverMasterSalt.front(), salt_len);
    //cout << "server master key and salt: " << 
    //   octet_string_hex_string(server_master_key_and_salt, key_len + salt_len) << endl;
 

--- a/reflow/dtls_wrapper/DtlsSocket.cxx
+++ b/reflow/dtls_wrapper/DtlsSocket.cxx
@@ -10,7 +10,7 @@
 
 #include "DtlsFactory.hxx"
 #include "DtlsSocket.hxx"
-#include "bf_dwrap.h"
+#include "bf_dwrap.hxx"
 using namespace std;
 using namespace dtls;
 

--- a/reflow/dtls_wrapper/DtlsSocket.hxx
+++ b/reflow/dtls_wrapper/DtlsSocket.hxx
@@ -8,6 +8,7 @@
 #define DtlsSocket_hxx
 
 #include <memory>
+#include <vector>
 extern "C" 
 {
 #ifdef WIN32
@@ -51,14 +52,10 @@ class DtlsSocketContext
 class SrtpSessionKeys
 {
    public:
-      unsigned char *clientMasterKey;
-      int clientMasterKeyLen;
-      unsigned char *serverMasterKey;
-      int serverMasterKeyLen;
-      unsigned char *clientMasterSalt;
-      int clientMasterSaltLen;
-      unsigned char *serverMasterSalt;
-      int serverMasterSaltLen;
+      std::vector<unsigned char> clientMasterKey;
+      std::vector<unsigned char> serverMasterKey;
+      std::vector<unsigned char> clientMasterSalt;
+      std::vector<unsigned char> serverMasterSalt;
 };
 
 class DtlsSocketTimer;

--- a/reflow/dtls_wrapper/bf_dwrap.c
+++ b/reflow/dtls_wrapper/bf_dwrap.c
@@ -7,8 +7,37 @@
 #include <stdio.h>
 #include <errno.h>
 #include <openssl/bio.h>
+#include <openssl/opensslv.h>
 #include "rutil/ResipAssert.h"
 #include <memory.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
+{
+  BIO_METHOD *biom = calloc(1, sizeof(BIO_METHOD));
+
+  if (biom != NULL) {
+    biom->type = type;
+    biom->name = name;
+  }
+  return biom;
+}
+
+#define BIO_meth_set_write(b, f) (b)->bwrite = (f)
+#define BIO_meth_set_read(b, f) (b)->bread = (f)
+#define BIO_meth_set_puts(b, f) (b)->bputs = (f)
+#define BIO_meth_set_gets(b, f) (b)->bgets = (f)
+#define BIO_meth_set_ctrl(b, f) (b)->ctrl = (f)
+#define BIO_meth_set_create(b, f) (b)->create = (f)
+#define BIO_meth_set_destroy(b, f) (b)->destroy = (f)
+#define BIO_meth_set_callback_ctrl(b, f) (b)->callback_ctrl = (f)
+
+#define BIO_set_init(b, val) (b)->init = (val)
+#define BIO_set_data(b, val) (b)->ptr = (val)
+#define BIO_get_data(b) (b)->ptr
+
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
 #define BIO_TYPE_DWRAP       (50 | 0x0400 | 0x0200)
 

--- a/reflow/dtls_wrapper/bf_dwrap.c
+++ b/reflow/dtls_wrapper/bf_dwrap.c
@@ -86,9 +86,12 @@ static int dwrap_new(BIO *bi)
 
 static int dwrap_free(BIO *a)
 {
-   if(a) return 0;
+   if(!a) return 0;
 
-   free(a);
+   OPENSSL_free(BIO_get_data(a));
+   BIO_set_data(a, NULL);
+   BIO_set_init(a, 0);
+
    return 1;
 }
 

--- a/reflow/dtls_wrapper/bf_dwrap.cxx
+++ b/reflow/dtls_wrapper/bf_dwrap.cxx
@@ -24,6 +24,11 @@ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
   return biom;
 }
 
+static void BIO_meth_free(BIO_METHOD *biom)
+{
+   free(biom);
+}
+
 #define BIO_meth_set_write(b, f) (b)->bwrite = (f)
 #define BIO_meth_set_read(b, f) (b)->bread = (f)
 #define BIO_meth_set_puts(b, f) (b)->bputs = (f)
@@ -41,138 +46,158 @@ static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
 
 #define BIO_TYPE_DWRAP       (50 | 0x0400 | 0x0200)
 
-static int dwrap_new(BIO *bio);
-static int dwrap_free(BIO *a);
-static int dwrap_read(BIO *b, char *out, int outl);
-static int dwrap_write(BIO *b, const char *in, int inl);
-static int dwrap_puts(BIO *b, const char *in);
-static int dwrap_gets(BIO *b, char *buf, int size);
-static long dwrap_ctrl(BIO *b, int cmd, long num, void *ptr);
-static long dwrap_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp);
+namespace {
 
-typedef struct BIO_F_DWRAP_CTX_ 
+class DtlsWrapper
 {
-   int dgram_timer_exp;
-} BIO_F_DWRAP_CTX;
+public:
+   DtlsWrapper()
+   {
+      dtls_meth = BIO_meth_new(BIO_TYPE_DWRAP, "dtls_wrapper");
+      BIO_meth_set_write(dtls_meth, dwrap_write);
+      BIO_meth_set_read(dtls_meth, dwrap_read);
+      BIO_meth_set_puts(dtls_meth, dwrap_puts);
+      BIO_meth_set_gets(dtls_meth, dwrap_gets);
+      BIO_meth_set_ctrl(dtls_meth, dwrap_ctrl);
+      BIO_meth_set_create(dtls_meth, dwrap_new);
+      BIO_meth_set_destroy(dtls_meth, dwrap_free);
+      BIO_meth_set_callback_ctrl(dtls_meth, dwrap_callback_ctrl);
+   }
+
+   ~DtlsWrapper()
+   {
+      if(dtls_meth) {
+         BIO_meth_free(dtls_meth);
+      }
+   }
+
+   BIO_METHOD* getBioMethod()
+   {
+      return dtls_meth;
+   }
+
+private:
+   BIO_METHOD* dtls_meth;
+
+   struct BIO_F_DWRAP_CTX 
+   {
+      int dgram_timer_exp;
+   };
+
+   static int dwrap_new(BIO *bi) 
+   {
+      BIO_F_DWRAP_CTX *ctx = (BIO_F_DWRAP_CTX*)OPENSSL_malloc(sizeof(BIO_F_DWRAP_CTX));
+      if(!ctx) return(0);
+
+      memset(ctx,0,sizeof(BIO_F_DWRAP_CTX));
+
+      BIO_set_init(bi, 1);
+      BIO_set_data(bi, ctx);
+
+      return 1;
+   }
+
+   static int dwrap_free(BIO *a)
+   {
+      if(!a) return 0;
+
+      OPENSSL_free(BIO_get_data(a));
+      BIO_set_data(a, NULL);
+      BIO_set_init(a, 0);
+
+      return 1;
+   }
+
+   static int dwrap_read(BIO *b, char *out, int outl)
+   {
+      int ret;
+      if(!b || !out) return 0;
+
+
+      BIO_clear_retry_flags(b);
+
+      ret=BIO_read(BIO_next(b),out,outl);
+
+      if(ret<=0)
+         BIO_copy_next_retry(b);
+
+      return ret;
+   }
+
+   static int dwrap_write(BIO *b, const char *in, int inl)
+   {
+      if(!b || !in || (inl<=0)) return 0;
+
+      return BIO_write(BIO_next(b),in,inl);
+   }
+
+   static int dwrap_puts(BIO *b, const char *in)
+   {
+      resip_assert(0);
+
+      return 0;
+   }
+
+   static int dwrap_gets(BIO *b, char *buf, int size)
+   {
+      resip_assert(0);
+
+      return 0;
+   }
+
+   static long dwrap_ctrl(BIO *b, int cmd, long num, void *ptr)
+   {
+      long ret;
+      BIO_F_DWRAP_CTX *ctx;
+
+      ctx=(BIO_F_DWRAP_CTX*)BIO_get_data(b);
+
+      switch(cmd){
+       case BIO_CTRL_DGRAM_GET_RECV_TIMER_EXP:
+          if(ctx->dgram_timer_exp){
+             ret=1;
+             ctx->dgram_timer_exp=0;
+          }
+          else
+             ret=0;
+          break;
+
+          /* Overloading this */
+       case BIO_CTRL_DGRAM_SET_RECV_TIMEOUT:
+          ctx->dgram_timer_exp=1;
+          ret=1;
+          break;
+       default:
+          ret=BIO_ctrl(BIO_next(b),cmd,num,ptr);
+          break;
+      }
+
+      return ret;
+   }
+
+   static long dwrap_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
+   {
+      long ret;
+
+      ret=BIO_callback_ctrl(BIO_next(b),cmd,fp);
+
+      return ret;
+   }
+};
+
+static DtlsWrapper dtlsWrapper;
+
+} // anonymous namespace
+
 
 namespace dtls
 {
 
-BIO_METHOD *BIO_f_dwrap(void) 
+BIO_METHOD *BIO_f_dwrap(void)
 {
-   BIO_METHOD *meth = BIO_meth_new(BIO_TYPE_DWRAP, "dtls_wrapper");
-   BIO_meth_set_write(meth, dwrap_write);
-   BIO_meth_set_read(meth, dwrap_read);
-   BIO_meth_set_puts(meth, dwrap_puts);
-   BIO_meth_set_gets(meth, dwrap_gets);
-   BIO_meth_set_ctrl(meth, dwrap_ctrl);
-   BIO_meth_set_create(meth, dwrap_new);
-   BIO_meth_set_destroy(meth, dwrap_free);
-   BIO_meth_set_callback_ctrl(meth, dwrap_callback_ctrl);
-   return meth;
+   return dtlsWrapper.getBioMethod();
 }
 
-}
-
-static int dwrap_new(BIO *bi) 
-{
-   BIO_F_DWRAP_CTX *ctx = (BIO_F_DWRAP_CTX*)OPENSSL_malloc(sizeof(BIO_F_DWRAP_CTX));
-   if(!ctx) return(0);
-
-   memset(ctx,0,sizeof(BIO_F_DWRAP_CTX));
-
-   BIO_set_init(bi, 1);
-   BIO_set_data(bi, ctx);
-   // bi->flags=0;
-
-   return 1;
-}
-
-static int dwrap_free(BIO *a)
-{
-   if(!a) return 0;
-
-   OPENSSL_free(BIO_get_data(a));
-   BIO_set_data(a, NULL);
-   BIO_set_init(a, 0);
-
-   return 1;
-}
-
-static int dwrap_read(BIO *b, char *out, int outl)
-{
-   int ret;
-   if(!b || !out) return 0;
-
-
-   BIO_clear_retry_flags(b);
-
-   ret=BIO_read(BIO_next(b),out,outl);
-
-   if(ret<=0)
-      BIO_copy_next_retry(b);
-
-   return ret;
-}
-
-static int dwrap_write(BIO *b, const char *in, int inl)
-{
-   if(!b || !in || (inl<=0)) return 0;
-
-   return BIO_write(BIO_next(b),in,inl);
-}
-
-static int dwrap_puts(BIO *b, const char *in)
-{
-   resip_assert(0);
-
-   return 0;
-}
-
-static int dwrap_gets(BIO *b, char *buf, int size)
-{
-   resip_assert(0);
-
-   return 0;
-}
-
-static long dwrap_ctrl(BIO *b, int cmd, long num, void *ptr)
-{
-   long ret;
-   BIO_F_DWRAP_CTX *ctx;
-
-   ctx=(BIO_F_DWRAP_CTX*)BIO_get_data(b);
-
-   switch(cmd){
-    case BIO_CTRL_DGRAM_GET_RECV_TIMER_EXP:
-       if(ctx->dgram_timer_exp){
-          ret=1;
-          ctx->dgram_timer_exp=0;
-       }
-       else
-          ret=0;
-       break;
-
-       /* Overloading this */
-    case BIO_CTRL_DGRAM_SET_RECV_TIMEOUT:
-       ctx->dgram_timer_exp=1;
-       ret=1;
-       break;
-    default:
-       ret=BIO_ctrl(BIO_next(b),cmd,num,ptr);
-       break;
-   }
-
-   return ret;
-}
-
-static long dwrap_callback_ctrl(BIO *b, int cmd, bio_info_cb *fp)
-{
-   long ret;
-
-   ret=BIO_callback_ctrl(BIO_next(b),cmd,fp);
-
-   return ret;
 }
 
 #endif //USE_SSL

--- a/reflow/dtls_wrapper/bf_dwrap.cxx
+++ b/reflow/dtls_wrapper/bf_dwrap.cxx
@@ -15,7 +15,7 @@
 
 static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
 {
-  BIO_METHOD *biom = calloc(1, sizeof(BIO_METHOD));
+  BIO_METHOD *biom = (BIO_METHOD*)calloc(1, sizeof(BIO_METHOD));
 
   if (biom != NULL) {
     biom->type = type;
@@ -55,6 +55,8 @@ typedef struct BIO_F_DWRAP_CTX_
    int dgram_timer_exp;
 } BIO_F_DWRAP_CTX;
 
+namespace dtls
+{
 
 BIO_METHOD *BIO_f_dwrap(void) 
 {
@@ -70,9 +72,11 @@ BIO_METHOD *BIO_f_dwrap(void)
    return meth;
 }
 
+}
+
 static int dwrap_new(BIO *bi) 
 {
-   BIO_F_DWRAP_CTX *ctx=OPENSSL_malloc(sizeof(BIO_F_DWRAP_CTX));
+   BIO_F_DWRAP_CTX *ctx = (BIO_F_DWRAP_CTX*)OPENSSL_malloc(sizeof(BIO_F_DWRAP_CTX));
    if(!ctx) return(0);
 
    memset(ctx,0,sizeof(BIO_F_DWRAP_CTX));
@@ -137,7 +141,7 @@ static long dwrap_ctrl(BIO *b, int cmd, long num, void *ptr)
    long ret;
    BIO_F_DWRAP_CTX *ctx;
 
-   ctx=BIO_get_data(b);
+   ctx=(BIO_F_DWRAP_CTX*)BIO_get_data(b);
 
    switch(cmd){
     case BIO_CTRL_DGRAM_GET_RECV_TIMER_EXP:

--- a/reflow/dtls_wrapper/bf_dwrap.hxx
+++ b/reflow/dtls_wrapper/bf_dwrap.hxx
@@ -4,9 +4,9 @@
 
 #ifdef USE_SSL 
 
-extern "C" 
+namespace dtls
 {
-     BIO_METHOD *BIO_f_dwrap(void);
+BIO_METHOD *BIO_f_dwrap(void);
 }
 
 #endif

--- a/reflow/dtls_wrapper/test/Makefile.am
+++ b/reflow/dtls_wrapper/test/Makefile.am
@@ -7,7 +7,7 @@ LDADD += -lsrtp
 noinst_LTLIBRARIES = libdtlswrappertest.la
 
 libdtlswrappertest_la_SOURCES = \
-	../bf_dwrap.c \
+	../bf_dwrap.cxx \
 	../DtlsFactory.cxx \
 	../DtlsSocket.cxx \
 	../DtlsTimer.cxx \

--- a/reflow/reflow_10_0.vcxproj
+++ b/reflow/reflow_10_0.vcxproj
@@ -87,7 +87,7 @@
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="dtls_wrapper\bf_dwrap.c" />
+    <ClCompile Include="dtls_wrapper\bf_dwrap.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsFactory.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsSocket.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsTimer.cxx" />
@@ -100,7 +100,7 @@
     <ClCompile Include="MediaStream.cxx" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="dtls_wrapper\bf_dwrap.h" />
+    <ClInclude Include="dtls_wrapper\bf_dwrap.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsFactory.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsSocket.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsTimer.hxx" />

--- a/reflow/reflow_10_0.vcxproj.filters
+++ b/reflow/reflow_10_0.vcxproj.filters
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="dtls_wrapper\bf_dwrap.c" />
+    <ClCompile Include="dtls_wrapper\bf_dwrap.cxx" />
     <ClCompile Include="MediaStream.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsFactory.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsSocket.cxx" />
@@ -14,7 +14,7 @@
     <ClCompile Include="FlowManagerSubsystem.cxx" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="dtls_wrapper\bf_dwrap.h" />
+    <ClInclude Include="dtls_wrapper\bf_dwrap.hxx" />
     <ClInclude Include="MediaStream.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsFactory.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsSocket.hxx" />

--- a/reflow/reflow_12_0.vcxproj
+++ b/reflow/reflow_12_0.vcxproj
@@ -160,7 +160,7 @@
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="dtls_wrapper\bf_dwrap.c" />
+    <ClCompile Include="dtls_wrapper\bf_dwrap.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsFactory.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsSocket.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsTimer.cxx" />
@@ -173,7 +173,7 @@
     <ClCompile Include="MediaStream.cxx" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="dtls_wrapper\bf_dwrap.h" />
+    <ClInclude Include="dtls_wrapper\bf_dwrap.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsFactory.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsSocket.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsTimer.hxx" />

--- a/reflow/reflow_12_0.vcxproj.filters
+++ b/reflow/reflow_12_0.vcxproj.filters
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="dtls_wrapper\bf_dwrap.c" />
+    <ClCompile Include="dtls_wrapper\bf_dwrap.cxx" />
     <ClCompile Include="MediaStream.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsFactory.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsSocket.cxx" />
@@ -14,7 +14,7 @@
     <ClCompile Include="FlowManagerSubsystem.cxx" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="dtls_wrapper\bf_dwrap.h" />
+    <ClInclude Include="dtls_wrapper\bf_dwrap.hxx" />
     <ClInclude Include="MediaStream.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsFactory.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsSocket.hxx" />

--- a/reflow/reflow_14_0.filters
+++ b/reflow/reflow_14_0.filters
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="dtls_wrapper\bf_dwrap.c" />
+    <ClCompile Include="dtls_wrapper\bf_dwrap.cxx" />
     <ClCompile Include="MediaStream.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsFactory.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsSocket.cxx" />
@@ -14,7 +14,7 @@
     <ClCompile Include="FlowManagerSubsystem.cxx" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="dtls_wrapper\bf_dwrap.h" />
+    <ClInclude Include="dtls_wrapper\bf_dwrap.hxx" />
     <ClInclude Include="MediaStream.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsFactory.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsSocket.hxx" />

--- a/reflow/reflow_14_0.vcxproj
+++ b/reflow/reflow_14_0.vcxproj
@@ -160,7 +160,7 @@
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="dtls_wrapper\bf_dwrap.c" />
+    <ClCompile Include="dtls_wrapper\bf_dwrap.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsFactory.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsSocket.cxx" />
     <ClCompile Include="dtls_wrapper\DtlsTimer.cxx" />
@@ -173,7 +173,7 @@
     <ClCompile Include="MediaStream.cxx" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="dtls_wrapper\bf_dwrap.h" />
+    <ClInclude Include="dtls_wrapper\bf_dwrap.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsFactory.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsSocket.hxx" />
     <ClInclude Include="dtls_wrapper\DtlsTimer.hxx" />

--- a/resip/stack/ssl/DtlsTransport.cxx
+++ b/resip/stack/ssl/DtlsTransport.cxx
@@ -58,6 +58,7 @@
 #include <openssl/pkcs7.h>
 #include <openssl/x509v3.h>
 #include <openssl/ssl.h>
+#include <openssl/opensslv.h>
 
 #ifdef USE_SIGCOMP
 #include <osc/Stack.h>
@@ -66,6 +67,21 @@
 #endif
 
 #define RESIPROCATE_SUBSYSTEM Subsystem::TRANSPORT
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+static void SSL_set0_rbio(SSL *s, BIO *rbio)
+{
+    BIO_free_all(s->rbio);
+    s->rbio = rbio;
+}
+
+static void BIO_up_ref(BIO *a)
+{
+    CRYPTO_add(&a->references, 1, CRYPTO_LOCK_BIO);
+}
+
+#endif
 
 using namespace std;
 using namespace resip;
@@ -227,14 +243,13 @@ DtlsTransport::_read( FdSet& fdset )
    rbio = BIO_new_mem_buf( buffer, len ) ;
    BIO_set_mem_eof_return( rbio, -1 ) ;
 
-   ssl->rbio = rbio ;
+   SSL_set0_rbio( ssl, rbio );
 
    len = SSL_read( ssl, pt, UdpTransport::MaxBufferSize ) ;
    int err = SSL_get_error( ssl, len ) ;
 
    /* done with the rbio */
-   BIO_free( ssl->rbio ) ;
-   ssl->rbio = mDummyBio ;
+   SSL_set0_rbio( ssl, mDummyBio );
    delete [] buffer ;
    buffer = 0 ;
 
@@ -696,7 +711,7 @@ DtlsTransport::_cleanupConnectionState( SSL *ssl, struct sockaddr_in peer )
     * SSL_free decrements the ref-count for mDummyBio by 1, so
     * add 1 to the ref-count to make sure it does not get free'd
     */
-   CRYPTO_add(&mDummyBio->references, 1, CRYPTO_LOCK_BIO);
+   BIO_up_ref(mDummyBio);
    SSL_shutdown(ssl);
    SSL_free(ssl) ;
    mDtlsConnections.erase(peer) ;

--- a/resip/stack/ssl/Security.cxx
+++ b/resip/stack/ssl/Security.cxx
@@ -1816,15 +1816,16 @@ BaseSecurity::computeIdentity( const Data& signerDomain, const Data& in ) const
    EVP_PKEY* pKey = k->second;
    resip_assert( pKey );
 
-   if ( EVP_PKEY_id(pKey) !=  EVP_PKEY_RSA )
+   RSA* rsa = EVP_PKEY_get1_RSA(pKey);
+
+   if ( !rsa )
    {
       ErrLog( << "Private key (type=" << EVP_PKEY_id(pKey) <<"for "
               << signerDomain << " is not of type RSA" );
       throw Exception("No RSA private key when computing identity",__FILE__,__LINE__);
    }
 
-   resip_assert( EVP_PKEY_id(pKey) ==  EVP_PKEY_RSA );
-   RSA* rsa = EVP_PKEY_get1_RSA(pKey);
+   resip_assert( rsa );
 
    unsigned char result[4096];
    int resultSize = sizeof(result);
@@ -1920,8 +1921,8 @@ BaseSecurity::checkIdentity( const Data& signerDomain, const Data& in, const Dat
    EVP_PKEY* pKey = X509_get_pubkey( cert );
    resip_assert( pKey );
 
-   resip_assert( EVP_PKEY_id(pKey) ==  EVP_PKEY_RSA );
    RSA* rsa = EVP_PKEY_get1_RSA(pKey);
+   resip_assert( rsa );
 
 #if 1
    int ret = RSA_verify(NID_sha256, (unsigned char *)hashRes.data(),

--- a/rutil/ssl/OpenSSLInit.cxx
+++ b/rutil/ssl/OpenSSLInit.cxx
@@ -18,6 +18,7 @@
 
 #define OPENSSL_THREAD_DEFINES
 #include <openssl/opensslconf.h>
+#include <openssl/opensslv.h>
 
 #if  defined(WIN32) && defined(_MSC_VER) && (_MSC_VER >= 1900)
 // OpenSSL builds use an older version of visual studio that require the following definition
@@ -66,8 +67,13 @@ OpenSSLInit::OpenSSLInit()
 	CRYPTO_set_dynlock_lock_callback(::resip_OpenSSLInit_dynLockFunction);
 #endif
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	CRYPTO_malloc_debug_init();
 	CRYPTO_set_mem_debug_options(V_CRYPTO_MDEBUG_ALL);
+#else
+	CRYPTO_set_mem_debug(1);
+#endif
+
 	CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
 
 	SSL_library_init();


### PR DESCRIPTION
Hello,

I tried to migrate reSIProcate to the OpenSSL 1.1 API. Those changes have been compile tested with OpenSSL 1.0.2 and OpenSSL 1.1.0.

Unfortunately my (D)TLS and OpenSSL knowledge is quite small. So I consider this PR just a discussion and review starter instead of a polished PR.

Thanks,
Gregor