### PR TITLE
LibreSSL fixes

### DIFF
--- a/resip/stack/ssl/DtlsTransport.cxx
+++ b/resip/stack/ssl/DtlsTransport.cxx
@@ -70,7 +70,7 @@
 
 #define RESIPROCATE_SUBSYSTEM Subsystem::TRANSPORT
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
 
 static void SSL_set0_rbio(SSL *s, BIO *rbio)
 {
@@ -78,10 +78,12 @@ static void SSL_set0_rbio(SSL *s, BIO *rbio)
     s->rbio = rbio;
 }
 
+#if !defined(LIBRESSL_VERSION_NUMBER)
 static void BIO_up_ref(BIO *a)
 {
     CRYPTO_add(&a->references, 1, CRYPTO_LOCK_BIO);
 }
+#endif
 
 #endif
 

--- a/rutil/ssl/OpenSSLInit.cxx
+++ b/rutil/ssl/OpenSSLInit.cxx
@@ -69,7 +69,7 @@ OpenSSLInit::OpenSSLInit()
 	CRYPTO_set_dynlock_lock_callback(::resip_OpenSSLInit_dynLockFunction);
 #endif
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
 	CRYPTO_malloc_debug_init();
 	CRYPTO_set_mem_debug_options(V_CRYPTO_MDEBUG_ALL);
 #else


### PR DESCRIPTION
LibreSSL currently only supports `BIO_up_ref` but not `SSL_set0_rbio` nor `CRYPTO_set_mem_debug`. So use code paths compatible with older OpenSSL versions.

Successfully tested on OpenBSD -current.