### PR TITLE
Added Profile feature Handling491AsGeneralFailure

### DIFF
--- a/resip/dum/InviteSession.cxx
+++ b/resip/dum/InviteSession.cxx
@@ -3019,7 +3019,8 @@ InviteSession::toEvent(const SipMessage& msg, const Contents* offerAnswer)
    {
       return On487Invite;
    }
-   else if (method == INVITE && code == 491)
+   else if (method == INVITE && code == 491 &&
+            !mDialog.mDialogSet.getUserProfile()->getHandling491AsGeneralFailure())
    {
       return On491Invite;
    }
@@ -3085,7 +3086,8 @@ InviteSession::toEvent(const SipMessage& msg, const Contents* offerAnswer)
    {
       return On422Update;
    }
-   else if (method == UPDATE && code == 491)
+   else if (method == UPDATE && code == 491 &&
+            !mDialog.mDialogSet.getUserProfile()->getHandling491AsGeneralFailure())
    {
       return On491Update;
    }

--- a/resip/dum/InviteSession.cxx
+++ b/resip/dum/InviteSession.cxx
@@ -3020,7 +3020,7 @@ InviteSession::toEvent(const SipMessage& msg, const Contents* offerAnswer)
       return On487Invite;
    }
    else if (method == INVITE && code == 491 &&
-            !mDialog.mDialogSet.getUserProfile()->getHandling491AsGeneralFailure())
+            !mDialog.mDialogSet.getUserProfile()->getHandleInviteSession491AsGeneralFailureEnabled())
    {
       return On491Invite;
    }
@@ -3087,7 +3087,7 @@ InviteSession::toEvent(const SipMessage& msg, const Contents* offerAnswer)
       return On422Update;
    }
    else if (method == UPDATE && code == 491 &&
-            !mDialog.mDialogSet.getUserProfile()->getHandling491AsGeneralFailure())
+            !mDialog.mDialogSet.getUserProfile()->getHandleInviteSession491AsGeneralFailureEnabled())
    {
       return On491Update;
    }

--- a/resip/dum/Profile.cxx
+++ b/resip/dum/Profile.cxx
@@ -56,7 +56,7 @@ Profile::reset()
    unsetMethodsParamEnabled();
    unsetUserAgentCapabilities();
    unsetExtraHeadersInReferNotifySipFragEnabled();
-   unsetHandling491AsGeneralFailure();
+   unsetHandleInviteSession491AsGeneralFailureEnabled();
 }
 
 void
@@ -994,34 +994,34 @@ Profile::unsetExtraHeadersInReferNotifySipFragEnabled()
 }
 
 void
-Profile::setHandling491AsGeneralFailure(bool enabled)
+Profile::setHandleInviteSession491AsGeneralFailureEnabled(bool enabled)
 {
-   mHandling491AsGeneralFailure = enabled;
-   mHasHandling491AsGeneralFailure = true;
+   mHandleInviteSession491AsGeneralFailureEnabled = enabled;
+   mHasHandleInviteSession491AsGeneralFailureEnabled = true;
 }
 
 bool
-Profile::getHandling491AsGeneralFailure() const
+Profile::getHandleInviteSession491AsGeneralFailureEnabled() const
 {
    // Fall through seting (if required)
-   if(!mHasHandling491AsGeneralFailure && mBaseProfile.get())
+   if(!mHasHandleInviteSession491AsGeneralFailureEnabled && mBaseProfile.get())
    {
-       return mBaseProfile->getHandling491AsGeneralFailure();
+       return mBaseProfile->getHandleInviteSession491AsGeneralFailureEnabled();
    }
-   return mHandling491AsGeneralFailure;
+   return mHandleInviteSession491AsGeneralFailureEnabled;
 }
 
 void
-Profile::unsetHandling491AsGeneralFailure()
+Profile::unsetHandleInviteSession491AsGeneralFailureEnabled()
 {
    if(mBaseProfile.get())
    {
-      mHasHandling491AsGeneralFailure = false;
+      mHasHandleInviteSession491AsGeneralFailureEnabled = false;
    }
    else
    {
-      mHasHandling491AsGeneralFailure = true;
-      mHandling491AsGeneralFailure = false;
+      mHasHandleInviteSession491AsGeneralFailureEnabled = true;
+      mHandleInviteSession491AsGeneralFailureEnabled = false;
    }
 }
 

