### PR TITLE
Avoid using deprecated OpenSSL APIs

### DIFF
--- a/reTurn/AsyncTlsSocketBase.cxx
+++ b/reTurn/AsyncTlsSocketBase.cxx
@@ -7,6 +7,7 @@
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 
+#include <openssl/opensslv.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
@@ -16,6 +17,15 @@
 #include "ReTurnSubsystem.hxx"
 
 #define RESIPROCATE_SUBSYSTEM ReTurnSubsystem::RETURN
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+inline const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x)
+{
+    return ASN1_STRING_data(const_cast< ASN1_STRING* >(x));
+}
+
+#endif // OPENSSL_VERSION_NUMBER < 0x10100000L
 
 using namespace std;
 
@@ -233,7 +243,7 @@ AsyncTlsSocketBase::validateServerCertificateHostname()
    
          int t = ASN1_STRING_type(s);
          int l = ASN1_STRING_length(s);
-         unsigned char* d = ASN1_STRING_data(s);
+         const unsigned char* d = ASN1_STRING_get0_data(s);
          resip::Data name(d,l);
          DebugLog( << "got x509 string type=" << t << " len="<< l << " data=" << d );
          resip_assert( name.size() == (unsigned)l );

--- a/reTurn/client/TurnTlsSocket.cxx
+++ b/reTurn/client/TurnTlsSocket.cxx
@@ -7,12 +7,22 @@
 #include <boost/bind.hpp>
 
 #include "TurnTlsSocket.hxx"
+#include <openssl/opensslv.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <rutil/Logger.hxx>
 #include "../ReTurnSubsystem.hxx"
 
 #define RESIPROCATE_SUBSYSTEM ReTurnSubsystem::RETURN
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+inline const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x)
+{
+    return ASN1_STRING_data(const_cast< ASN1_STRING* >(x));
+}
+
+#endif // OPENSSL_VERSION_NUMBER < 0x10100000L
 
 using namespace std;
 
@@ -178,7 +188,7 @@ TurnTlsSocket::validateServerCertificateHostname(const std::string& hostname)
    
          int t = ASN1_STRING_type(s);
          int l = ASN1_STRING_length(s);
-         unsigned char* d = ASN1_STRING_data(s);
+         const unsigned char* d = ASN1_STRING_get0_data(s);
          resip::Data name(d,l);
          DebugLog( << "got x509 string type=" << t << " len="<< l << " data=" << d );
          resip_assert( name.size() == (unsigned)l );

--- a/resip/stack/ssl/Security.cxx
+++ b/resip/stack/ssl/Security.cxx
@@ -57,6 +57,15 @@
 #include <openssl/x509v3.h>
 #include <openssl/ssl.h>
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+inline const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x)
+{
+    return ASN1_STRING_data(const_cast< ASN1_STRING* >(x));
+}
+
+#endif // OPENSSL_VERSION_NUMBER < 0x10100000L
+
 using namespace resip;
 using namespace std;
 
@@ -2637,7 +2646,7 @@ BaseSecurity::getCertNames(X509 *cert, std::list<PeerName> &peerNames,
       
       int t = ASN1_STRING_type(s);
       int l = ASN1_STRING_length(s);
-      unsigned char* d = ASN1_STRING_data(s);
+      const unsigned char* d = ASN1_STRING_get0_data(s);
       Data name(d,l);
       DebugLog( << "got x509 string type=" << t << " len="<< l << " data=" << d );
       resip_assert( name.size() == (unsigned)l );


### PR DESCRIPTION
1. Use `ERR_remove_thread_state` to free thread-specific state on OpenSSL from 1.0.0 up to 1.1.0.
2. Use `SSL_COMP_free_compression_methods` on OpenSSL 1.0.2 to free memory allocated for compression methods.
3. Use `ASN1_STRING_get0_data` to access ASN.1 string contents. On OpenSSL older than 1.1.0, implement the function as a simple wrapper forwarding to `ASN1_STRING_data`.

This removes a bunch of compilation warnings about using deprecated OpenSSL APIs. In case of OpenSSL 1.0.2 this also fixes a memory leak of compression methods.
