### PR TITLE
Support LibreSSL

### DIFF
--- a/resip/stack/ssl/DtlsTransport.cxx
+++ b/resip/stack/ssl/DtlsTransport.cxx
@@ -50,7 +50,10 @@
 
 #include "rutil/WinLeakCheck.hxx"
 
+#include <openssl/opensslv.h>
+#if !defined(LIBRESSL_VERSION_NUMBER)
 #include <openssl/e_os2.h>
+#endif
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
@@ -58,7 +61,6 @@
 #include <openssl/pkcs7.h>
 #include <openssl/x509v3.h>
 #include <openssl/ssl.h>
-#include <openssl/opensslv.h>
 
 #ifdef USE_SIGCOMP
 #include <osc/Stack.h>

--- a/resip/stack/ssl/Security.cxx
+++ b/resip/stack/ssl/Security.cxx
@@ -43,7 +43,10 @@
 #endif
 
 #include <sys/types.h>
+#include <openssl/opensslv.h>
+#if !defined(LIBRESSL_VERSION_NUMBER)
 #include <openssl/e_os2.h>
+#endif
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>

--- a/resip/stack/ssl/TlsConnection.cxx
+++ b/resip/stack/ssl/TlsConnection.cxx
@@ -11,7 +11,10 @@
 #include "resip/stack/Uri.hxx"
 #include "rutil/Socket.hxx"
 
+#include <openssl/opensslv.h>
+#if !defined(LIBRESSL_VERSION_NUMBER)
 #include <openssl/e_os2.h>
+#endif
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>

--- a/rutil/Random.cxx
+++ b/rutil/Random.cxx
@@ -37,7 +37,10 @@
 #endif
 
 #if ( USE_OPENSSL == 1 )
+#  include <openssl/opensslv.h>
+#if !defined(LIBRESSL_VERSION_NUMBER)
 #  include <openssl/e_os2.h>
+#endif
 #  include <openssl/rand.h>
 #  include <openssl/err.h>
 #endif

--- a/rutil/ssl/OpenSSLInit.cxx
+++ b/rutil/ssl/OpenSSLInit.cxx
@@ -10,7 +10,10 @@
 
 #include "rutil/ssl/OpenSSLInit.hxx"
 
+#include <openssl/opensslv.h>
+#if !defined(LIBRESSL_VERSION_NUMBER)
 #include <openssl/e_os2.h>
+#endif
 #include <openssl/rand.h>
 #include <openssl/err.h>
 #include <openssl/crypto.h>
@@ -18,7 +21,6 @@
 
 #define OPENSSL_THREAD_DEFINES
 #include <openssl/opensslconf.h>
-#include <openssl/opensslv.h>
 
 #if  defined(WIN32) && defined(_MSC_VER) && (_MSC_VER >= 1900)
 // OpenSSL builds use an older version of visual studio that require the following definition


### PR DESCRIPTION
Newer versions of LibreSSL do not ship the `openssl/e_os2.h` header anymore. So exclude it if LibreSSL is detected.