### PR TITLE
Handle undefined IPPROTO_SCTP

### DIFF
--- a/rutil/compat.hxx
+++ b/rutil/compat.hxx
@@ -298,6 +298,10 @@ hton64(const UInt64 input)
 #endif
 #endif
 
+#ifndef IPPROTO_SCTP
+#define IPPROTO_SCTP 132
+#endif
+
 // !bwc! Some poking around seems to indicate that icc supports gcc's function 
 // attributes, at least as far back as version 8. I have no idea what support is 
 // like prior to that. As for SUNPRO, it uses gcc's frontend, so I would expect 


### PR DESCRIPTION
OpenBSD does not define `IPPROTO_SCTP` in its standard include headers. Consequently compilation fails in `rutil/hep/HepAgent.hxx` due to an undefined symbol.

So check for its existence and if necessary define it in `rutil/compat.hxx` with the IANA assigned protocol number of SCTP.