### PR TITLE
STUN: use RFC5389-fixed-magic-cookie to be able to decode XOR-MAPPED-…

### DIFF
--- a/rutil/stun/Stun.cxx
+++ b/rutil/stun/Stun.cxx
@@ -1918,6 +1918,7 @@ stunFindLocalInterfaces(UInt32* addresses,int maxRet)
 #endif
 }
 
+
 void
 stunBuildReqSimple( StunMessage* msg,
                     const StunAtrString& username,
@@ -1927,8 +1928,14 @@ stunBuildReqSimple( StunMessage* msg,
    memset( msg , 0 , sizeof(*msg) );
 	
    msg->msgHdr.msgType = BindRequestMsg;
-	
-   for ( int i=0; i<16; i=i+4 )
+    
+   int magic_cookie = htonl(0x2112A442); /* RFC5389 chapter 6 */
+   msg->msgHdr.id.octet[0]= magic_cookie>>0;
+   msg->msgHdr.id.octet[1]= magic_cookie>>8;
+   msg->msgHdr.id.octet[2]= magic_cookie>>16;
+   msg->msgHdr.id.octet[3]= magic_cookie>>24;
+   
+   for ( int i=4; i<16; i=i+4 )
    {
       resip_assert(i+3<16);
       int r = stunRand();


### PR DESCRIPTION
…ADDRESS

Since RFC5389 stun server answer contains a XOR-MAPPED-ADDRESS version of MAPPED ADDRESS. To create the XOR-MAPPED-ADDRESS the 4 first bytes of transaction id field are used as 'magic cookie'.
RFC5389 chapter 6 says 'The magic cookie field MUST contain the fixed value 0x2112A442 in network byte order.'
Out there are stun servers, that don't use the random 4 bytes, delivered by the client, to XOR the MAPPED ADDRESS. They always use the fixed value from RFC5389, ignoring the first random 4 bytes in transaction id field.
In decoding algorithm resiprocate stun implementation uses the randomly generated 4 bytes, before this fix.
Now the fixed value 0x2112A442 for magic cookie is used, while transaction id is generated. So decoding is successful always.