### PR TITLE
MasterProfile: added a removeSupportedMethod() 

### DIFF
--- a/resip/dum/MasterProfile.cxx
+++ b/resip/dum/MasterProfile.cxx
@@ -66,6 +66,24 @@ MasterProfile::addSupportedMethod(const MethodTypes& method)
    mSupportedMethods.push_back(Token(getMethodName(method)));
 }
 
+void 
+MasterProfile::removeSupportedMethod(const MethodTypes& method)
+{
+   mSupportedMethodTypes.erase(method);
+   for (Tokens::iterator i = mSupportedMethods.begin();
+            i != mSupportedMethods.end(); ++i)
+   {
+       if (getMethodType(i->value()) == method)
+       {
+           mSupportedMethods.erase(i);
+           break;
+       }
+   }
+
+   // Should we clear the mimetypes as well?
+   // clearSupportedMimeTypes(method);
+}
+
 bool 
 MasterProfile::isMethodSupported(MethodTypes method) const
 {

--- a/resip/dum/MasterProfile.hxx
+++ b/resip/dum/MasterProfile.hxx
@@ -28,6 +28,7 @@ class MasterProfile : public UserProfile
 
       /// Defaults are: INVITE, ACK, CANCEL, OPTIONS, BYE, UPDATE
       virtual void addSupportedMethod(const MethodTypes& method);   
+      virtual void removeSupportedMethod(const MethodTypes& method);   
       virtual bool isMethodSupported(MethodTypes method) const;
       virtual Tokens getAllowedMethods() const;
       virtual Data getAllowedMethodsData() const;


### PR DESCRIPTION
I implemented a simple removeSupportedMethod() to remove a specific SIP method from those available to profile (instead of deleting them all and re-adding only the ones needed)