### PR TITLE
ParseBuffer: Skip substring search in skipToChars when the length is …

### DIFF
--- a/rutil/ParseBuffer.cxx
+++ b/rutil/ParseBuffer.cxx
@@ -247,7 +247,9 @@ ParseBuffer::skipToChars(const char* cs)
 
    const char* rpos;
    const char* cpos;
-   while (mPosition < mEnd)
+   // Checking mPosition >= mEnd - l is unnecessary because there won't be
+   // enough bytes left to find [cs].
+   while (mPosition < mEnd - l)
    {
       rpos = mPosition;
       cpos = cs;
@@ -262,6 +264,8 @@ ParseBuffer::skipToChars(const char* cs)
       return CurrentPosition(*this);
      skip: ;
    }
+   // Advance to the end since we didn't find a match.
+   mPosition = mEnd;
    return CurrentPosition(*this);
 }
 

--- a/rutil/test/testParseBuffer.cxx
+++ b/rutil/test/testParseBuffer.cxx
@@ -258,6 +258,13 @@ main(int argc, char** argv)
    }
 
    {
+      char buf[] = {'a', 'x', 'y'};      // Intentionally not NUL terminated.
+      ParseBuffer pb(buf, sizeof(buf));  // Note: sizeof instead of strlen.
+
+      pb.skipToChars("xyzabc123");
+   }
+
+   {
       char buf[] = "Here is a \t buffer with some stuff.";
       ParseBuffer pb(buf, strlen(buf));
 


### PR DESCRIPTION
…longer than the amount of remaining characters.

This makes the loop terminate earlier, and also allows the compiler to safely optimize this to bcmp. See https://bugs.llvm.org/show_bug.cgi?id=43870 for more details on this optimization.

Tested by running the ParseBuffer test with `./configure CXXFLAGS=-fsanitize=address` 