### PR TITLE
Enable OpenSSL automatic curve selection mechanism

### DIFF
--- a/resip/stack/ssl/Security.cxx
+++ b/resip/stack/ssl/Security.cxx
@@ -3154,6 +3154,8 @@ BaseSecurity::setDHParams(SSL_CTX* ctx)
       BIO_free(bio);
    }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
 #ifndef SSL_CTRL_SET_ECDH_AUTO
 #define SSL_CTRL_SET_ECDH_AUTO 94
 #endif
@@ -3189,6 +3191,10 @@ BaseSecurity::setDHParams(SSL_CTX* ctx)
       WarningLog(<<"unable to initialize ECDH: SSL_CTX_ctrl failed, OPENSSL_NO_ECDH defined or repro was compiled with an old OpenSSL version");
 #endif
    }
+
+#endif
+
+
 }
 
 #endif


### PR DESCRIPTION
SSL_{CTX_}set_ecdh_auto() has been removed from OpenSSL 1.1.0. and
ECDH is support is always enabled now. See
https://github.com/openssl/openssl/issues/1437#issuecomment-238828306

The code which calls SSL_CTX_ctrl(ctx, SSL_CTRL_SET_ECDH_AUTO
is failing with OpenSSL 1.1.0 and this causes set SSL_CTX_set_tmp_ecdh
with hard coded P-256 curve.

As a side-effect the OpenSSL automatic curve selection mechanism
is disabled and reSIProcate uses only the P-256 curve and doesn't use
newer curves, for example X-25519 with TLS connections.