--- a/resip/dum/Profile.cxx
+++ b/resip/dum/Profile.cxx
@@ -56,6 +56,7 @@ Profile::reset()
    unsetMethodsParamEnabled();
    unsetUserAgentCapabilities();
    unsetExtraHeadersInReferNotifySipFragEnabled();
+   unsetHandling491AsGeneralFailure();
 }
 
 void
@@ -992,6 +993,37 @@ Profile::unsetExtraHeadersInReferNotifySipFragEnabled()
    }
 }
 
+void
+Profile::setHandling491AsGeneralFailure(bool enabled)
+{
+   mHandling491AsGeneralFailure = enabled;
+   mHasHandling491AsGeneralFailure = true;
+}
+
+bool
+Profile::getHandling491AsGeneralFailure() const
+{
+   // Fall through seting (if required)
+   if(!mHasHandling491AsGeneralFailure && mBaseProfile.get())
+   {
+       return mBaseProfile->getHandling491AsGeneralFailure();
+   }
+   return mHandling491AsGeneralFailure;
+}
+
+void
+Profile::unsetHandling491AsGeneralFailure()
+{
+   if(mBaseProfile.get())
+   {
+      mHasHandling491AsGeneralFailure = false;
+   }
+   else
+   {
+      mHasHandling491AsGeneralFailure = true;
+      mHandling491AsGeneralFailure = false;
+   }
+}
 
 /* ====================================================================
  * The Vovida Software License, Version 1.0 

--- a/resip/dum/Profile.hxx
+++ b/resip/dum/Profile.hxx
@@ -236,6 +236,10 @@ class Profile
       virtual bool getExtraHeadersInReferNotifySipFragEnabled() const;
       virtual void unsetExtraHeadersInReferNotifySipFragEnabled();
 
+      virtual void setHandling491AsGeneralFailure(bool enabled);
+      virtual bool getHandling491AsGeneralFailure() const;
+      virtual void unsetHandling491AsGeneralFailure();
+
    private:
       bool mHasDefaultRegistrationExpires;
       UInt32 mDefaultRegistrationExpires;
@@ -320,6 +324,9 @@ class Profile
 
       bool mHasExtraHeadersInReferNotifySipFragEnabled;
       bool mExtraHeadersInReferNotifySipFragEnabled;
+
+      bool mHasHandling491AsGeneralFailure;
+      bool mHandling491AsGeneralFailure;
 
       SharedPtr<Profile> mBaseProfile;  // All non-set settings will fall through to this Profile (if set)
 };

--- a/resip/dum/Profile.hxx
+++ b/resip/dum/Profile.hxx
@@ -236,9 +236,9 @@ class Profile
       virtual bool getExtraHeadersInReferNotifySipFragEnabled() const;
       virtual void unsetExtraHeadersInReferNotifySipFragEnabled();
 
-      virtual void setHandling491AsGeneralFailure(bool enabled);
-      virtual bool getHandling491AsGeneralFailure() const;
-      virtual void unsetHandling491AsGeneralFailure();
+      virtual void setHandleInviteSession491AsGeneralFailureEnabled(bool enabled);
+      virtual bool getHandleInviteSession491AsGeneralFailureEnabled() const;
+      virtual void unsetHandleInviteSession491AsGeneralFailureEnabled();
 
    private:
       bool mHasDefaultRegistrationExpires;
@@ -325,8 +325,8 @@ class Profile
       bool mHasExtraHeadersInReferNotifySipFragEnabled;
       bool mExtraHeadersInReferNotifySipFragEnabled;
 
-      bool mHasHandling491AsGeneralFailure;
-      bool mHandling491AsGeneralFailure;
+      bool mHasHandleInviteSession491AsGeneralFailureEnabled;
+      bool mHandleInviteSession491AsGeneralFailureEnabled;
 
       SharedPtr<Profile> mBaseProfile;  // All non-set settings will fall through to this Profile (if set)
 };


### PR DESCRIPTION
The patch allows to switch off the resending mechanism activated by response 491 in order to allow the app layer to handle it. The feature is off by default. So if someone does not touch anything then DUM behaves as normal.