### PR TITLE
dnsresult: key to lowercase letters

### DIFF
--- a/resip/stack/DnsResult.cxx
+++ b/resip/stack/DnsResult.cxx
@@ -1118,6 +1118,7 @@ void DnsResult::onDnsResult(const DNSResult<DnsSrvRecord>& result)
       {
          SRV srv;
          srv.key = (*it).name();
+         srv.key.lowercase();
          srv.priority = (*it).priority();
          srv.weight = (*it).weight();
          srv.port = (*it).port();


### PR DESCRIPTION
With some routers, the DNS query provides a mixed uppercase and lowercase answer, e.g. for _sip._tcp.tel.t-online.de you get the answer for _sIp._tcp.TeL.t-oNLinE.De
The transport key check then fails.
First and foremost, this can be observed with an IPv6 DNS implementation in the router