### PR TITLE
Fix compilation error in resip::RecursiveMutex using musl on Alpine Linux

### DIFF
--- a/rutil/RecursiveMutex.cxx
+++ b/rutil/RecursiveMutex.cxx
@@ -69,7 +69,7 @@ RecursiveMutex::RecursiveMutex()
 {
 #ifndef WIN32
    int rc = pthread_mutexattr_init(&mMutexAttr);
- #if defined(__linux__)
+ #if defined(__linux__) && defined(PTHREAD_MUTEX_RECURSIVE_NP)
    pthread_mutexattr_settype(&mMutexAttr, PTHREAD_MUTEX_RECURSIVE_NP);
  #else
    pthread_mutexattr_settype(&mMutexAttr, PTHREAD_MUTEX_RECURSIVE);


### PR DESCRIPTION
Found an issue when compiling rutil on Alpine Linux, which uses musl instead of glibc.

It appears that __linux__ is defined, but PTHREAD_MUTEX_RECURSIVE_NP is not. The change I've suggested appears to solve the problem because PTHREAD_MUTEX_RECURSIVE is defined. Happy to hear if you know of a better way though.