### PR TITLE
rutil: ParseBuffer: Do not read past the buffer.

### DIFF
--- a/rutil/ParseBuffer.cxx
+++ b/rutil/ParseBuffer.cxx
@@ -857,7 +857,7 @@ ParseBuffer::qVal()
          return 0;
       }
       
-      if (*mPosition == '.')
+      if (!eof() && *mPosition == '.')
       {
          skipChar();
          

--- a/rutil/test/testParseBuffer.cxx
+++ b/rutil/test/testParseBuffer.cxx
@@ -388,6 +388,32 @@ main(int argc, char** argv)
    }
    
    {
+      char buf[] = "1.000";
+      ParseBuffer pb(buf, strlen(buf));
+      assert(pb.qVal() == 1000);
+   }
+
+   {
+      const char buf[] = {'1'};
+      const Data data(Data::Share, buf, sizeof(buf));
+      ParseBuffer pb(data);
+      assert(pb.qVal() == 1000);
+   }
+
+   {
+      const char buf[] = {'1', '.'};
+      const Data data(Data::Share, buf, sizeof(buf));
+      ParseBuffer pb(data);
+      assert(pb.qVal() == 1000);
+   }
+
+   {
+      char buf[] = "0.800";
+      ParseBuffer pb(buf, strlen(buf));
+      assert(pb.qVal() == 800);
+   }
+
+   {
       char buf[] = "17 ";
       ParseBuffer pb(buf, strlen(buf));   
       assert(pb.integer() == 17);


### PR DESCRIPTION
That heap-buffer-overflow was found by oss-fuzz.

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=6713