### PR TITLE
change the current startup directory as daemon process's working directory 

### DIFF
--- a/rutil/ServerProcess.cxx
+++ b/rutil/ServerProcess.cxx
@@ -267,7 +267,7 @@ ServerProcess::daemonize()
       // parent process done
       exit(0);
    }
-   if(chdir("/") < 0)
+   if(chdir("./") < 0)
    {
       ErrLog(<<"chdir() failed: "<<strerror(errno));
       throw std::runtime_error(strerror(errno));


### PR DESCRIPTION
I think it is unreasonable to set `/` as the daemon process's working directory. while my config file at startup directory but the working directory at `/`, perhaps the directory `./` will be more convenient.