### PR TITLE
resip/stack: SdpContents: Avoid out-of-memory condition

### DIFF
--- a/resip/stack/SdpContents.cxx
+++ b/resip/stack/SdpContents.cxx
@@ -1345,6 +1345,11 @@ SdpContents::Session::Medium::parse(ParseBuffer& pb)
          pb.skipChar();
          int num = pb.integer();
 
+         if (num > 255)
+         {
+            pb.fail(__FILE__, __LINE__, "Too many connection addresses");
+         }
+
          Connection& con = mConnections.back();
          const Data& addr = con.getAddress();
          size_t i = addr.size() - 1;

--- a/resip/stack/test/testSdp.cxx
+++ b/resip/stack/test/testSdp.cxx
@@ -165,6 +165,28 @@ main(int argc, char* argv[])
     }
 
     //exit(0);
+
+    {
+       const char* txt = ("v=0\r\n"
+                          "o=Evil 3559 3228 IN IP4 192.168.2.122\r\n"
+                          "s=SIP Call\r\n"
+                          "t=0 0\r\n"
+                          "m=audio 17124 RTP/AVP 18\r\n"
+                          "c=IN IP4 192.168.2.122/127/2000000000\r\n" // way too many connections
+                          "a=rtpmap:18 G729/8000\r\n");
+
+       HeaderFieldValue hfv(txt, strlen(txt));
+       Mime type("application", "sdp");
+       SdpContents sdp(hfv, type);
+
+       try
+       {
+          sdp.checkParsed();
+       }
+       catch (resip::ParseException)
+       {
+       }
+    }
     
     {
        Data txt("v=0\r\n"


### PR DESCRIPTION
Adding too many media connections may lead to memory
exhaustion.