### PR TITLE
fix a sip message body bug

### DIFF
--- a/resip/stack/ConnectionBase.cxx
+++ b/resip/stack/ConnectionBase.cxx
@@ -403,7 +403,8 @@ ConnectionBase::preparseNewBytes(int bytesRead)
                }
 
                // The message body is complete.
-               mMessage->setBody(unprocessedCharPtr, (UInt32)contentLength);
+               if (contentLength > 0)
+                        mMessage->setBody(unprocessedCharPtr, (UInt32)contentLength);
                CongestionManager::RejectionBehavior b=mTransport->getRejectionBehaviorForIncoming();
                if (b==CongestionManager::REJECTING_NON_ESSENTIAL
                      || (b==CongestionManager::REJECTING_NEW_WORK


### PR DESCRIPTION
This fixes a sip message body issue when get the message from TCP connection. If content length is set to 0, the message body should not be set, otherwise it is considered has body but actually has not, and result to incorrect status UAS_Offer in ServerInviteSession, but it should be UAS_NoOffer.

Please refer code diff, and let me know if any question.