### PR TITLE
Fix off-by-one error in ParseBuffer::SkipToChars()

### DIFF
--- a/rutil/ParseBuffer.cxx
+++ b/rutil/ParseBuffer.cxx
@@ -247,9 +247,9 @@ ParseBuffer::skipToChars(const char* cs)
 
    const char* rpos;
    const char* cpos;
-   // Checking mPosition >= mEnd - l is unnecessary because there won't be
+   // Checking mPosition >= mEnd - l +1 is unnecessary because there won't be
    // enough bytes left to find [cs].
-   while (mPosition < mEnd - l)
+   while (mPosition < mEnd - l + 1)
    {
       rpos = mPosition;
       cpos = cs;

--- a/rutil/test/testParseBuffer.cxx
+++ b/rutil/test/testParseBuffer.cxx
@@ -244,6 +244,15 @@ main(int argc, char** argv)
    }
 
    {
+      char buf[] = "abcdef";
+      ParseBuffer pb(buf, strlen(buf));
+
+      pb.skipToChars("def");
+      pb.skipChars("def");
+      pb.assertEof();
+   }
+
+   {
       char buf[] = "Here is asom \t buffer with some stuff.";
       ParseBuffer pb(buf, strlen(buf));
       pb.skipToChars(Data("some"));


### PR DESCRIPTION
When the search string is present in the parse buffer, the buffer's position on return should be at
the beginning of where the search string was found. In the case where the search string was at the
very end of the buffer the new position would incorrectly be the end of the buffer.