### PR TITLE
resip/DUM: append stale flag to authenticate header

### DIFF
--- a/resip/dum/ServerAuthManager.cxx
+++ b/resip/dum/ServerAuthManager.cxx
@@ -205,7 +205,7 @@ ServerAuthManager::handleUserAuthInfo(UserAuthInfo* userAuth)
    {
       InfoLog (<< "Nonce expired for " << userAuth->getUser());
 
-      issueChallenge(requestWithAuth);
+      issueChallenge(requestWithAuth, true);
       delete requestWithAuth;
       return 0;
    }
@@ -459,13 +459,13 @@ ServerAuthManager::issueChallengeIfRequired(SipMessage *sipMsg)
 }
 
 void
-ServerAuthManager::issueChallenge(SipMessage *sipMsg) 
+ServerAuthManager::issueChallenge(SipMessage *sipMsg, bool stale)
 {
   //assume TransactionUser has matched/repaired a realm
   std::shared_ptr<SipMessage> challenge(Helper::makeChallenge(*sipMsg,
                                                         getChallengeRealm(*sipMsg), 
                                                         useAuthInt(), 
-                                                        false /*stale*/,
+                                                        stale,
                                                         proxyAuthenticationMode()));
 
   InfoLog (<< "Sending challenge to " << sipMsg->brief());

--- a/resip/dum/ServerAuthManager.hxx
+++ b/resip/dum/ServerAuthManager.hxx
@@ -89,7 +89,7 @@ class ServerAuthManager : public DumFeature
       Result issueChallengeIfRequired(SipMessage *sipMsg);
 
       // sends a 407 challenge to the UAC who sent sipMsg
-      void issueChallenge(SipMessage *sipMsg);
+      void issueChallenge(SipMessage *sipMsg, bool stale=false);
 
       virtual void onAuthSuccess(const SipMessage& msg);
       virtual void onAuthFailure(AuthFailureReason reason, const SipMessage& msg);


### PR DESCRIPTION
If `handleUserAuthInfo()` gets message with mode == UserAuthInfo::Stale than it is supposedly should lead to generation a `WWW-Authenticate` or `Proxy-Authenticate` which is akin to:
```
WWW-Authenticate: Digest nonce="1623965236:29487d401af226a46bc5e032992eb966",algorithm=MD5,realm="realm",qop="auth,auth-int",stale=true
```
(i.e. with a flag stale=true). But currently `stale=true` is not applied.
(further reference in [3.2.1 The WWW-Authenticate Response Header](https://datatracker.ietf.org/doc/html/rfc2617#section-3.2.1) in a `stale` paragraph)

AFAIU, the proposed way to change code keeps existing behavior intact, modifying handling only for UserAuthInfo::Stale case.
