### PR TITLE
Missing handling of timers when using c-ares

### DIFF
--- a/rutil/dns/AresDns.cxx
+++ b/rutil/dns/AresDns.cxx
@@ -653,7 +653,7 @@ void
 AresDns::processTimers()
 {
 #ifdef USE_CARES
-   return;
+   ares_process(mChannel, NULL, NULL);
 #else
    resip_assert( mPollGrp!=0 );
    time_t timeSecs;


### PR DESCRIPTION
Missing handling of timers can cause 100% load in dns-thread if no answer is received from server.
Timers are only handled at socket events currently