### PR TITLE
rutil: Data: Fix out of bounds read

### DIFF
--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -747,11 +747,7 @@ resip::operator==(const Data& lhs, const char* rhs)
    {
       return false;
    }
-   else
-   {
-      // make sure the string terminates at size
-      return (rhs[lhs.mSize] == 0);
-   }
+   return strlen(rhs) == lhs.mSize;
 }
 
 bool

--- a/rutil/test/testData.cxx
+++ b/rutil/test/testData.cxx
@@ -266,6 +266,12 @@ class TestData
             assert(input == "ABCD123ABCDa");
          }
          
+         {
+            // construct a Data object with binary zero in content
+            const char rawInput[] = {'I', 'P', '4', '\0'};
+            const Data input(rawInput, sizeof(rawInput));
+            assert(input != "IP4");
+         }
          
          {
             const char* s = "a";


### PR DESCRIPTION
In case a data object contained content with a binary
zero in it and it was comared to a string literal that
matched the content before the binary zero, the
rhs[lhs.mSize] check could be out of bounds.

This issue was found while fuzzing the SDP parser
with LLVM libFuzzer.