### PR TITLE
rutil: Do not provide snprintf wrapper for VS2015 and newer

### DIFF
--- a/rutil/compat.hxx
+++ b/rutil/compat.hxx
@@ -54,7 +54,7 @@
 #include "wince/WceCompat.hxx"
 #endif // UNDER_CE
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #include <stdio.h>
 #ifndef snprintf
 #define snprintf c99_snprintf


### PR DESCRIPTION
Defining snprintf breaks std::snprintf and should be avoided
wherever possible.

See: https://stackoverflow.com/a/8712996