### PR TITLE
Fix an issue where the HEPSipMessageLoggingHandler constructor always throws

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,4 @@
 Checks: >-
   -*,
   bugprone-*
+HeaderFilterRegex: .*

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+Checks: >-
+  -*,
+  bugprone-*

--- a/build/jenkins/Jenkinsfile
+++ b/build/jenkins/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         timestamps()
     }
     stages {
-        stage('Build'){
+        stage('Build') {
             matrix {
                 axes {
                     axis {
@@ -16,16 +16,17 @@ pipeline {
                 agent {
                     dockerfile {
                         dir "build/jenkins/${DISTRO}"
+                        additionalBuildArgs '--load'
                     }
                 }
                 stages {
-                    stage('Bootstrap'){
+                    stage('Bootstrap') {
                         steps {
                             sh 'autoreconf --install'
                             sh 'rm resip/stack/gen/*'
                         }
                     }
-                    stage('Configure'){
+                    stage('Configure') {
                         steps {
                             sh "./configure --enable-assert-syslog \
                                             --enable-dtls \
@@ -54,12 +55,12 @@ pipeline {
                                             PYCXX_SRCDIR=/usr/share/python3.8/CXX/Python3"
                         }
                     }
-                    stage('Build'){
+                    stage('Build') {
                         steps {
                             sh 'make -j'
                         }
                     }
-                    stage('Test'){
+                    stage('Test') {
                         steps {
                             sh 'make -j check TESTS='
                             sh 'make check'
@@ -68,7 +69,7 @@ pipeline {
                 }
                 post {
                     always {
-                        archiveArtifacts artifacts: "**/test-suite.log", allowEmptyArchive: true, fingerprint: true
+                        archiveArtifacts artifacts: '**/test-suite.log', allowEmptyArchive: true, fingerprint: true
                         recordIssues (
                             tools: [
                                 gcc(

--- a/build/jenkins/Jenkinsfile
+++ b/build/jenkins/Jenkinsfile
@@ -68,9 +68,10 @@ pipeline {
                             expression { DISTRO == 'alpine' }
                         }
                         steps {
-                            sh 'compiledb make'
+                            sh 'compiledb -n make'
                             sh 'clang-tidy --list-checks'
-                            sh "/usr/share/clang/run-clang-tidy.py -j8 2>/dev/null | sed -e 's|${WORKSPACE}/||g' > clang-tidy-results.txt || true"
+                            sh "/usr/share/clang/run-clang-tidy.py -j8 2>/dev/null > clang-tidy-results.txt || true"
+                            archiveArtifacts artifacts: 'clang-tidy-results.txt'
                             recordIssues(
                                 tools: [
                                     clangTidy(pattern: 'clang-tidy-results.txt')

--- a/build/jenkins/Jenkinsfile
+++ b/build/jenkins/Jenkinsfile
@@ -1,3 +1,6 @@
+/* groovylint-disable DuplicateStringLiteral */
+/* groovylint-disable LineLength */
+/* groovylint-disable NestedBlockDepth */
 
 pipeline {
     agent none
@@ -60,17 +63,35 @@ pipeline {
                             sh 'make -j'
                         }
                     }
+                    stage('Static Analysis') {
+                        when {
+                            expression { DISTRO == 'alpine' }
+                        }
+                        steps {
+                            sh 'compiledb make'
+                            sh 'clang-tidy --list-checks'
+                            sh "/usr/share/clang/run-clang-tidy.py -j8 2>/dev/null | sed -e 's|${WORKSPACE}/||g' > clang-tidy-results.txt || true"
+                            recordIssues(
+                                tools: [
+                                    clangTidy(pattern: 'clang-tidy-results.txt')
+                                ]
+                            )
+                        }
+                    }
                     stage('Test') {
                         steps {
                             sh 'make -j check TESTS='
                             sh 'make check'
+                            archiveArtifacts artifacts: '**/test-suite.log', allowEmptyArchive: true
                         }
                     }
                 }
                 post {
                     always {
-                        archiveArtifacts artifacts: '**/test-suite.log', allowEmptyArchive: true, fingerprint: true
                         recordIssues (
+                            filters: [
+                                excludeFile('/root/*')
+                            ],
                             tools: [
                                 gcc(
                                     id: "${DISTRO}-gcc",
@@ -78,9 +99,6 @@ pipeline {
                                 )
                             ]
                         )
-                    }
-                    cleanup {
-                        cleanWs()
                     }
                 }
             }

--- a/build/jenkins/Jenkinsfile
+++ b/build/jenkins/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                         steps {
                             sh 'compiledb -n make'
                             sh 'clang-tidy --list-checks'
-                            sh "/usr/share/clang/run-clang-tidy.py -j8 2>/dev/null > clang-tidy-results.txt || true"
+                            sh '/usr/share/clang/run-clang-tidy.py -j8 2>/dev/null > clang-tidy-results.txt || true'
                             archiveArtifacts artifacts: 'clang-tidy-results.txt'
                             recordIssues(
                                 tools: [

--- a/build/jenkins/alpine/Dockerfile
+++ b/build/jenkins/alpine/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache abi-compliance-checker \
                        gnutls-dev \
                        gperf \
                        linux-headers \
+                       libsrtp-dev \
                        libtool \
                        make \
                        mariadb-connector-c-dev \
@@ -72,16 +73,6 @@ RUN tar -xf 4.0.0.tar.gz && \
     cd ../.. && \
     rm -fr soci-4.0.0 && \
     rm soci-code-fixes.patch
-
-ADD https://github.com/cisco/libsrtp/archive/v1.6.0.tar.gz /root/
-RUN tar -xf v1.6.0.tar.gz && \
-    rm v1.6.0.tar.gz && \
-    cd libsrtp-1.6.0 && \
-    ./configure --prefix=/usr && \
-    make && \
-    make install && \
-    cd .. && \
-    rm -fr libsrtp-1.6.0
 
 RUN svn checkout svn://svn.camaya.net/gloox/branches/1.0 gloox && \
     cd gloox && \

--- a/build/jenkins/alpine/Dockerfile
+++ b/build/jenkins/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.12 AS build-env
 
 RUN apk add --no-cache abi-compliance-checker \
                        asio-dev \
@@ -6,6 +6,8 @@ RUN apk add --no-cache abi-compliance-checker \
                        automake \
                        boost-dev \
                        c-ares-dev \
+                       clang \
+                       clang-extra-tools \
                        cmake \
                        coreutils \
                        cppunit-dev \
@@ -29,6 +31,7 @@ RUN apk add --no-cache abi-compliance-checker \
                        pkgconfig \
                        popt-dev \
                        postgresql-dev \
+                       py3-pip \
                        python3-dev \
                        qtchooser \
                        subversion \
@@ -37,6 +40,8 @@ RUN apk add --no-cache abi-compliance-checker \
                        util-linux-dev \
                        xerces-c-dev \
                        xxd && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    pip install compiledb && \
     adduser --system --uid 1000 jenkins
 
 WORKDIR /root

--- a/build/jenkins/ubuntu/Dockerfile
+++ b/build/jenkins/ubuntu/Dockerfile
@@ -25,6 +25,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
                        libsipxtapi-dev \
                        libsnmp-dev \
                        libsoci-dev \
+                       libsrtp2-dev \
                        libssl-dev \
                        libtelepathy-qt5-dev \
                        libtool \
@@ -37,16 +38,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     adduser --system --uid 1000 jenkins
 
 WORKDIR /root
-
-ADD https://github.com/cisco/libsrtp/archive/v1.6.0.tar.gz /root/
-RUN tar -xf v1.6.0.tar.gz && \
-    rm v1.6.0.tar.gz && \
-    cd libsrtp-1.6.0 && \
-    ./configure --prefix=/usr && \
-    make && \
-    make install && \
-    cd .. && \
-    rm -fr libsrtp-1.6.0
 
 ENV CPATH="/usr/include/postgresql:${CPATH}"
 

--- a/build/jenkins/ubuntu/Dockerfile
+++ b/build/jenkins/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:focal AS build-env
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get -y update && \

--- a/reflow/FlowManager.hxx
+++ b/reflow/FlowManager.hxx
@@ -57,8 +57,8 @@ public:
    void initializeDtlsFactory(const char* certAor);
    dtls::DtlsFactory* getDtlsFactory() { return mDtlsFactory; }
 
-   void setRTCPEventLoggingHandler(std::shared_ptr<RTCPEventLoggingHandler> handler) { mRtcpEventLoggingHandler = std::move(handler); }
-   RTCPEventLoggingHandler* getRTCPEventLoggingHandler() { return 0 != mRtcpEventLoggingHandler.get() ? mRtcpEventLoggingHandler.get() : 0; }
+   void setRTCPEventLoggingHandler(std::shared_ptr<RTCPEventLoggingHandler> handler) noexcept { mRtcpEventLoggingHandler = std::move(handler); }
+   RTCPEventLoggingHandler* getRTCPEventLoggingHandler() const noexcept { return 0 != mRtcpEventLoggingHandler.get() ? mRtcpEventLoggingHandler.get() : 0; }
 
 protected: 
 

--- a/repro/Proxy.cxx
+++ b/repro/Proxy.cxx
@@ -128,13 +128,13 @@ Proxy::~Proxy()
 }
 
 void 
-Proxy::setOptionsHandler(OptionsHandler* handler)
+Proxy::setOptionsHandler(OptionsHandler* handler) noexcept
 {
    mOptionsHandler = handler;
 }
  
 void 
-Proxy::setRequestContextFactory(std::unique_ptr<RequestContextFactory> requestContextFactory)
+Proxy::setRequestContextFactory(std::unique_ptr<RequestContextFactory> requestContextFactory) noexcept
 {
    mRequestContextFactory = std::move(requestContextFactory);
 }
@@ -146,7 +146,7 @@ Proxy::isShutDown() const
 }
 
 UserStore&
-Proxy::getUserStore()
+Proxy::getUserStore() noexcept
 {
    return mUserStore;
 }

--- a/repro/Proxy.hxx
+++ b/repro/Proxy.hxx
@@ -67,10 +67,10 @@ class Proxy : public resip::TransactionUser, public resip::ThreadIf
       static resip::KeyValueStore::Key allocateTargetKeyValueStoreKey();  // should only be called at static initialization time
 
       // Note:  These are not thread safe and should be called before run() only
-      void setOptionsHandler(OptionsHandler* handler);
-      void setRequestContextFactory(std::unique_ptr<RequestContextFactory> requestContextFactory);
+      void setOptionsHandler(OptionsHandler* handler) noexcept;
+      void setRequestContextFactory(std::unique_ptr<RequestContextFactory> requestContextFactory) noexcept;
 
-      virtual bool isShutDown() const ;
+      virtual bool isShutDown() const;
       virtual void thread();
       
       virtual bool isMyUri(const resip::Uri& uri) const;
@@ -83,9 +83,9 @@ class Proxy : public resip::TransactionUser, public resip::ThreadIf
       bool isPAssertedIdentityProcessingEnabled() { return mPAssertedIdentityProcessing; }
       bool isNeverStripProxyAuthorizationHeadersEnabled() { return mNeverStripProxyAuthorizationHeaders; }
       
-      UserStore& getUserStore();
-      resip::SipStack& getStack(){return mStack;}
-      ProxyConfig& getConfig(){return mConfig;}
+      UserStore& getUserStore() noexcept;
+      resip::SipStack& getStack() noexcept { return mStack; }
+      ProxyConfig& getConfig() noexcept { return mConfig; }
       void send(const resip::SipMessage& msg);
       void addClientTransaction(const resip::Data& transactionId, RequestContext* rc);
 

--- a/resip/dum/ClientAuthExtension.cxx
+++ b/resip/dum/ClientAuthExtension.cxx
@@ -7,7 +7,7 @@ using namespace resip;
 std::unique_ptr<ClientAuthExtension> ClientAuthExtension::mInstance(new ClientAuthExtension());
 
 void 
-ClientAuthExtension::setInstance(std::unique_ptr<ClientAuthExtension> ext)
+ClientAuthExtension::setInstance(std::unique_ptr<ClientAuthExtension> ext) noexcept
 {
    mInstance = std::move(ext);
 }

--- a/resip/dum/ClientAuthExtension.hxx
+++ b/resip/dum/ClientAuthExtension.hxx
@@ -45,7 +45,7 @@ class ClientAuthExtension
       
       virtual bool algorithmAndQopSupported(const Auth& challenge);
 
-      static void setInstance(std::unique_ptr<ClientAuthExtension> ext);
+      static void setInstance(std::unique_ptr<ClientAuthExtension> ext) noexcept;
       static ClientAuthExtension& instance() 
       {
          return *mInstance;

--- a/resip/dum/DialogUsageManager.cxx
+++ b/resip/dum/DialogUsageManager.cxx
@@ -299,7 +299,7 @@ DialogUsageManager::forceShutdown(DumShutdownHandler* h)
    DialogUsageManager::onAllHandlesDestroyed();
 }
 
-void DialogUsageManager::setAppDialogSetFactory(std::unique_ptr<AppDialogSetFactory> factory)
+void DialogUsageManager::setAppDialogSetFactory(std::unique_ptr<AppDialogSetFactory> factory) noexcept
 {
    mAppDialogSetFactory = std::move(factory);
 }
@@ -325,29 +325,29 @@ void DialogUsageManager::setMasterProfile(const std::shared_ptr<MasterProfile>& 
    mMasterUserProfile = masterProfile; // required so that we can return a reference to std::shared_ptr<UserProfile> in getMasterUserProfile
 }
 
-void DialogUsageManager::setKeepAliveManager(std::unique_ptr<KeepAliveManager> manager)
+void DialogUsageManager::setKeepAliveManager(std::unique_ptr<KeepAliveManager> manager) noexcept
 {
    mKeepAliveManager = std::move(manager);
    mKeepAliveManager->setDialogUsageManager(this);
 }
 
-void DialogUsageManager::setRedirectManager(std::unique_ptr<RedirectManager> manager)
+void DialogUsageManager::setRedirectManager(std::unique_ptr<RedirectManager> manager) noexcept
 {
    mRedirectManager = std::move(manager);
 }
 
-void DialogUsageManager::setRedirectHandler(RedirectHandler* handler)
+void DialogUsageManager::setRedirectHandler(RedirectHandler* handler) noexcept
 {
    mRedirectHandler = handler;
 }
 
-RedirectHandler* DialogUsageManager::getRedirectHandler() const
+RedirectHandler* DialogUsageManager::getRedirectHandler() const noexcept
 {
    return mRedirectHandler;
 }
 
 void
-DialogUsageManager::setClientAuthManager(std::unique_ptr<ClientAuthManager> manager)
+DialogUsageManager::setClientAuthManager(std::unique_ptr<ClientAuthManager> manager) noexcept
 {
    mClientAuthManager = std::move(manager);
 }
@@ -373,7 +373,7 @@ DialogUsageManager::setServerRegistrationHandler(ServerRegistrationHandler* hand
 }
 
 void
-DialogUsageManager::setDialogSetHandler(DialogSetHandler* handler)
+DialogUsageManager::setDialogSetHandler(DialogSetHandler* handler) noexcept
 {
    mDialogSetHandler = handler;
 }
@@ -471,13 +471,13 @@ DialogUsageManager::addOutOfDialogHandler(MethodTypes type, OutOfDialogHandler* 
 }
 
 void
-DialogUsageManager::setClientPagerMessageHandler(ClientPagerMessageHandler* handler)
+DialogUsageManager::setClientPagerMessageHandler(ClientPagerMessageHandler* handler) noexcept
 {
    mClientPagerMessageHandler = handler;
 }
 
 void
-DialogUsageManager::setServerPagerMessageHandler(ServerPagerMessageHandler* handler)
+DialogUsageManager::setServerPagerMessageHandler(ServerPagerMessageHandler* handler) noexcept
 {
    mServerPagerMessageHandler = handler;
 }
@@ -1126,7 +1126,7 @@ void DialogUsageManager::outgoingProcess(std::unique_ptr<Message> message)
 }
 
 void
-DialogUsageManager::sendUsingOutboundIfAppropriate(UserProfile& userProfile, unique_ptr<SipMessage> msg)
+DialogUsageManager::sendUsingOutboundIfAppropriate(UserProfile& userProfile, std::unique_ptr<SipMessage> msg)
 {
    //a little inefficient, branch parameter might be better
    DialogId id(*msg);
@@ -2443,7 +2443,7 @@ DialogUsageManager::addOutgoingFeature(std::shared_ptr<DumFeature> feat)
 }
 
 void
-DialogUsageManager::setOutgoingMessageInterceptor(std::shared_ptr<DumFeature> feat)
+DialogUsageManager::setOutgoingMessageInterceptor(std::shared_ptr<DumFeature> feat) noexcept
 {
    mOutgoingMessageInterceptor = std::move(feat);
 }

--- a/resip/dum/DialogUsageManager.hxx
+++ b/resip/dum/DialogUsageManager.hxx
@@ -132,27 +132,27 @@ class DialogUsageManager : public HandleManager, public TransactionUser
       
       Data getHostAddress();
 
-      void setAppDialogSetFactory(std::unique_ptr<AppDialogSetFactory>);
+      void setAppDialogSetFactory(std::unique_ptr<AppDialogSetFactory>) noexcept;
 
       void setMasterProfile(const std::shared_ptr<MasterProfile>& masterProfile);
       std::shared_ptr<MasterProfile>& getMasterProfile();
       std::shared_ptr<UserProfile>& getMasterUserProfile();
       
       //optional handler to track the progress of DialogSets
-      void setDialogSetHandler(DialogSetHandler* handler);
+      void setDialogSetHandler(DialogSetHandler* handler) noexcept;
 
-      void setKeepAliveManager(std::unique_ptr<KeepAliveManager> keepAlive);
+      void setKeepAliveManager(std::unique_ptr<KeepAliveManager> keepAlive) noexcept;
 
       //There is a default RedirectManager.  Setting one may cause the old one
       //to be deleted. 
-      void setRedirectManager(std::unique_ptr<RedirectManager> redirect);
+      void setRedirectManager(std::unique_ptr<RedirectManager> redirect) noexcept;
       //informational, so a RedirectHandler is not required
-      void setRedirectHandler(RedirectHandler* handler);      
-      RedirectHandler* getRedirectHandler() const;      
+      void setRedirectHandler(RedirectHandler* handler) noexcept;
+      RedirectHandler* getRedirectHandler() const noexcept;
 
       /// If there is no ClientAuthManager, when the client receives a 401/407,
       /// pass it up through the normal BaseUsageHandler
-      void setClientAuthManager(std::unique_ptr<ClientAuthManager> client);
+      void setClientAuthManager(std::unique_ptr<ClientAuthManager> client) noexcept;
 
       /// If there is no ServerAuthManager, the server does not authenticate requests
       void setServerAuthManager(std::shared_ptr<ServerAuthManager> server);
@@ -180,8 +180,8 @@ class DialogUsageManager : public HandleManager, public TransactionUser
 
       void setRequestValidationHandler(RequestValidationHandler*);
 
-      void setClientPagerMessageHandler(ClientPagerMessageHandler*);
-      void setServerPagerMessageHandler(ServerPagerMessageHandler*);
+      void setClientPagerMessageHandler(ClientPagerMessageHandler*) noexcept;
+      void setServerPagerMessageHandler(ServerPagerMessageHandler*) noexcept;
 
       /// Add/Remove External Message Handler
       /// do following op when processing thread in not running
@@ -335,7 +335,7 @@ class DialogUsageManager : public HandleManager, public TransactionUser
       void addIncomingFeature(std::shared_ptr<DumFeature> feat);
       void addOutgoingFeature(std::shared_ptr<DumFeature> feat);
 
-      void setOutgoingMessageInterceptor(std::shared_ptr<DumFeature> feat);
+      void setOutgoingMessageInterceptor(std::shared_ptr<DumFeature> feat) noexcept;
 
       TargetCommand::Target& dumIncomingTarget();
 

--- a/resip/dum/HttpProvider.cxx
+++ b/resip/dum/HttpProvider.cxx
@@ -10,7 +10,7 @@ std::unique_ptr<HttpProviderFactory> HttpProvider::mFactory;
 Mutex HttpProvider::mMutex;      
 
 void 
-HttpProvider::setFactory(std::unique_ptr<HttpProviderFactory> fact)
+HttpProvider::setFactory(std::unique_ptr<HttpProviderFactory> fact) noexcept
 {
    mFactory = std::move(fact);
 }

--- a/resip/dum/HttpProvider.hxx
+++ b/resip/dum/HttpProvider.hxx
@@ -21,7 +21,7 @@ class HttpProvider
 {
    public:
       //HttpProvider assumes memory
-      static void setFactory(std::unique_ptr<HttpProviderFactory> fact);
+      static void setFactory(std::unique_ptr<HttpProviderFactory> fact) noexcept;
       //ptr so users can check for existence
       static HttpProvider* instance();
       

--- a/resip/dum/KeepAliveManager.hxx
+++ b/resip/dum/KeepAliveManager.hxx
@@ -37,7 +37,7 @@ class KeepAliveManager
 
       KeepAliveManager() : mCurrentId(0) {}
       virtual ~KeepAliveManager() {}
-      void setDialogUsageManager(DialogUsageManager* dum) { mDum = dum; }
+      void setDialogUsageManager(DialogUsageManager* dum) noexcept { mDum = dum; }
       virtual void add(const Tuple& target, int keepAliveInterval, bool targetSupportsOutbound);
       virtual void remove(const Tuple& target);
       virtual void process(KeepAliveTimeout& timeout);

--- a/resip/dum/test/basicClientCall.cxx
+++ b/resip/dum/test/basicClientCall.cxx
@@ -103,7 +103,7 @@ BasicClientCall::timerExpired()
    }
 
    // start timer for next one
-   unique_ptr<ApplicationMessage> timer(new CallTimer(mUserAgent, this));
+   std::unique_ptr<ApplicationMessage> timer(new CallTimer(mUserAgent, this));
    mUserAgent.mStack->post(std::move(timer), CallTimerTime, &mUserAgent.getDialogUsageManager());
 }
 
@@ -188,7 +188,7 @@ BasicClientCall::onNewSession(ServerInviteSessionHandle h, InviteSession::OfferA
          if(mPlacedCall)
          {
             // Restart Call Timer
-             unique_ptr<ApplicationMessage> timer(new CallTimer(mUserAgent, this));
+            std::unique_ptr<ApplicationMessage> timer(new CallTimer(mUserAgent, this));
             mUserAgent.mStack->post(std::move(timer), CallTimerTime, &mUserAgent.getDialogUsageManager());
          }
 
@@ -257,7 +257,7 @@ BasicClientCall::onConnected(ClientInviteSessionHandle h, const SipMessage& msg)
       mInviteSessionHandle = h->getSessionHandle();  
 
       // start call timer
-      unique_ptr<ApplicationMessage> timer(new CallTimer(mUserAgent, this));
+      std::unique_ptr<ApplicationMessage> timer(new CallTimer(mUserAgent, this));
       mUserAgent.mStack->post(std::move(timer), CallTimerTime, &mUserAgent.getDialogUsageManager());
    }
    else

--- a/resip/dum/test/basicClientUserAgent.cxx
+++ b/resip/dum/test/basicClientUserAgent.cxx
@@ -304,7 +304,7 @@ BasicClientUserAgent::BasicClientUserAgent(int argc, char** argv) :
    mDum->addServerSubscriptionHandler("basicClientTest", this);
 
    // Set AppDialogSetFactory
-   unique_ptr<AppDialogSetFactory> dsf(new ClientAppDialogSetFactory(*this));
+   std::unique_ptr<AppDialogSetFactory> dsf(new ClientAppDialogSetFactory(*this));
    mDum->setAppDialogSetFactory(std::move(dsf));
 
    mDum->setMasterProfile(mProfile);
@@ -467,7 +467,7 @@ BasicClientUserAgent::sendNotify()
       mServerSubscriptionHandle->send(mServerSubscriptionHandle->update(&plain));
 
       // start timer for next one
-      unique_ptr<ApplicationMessage> timer(new NotifyTimer(*this, ++mCurrentNotifyTimerId));
+      std::unique_ptr<ApplicationMessage> timer(new NotifyTimer(*this, ++mCurrentNotifyTimerId));
       mStack->post(std::move(timer), NotifySendTime, mDum);
    }
 }

--- a/resip/dum/test/basicMessage.cxx
+++ b/resip/dum/test/basicMessage.cxx
@@ -133,7 +133,7 @@ int main(int argc, char *argv[]) {
 	// sip logic
 	RegListener client;
 	auto profile = std::make_shared<MasterProfile>();   
-	unique_ptr<ClientAuthManager> clientAuth(new ClientAuthManager());
+	std::unique_ptr<ClientAuthManager> clientAuth(new ClientAuthManager());
 
     SipStack clientStack;
 	DialogUsageManager clientDum(clientStack);
@@ -174,7 +174,7 @@ int main(int argc, char *argv[]) {
 			NameAddr naTo(to.c_str());
 			ClientPagerMessageHandle cpmh = clientDum.makePagerMessage(naTo);
 			
-			unique_ptr<Contents> content(new PlainContents(Data("my first message!")));
+			std::unique_ptr<Contents> content(new PlainContents(Data("my first message!")));
 			cpmh.get()->page(std::move(content)); 
 		}
 	}   

--- a/resip/dum/test/basicRegister.cxx
+++ b/resip/dum/test/basicRegister.cxx
@@ -110,7 +110,7 @@ main (int argc, char** argv)
    clientDum.getMasterProfile()->setDefaultRegistrationTime(70);
 
    // keep alive test.
-   unique_ptr<KeepAliveManager> keepAlive(new KeepAliveManager);
+   std::unique_ptr<KeepAliveManager> keepAlive(new KeepAliveManager);
    clientDum.setKeepAliveManager(std::move(keepAlive));
 
    clientDum.getMasterProfile()->setDefaultFrom(userAor);

--- a/resip/stack/HEPSipMessageLoggingHandler.cxx
+++ b/resip/stack/HEPSipMessageLoggingHandler.cxx
@@ -19,7 +19,7 @@ using namespace std;
 HEPSipMessageLoggingHandler::HEPSipMessageLoggingHandler(std::shared_ptr<HepAgent> agent)
    : mHepAgent(std::move(agent))
 {
-   if (!agent)
+   if (!mHepAgent)
    {
       ErrLog(<<"agent must not be NULL");
       throw std::runtime_error("agent must not be NULL");

--- a/resip/stack/SipMessage.cxx
+++ b/resip/stack/SipMessage.cxx
@@ -1729,7 +1729,7 @@ SipMessage::mergeUri(const Uri& source)
 }
 
 void 
-SipMessage::setSecurityAttributes(unique_ptr<SecurityAttributes> sec)
+SipMessage::setSecurityAttributes(std::unique_ptr<SecurityAttributes> sec) noexcept
 {
    mSecurityAttributes = std::move(sec);
 }

--- a/resip/stack/SipMessage.hxx
+++ b/resip/stack/SipMessage.hxx
@@ -559,8 +559,8 @@ class SipMessage : public TransactionMessage
       
       SipMessage& mergeUri(const Uri& source);      
 
-      void setSecurityAttributes(std::unique_ptr<SecurityAttributes>);
-      const SecurityAttributes* getSecurityAttributes() const { return mSecurityAttributes.get(); }
+      void setSecurityAttributes(std::unique_ptr<SecurityAttributes>) noexcept;
+      const SecurityAttributes* getSecurityAttributes() const noexcept { return mSecurityAttributes.get(); }
 
       /// @brief Call a MessageDecorator to process the message before it is
       /// sent to the transport

--- a/resip/stack/SipStack.hxx
+++ b/resip/stack/SipStack.hxx
@@ -307,7 +307,7 @@ class SipStack : public FdSetIOObserver
                                       outbound SIP messages for all transports added
                                       after calling this.
       */
-      void setTransportSipMessageLoggingHandler(std::shared_ptr<Transport::SipMessageLoggingHandler> handler) { mTransportSipMessageLoggingHandler = std::move(handler); }
+      void setTransportSipMessageLoggingHandler(std::shared_ptr<Transport::SipMessageLoggingHandler> handler) noexcept { mTransportSipMessageLoggingHandler = std::move(handler); }
 
       /**
          Used by the application to add in a new built-in transport.  The transport is

--- a/resip/stack/TransactionUser.cxx
+++ b/resip/stack/TransactionUser.cxx
@@ -113,7 +113,7 @@ TransactionUser::removeDomain(const Data& domain)
 }
 
 void
-TransactionUser::setDomainMatcher(std::shared_ptr<DomainMatcher> domainMatcher)
+TransactionUser::setDomainMatcher(std::shared_ptr<DomainMatcher> domainMatcher) noexcept
 {
    mDomainMatcher = std::move(domainMatcher);
 }

--- a/resip/stack/TransactionUser.hxx
+++ b/resip/stack/TransactionUser.hxx
@@ -102,7 +102,7 @@ class TransactionUser
       /**
          @brief Replaces the default DomainMatcher
       */
-      void setDomainMatcher(std::shared_ptr<DomainMatcher> domainMatcher);
+      void setDomainMatcher(std::shared_ptr<DomainMatcher> domainMatcher) noexcept;
 
       /**
          @brief Return the name of this TransactionUser. Used in encode().

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -38,7 +38,7 @@ namespace resip
 template <int S>
 struct DataLocalSize
 {
-      explicit DataLocalSize(size_t) {}
+      explicit DataLocalSize(size_t) noexcept {}
 };
 
 // .bwc. Pack class Data; has to come before doxygen block though.
@@ -1053,7 +1053,7 @@ inline bool isLessThanNoCase(const Data& left, const Data& right)
 template<class Predicate> EncodeStream& 
 Data::escapeToStream(EncodeStream& str, Predicate shouldEscape) const
 {
-   static char hex[] = "0123456789ABCDEF";
+   constexpr char hex[] = "0123456789ABCDEF";
 
    if (empty())
    {


### PR DESCRIPTION
I've also run Clang-Tidy across the code base with all bugprone checks enabled and no more occurrences of bugprone-use-after-move have been detected for what it's worth.

There are quite a few other issues that have been highlighted though. I've attached the results. It might be worth going through to see if we need to worry about any of them.
[clang-tidy-results.txt](https://github.com/resiprocate/resiprocate/files/6334727/clang-tidy-results.txt)

I've got Jenkins running these checks. I'm not sure if Travis has a nice way to display the results. But it would be possible to run any worthwhile checks, write the results to the console, and fail the build if there are any problems found. If that's something that's of interest.