### PR TITLE
rutil: ParseBuffer: Do not rely on undefined behavior

### DIFF
--- a/rutil/ParseBuffer.cxx
+++ b/rutil/ParseBuffer.cxx
@@ -656,10 +656,10 @@ ParseBuffer::integer()
       fail(__FILE__, __LINE__,"Expected a digit, got eof ");
    }
 
-   int signum = 1;
+   bool negative = false;
    if (*mPosition == '-')
    {
-      signum = -1;
+      negative = true;
       ++mPosition;
       assertNotEof();
    }
@@ -671,25 +671,33 @@ ParseBuffer::integer()
 
    if (!isdigit(*mPosition))
    {
-       Data msg("Expected a digit, got: ");
-       msg += Data(mPosition, (mEnd - mPosition));
+      Data msg("Expected a digit, got: ");
+      msg += Data(mPosition, (mEnd - mPosition));
       fail(__FILE__, __LINE__,msg);
    }
-   
-   int num = 0;
-   int last=0;
+
+   // The absolute value limit depending on the detected sign
+   const unsigned int absoluteLimit = negative ? -(unsigned int)INT_MIN : INT_MAX;
+   // maximum value for full number except last digit
+   const unsigned int border = absoluteLimit / 10;
+   // value the last digit must not exceed
+   const unsigned int digitLimit = absoluteLimit % 10;
+
+   unsigned int num = 0;
    while (!eof() && isdigit(*mPosition))
    {
-      last=num;
-      num = num*10 + (*mPosition-'0');
-      if(last > num)
-      {
+      const unsigned int c = *mPosition++ - '0';
+      if (num > border || (num == border && c > digitLimit)) {
          fail(__FILE__, __LINE__,"Overflow detected.");
       }
-      ++mPosition;
-   }
-   
-   return signum*num;
+      num *= 10;
+      num += c;
+    }
+    if (negative)
+    {
+        num = -num;
+    }
+    return num;
 }
 
 UInt8

--- a/rutil/test/testParseBuffer.cxx
+++ b/rutil/test/testParseBuffer.cxx
@@ -1,6 +1,9 @@
 #include "rutil/ParseBuffer.hxx"
 #include <string.h>
 #include <assert.h>
+#include <limits>
+#include <sstream>
+#include <vector>
 #include "rutil/Logger.hxx"
 
 using namespace resip;
@@ -489,6 +492,55 @@ main(int argc, char** argv)
       Data t2;
       pb.data(t2, start);
       // should survive scope exit
+   }
+
+   // test integer() -- accept values near minimum / maximum
+   {
+      std::vector<int> testValues;
+      for (unsigned i = 0; i < 133; ++i)
+      {
+         testValues.push_back(std::numeric_limits<int>::max() - i);
+         testValues.push_back(std::numeric_limits<int>::min() + i);
+      }
+
+      for (unsigned i = 0; i < testValues.size(); ++i)
+      {
+         std::stringstream ss;
+         ss << testValues[i];
+         const Data stringValue(ss.str());
+         ParseBuffer test(stringValue);
+         const int parsed = test.integer();
+         assert(testValues[i] == parsed);
+      }
+   }
+
+   // test integer() -- reject values exceeding minimum / maximum
+   if (sizeof(Int64) > sizeof(int))
+   {
+      std::vector<Int64> testValues;
+      for (Int64 i = 1; i < 133; ++i)
+      {
+         testValues.push_back(std::numeric_limits<int>::max() + i);
+         testValues.push_back(std::numeric_limits<int>::min() - i);
+      }
+
+      for (unsigned i = 0; i < testValues.size(); ++i)
+      {
+         bool catchedException = false;
+         try
+         {
+            std::stringstream ss;
+            ss << testValues[i];
+            const Data stringValue(ss.str());
+            ParseBuffer test(stringValue);
+            test.integer();
+         }
+         catch (ParseException& e)
+         {
+            catchedException = true;
+         }
+         assert(catchedException);
+      }
    }
 
    std::cerr << "All OK" << std::endl;


### PR DESCRIPTION
The previous overflow detection relied on undefined behavior
because a signed integer overflow is undefined. Compilers
are allowed to remove the overflow check completely.

That issue was found by the oss-fuzz project.

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=6712
Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=6717