### PR TITLE
Changes to bring Stun implementation closer to RFC5389/8489 compliance

### DIFF
--- a/resip/stack/UdpTransport.cxx
+++ b/resip/stack/UdpTransport.cxx
@@ -440,7 +440,7 @@ UdpTransport::processRxParse(char *buffer, int len, Tuple& sender)
       // Once parsing is successful below, the return code will be updated
       mStunResult = StunResultResponseParseFailed;
 
-      if (stunParseMessage(buffer, len, resp, false))
+      if (stunParseMessage(buffer, len, resp, true))
       {
          in_addr sin_addr;
          // Use XorMappedAddress if present - if not use MappedAddress

--- a/resip/stack/UdpTransport.cxx
+++ b/resip/stack/UdpTransport.cxx
@@ -440,7 +440,7 @@ UdpTransport::processRxParse(char *buffer, int len, Tuple& sender)
       // Once parsing is successful below, the return code will be updated
       mStunResult = StunResultResponseParseFailed;
 
-      if (stunParseMessage(buffer, len, resp, true))
+      if (stunParseMessage(buffer, len, resp, false))
       {
          in_addr sin_addr;
          // Use XorMappedAddress if present - if not use MappedAddress

--- a/resip/stack/UdpTransport.hxx
+++ b/resip/stack/UdpTransport.hxx
@@ -83,8 +83,16 @@ public:
    static const int MaxBufferSize = 8192;
 
    // STUN client functionality
+   enum StunResult
+   {
+       StunResultUnknown,
+       StunResultSuccess,
+       StunResultNoResponse,
+       StunResultResponseParseFailed
+   };
+
    bool stunSendTest(const Tuple& dest);
-   bool stunResult(Tuple& mappedAddress);
+   StunResult stunResult(Tuple& mappedAddress);
 
    /// Installs a handler for the unknown datagrams arriving on the udp transport.
    void setExternalUnknownDatagramHandler(ExternalUnknownDatagramHandler *handler);
@@ -114,7 +122,10 @@ private:
    MsgHeaderScanner mMsgHeaderScanner;
    mutable resip::Mutex  myMutex;
    Tuple mStunMappedAddress;
-   bool mStunSuccess;
+   
+   StunResult mStunResult;
+   StunSetting mStunSetting;
+
    ExternalUnknownDatagramHandler* mExternalUnknownDatagramHandler;
    bool mInWritable;
    bool mInActiveWrite;

--- a/rutil/stun/Stun.cxx
+++ b/rutil/stun/Stun.cxx
@@ -222,7 +222,6 @@ bool
 stunParseMessage( char* buf, unsigned int bufLen, StunMessage& msg, bool verbose)
 {
    if (verbose) clog << "Received stun message: " << bufLen << " bytes" << endl;
-   memset(&msg, 0, sizeof(msg));
 	
    if (sizeof(StunMsgHdr) > bufLen)
    {
@@ -1353,11 +1352,6 @@ stunServerProcessMsg( char* buf,
                       bool* changeIp,
                       bool verbose)
 {
-    
-   // set up information for default response 
-	
-   memset( resp, 0 , sizeof(*resp) );
-	
    *changeIp = false;
    *changePort = false;
 	

--- a/rutil/stun/Stun.hxx
+++ b/rutil/stun/Stun.hxx
@@ -190,35 +190,10 @@ struct StunMessage
 {
     StunMessage() 
     {
-       memset(&msgHdr, 0, sizeof(msgHdr));
-
-       hasMappedAddress = false;
-       hasResponseAddress = false;
-       hasChangeRequest = false;
-       hasSourceAddress = false;
-       hasChangedAddress = false;
-       hasUsername = false;
-       hasPassword = false;
-       hasMessageIntegrity = false;
-       hasErrorCode = false;
-       hasUnknownAttributes = false;
-       hasReflectedFrom = false;
-       hasRealm = false;
-       hasNonce = false;
-       hasXorMappedAddress = false;
-       hasSoftware = false;
-       hasSecondaryAddress = false;
-       hasAlternateServer = false;
-       hasFingerprint = false;
-       hasTurnLifetime = false;
-       hasTurnAlternateServer = false;
-       hasTurnMagicCookie = false;
-       hasTurnBandwidth = false;
-       hasTurnDestinationAddress = false;
-       hasTurnRemoteAddress = false;
-       hasTurnData = false;
-
-       xorOnly = false;
+       // !jr! Zeroing the entire structure which is a bit dangerous.
+       // If you add any complex types to this structure, be careful of
+       // the results.
+       memset(this, 0, sizeof(*this));
     }
     
     ~StunMessage() 


### PR DESCRIPTION
Send/Accept XOR_MAPPED_ADDRESS using newer 0x0020 value (rather than
0x8020)
Use the correct 32bit magic cookie for sending stun requests from
UdpTransport
Add processing of all defined STUN attribute headers
Implement processing of UdpTransport StunEnabled flag (restrict usage of
UdpTransport as STUN server)
Add more detailed error response for StunResult (returns NO_RESPONSE or PARSE_FAILED as required)