### PR TITLE
Fix for WSS/TLS reads of large SIP messages with big SDPs

### DIFF
--- a/resip/stack/ConnectionBase.hxx
+++ b/resip/stack/ConnectionBase.hxx
@@ -83,7 +83,10 @@ class ConnectionBase
       void decompressNewBytes(int bytesRead);
       std::pair<char*, size_t> getWriteBuffer();
       std::pair<char*, size_t> getCurrentWriteBuffer();
-      char* getWriteBufferForExtraBytes(int extraBytes);
+
+	  // Mike did this.... bug fix!
+      //char* getWriteBufferForExtraBytes(int extraBytes);
+      char* getWriteBufferForExtraBytes(int readBytes, int extraBytes);
       
       // for avoiding copies in external transports--not used in core resip
       void setBuffer(char* bytes, int count);

--- a/resip/stack/ssl/TlsConnection.cxx
+++ b/resip/stack/ssl/TlsConnection.cxx
@@ -413,7 +413,7 @@ TlsConnection::read(char* buf, int count )
       if (bytesPending > 0)
       {
          //char* buffer = getWriteBufferForExtraBytes(bytesPending);
-         char* buffer = getWriteBufferForExtraBytes(readBytes, bytesPending);
+         char* buffer = getWriteBufferForExtraBytes(bytesRead, bytesPending);
          if (buffer)
          {
             //StackLog(<< "reading remaining buffered bytes");

--- a/resip/stack/ssl/TlsConnection.cxx
+++ b/resip/stack/ssl/TlsConnection.cxx
@@ -412,7 +412,8 @@ TlsConnection::read(char* buf, int count )
       int bytesPending = SSL_pending(mSsl);
       if (bytesPending > 0)
       {
-         char* buffer = getWriteBufferForExtraBytes(bytesPending);
+         //char* buffer = getWriteBufferForExtraBytes(bytesPending);
+         char* buffer = getWriteBufferForExtraBytes(readBytes, bytesPending);
          if (buffer)
          {
             //StackLog(<< "reading remaining buffered bytes");


### PR DESCRIPTION
getWriteBufferForExtraBytes() is returning the wrong value when the first
TlsConnection::SSL_read() returns more than the "chunk_size" (8192 bytes).