### PR TITLE
Update ReproRunner.cxx

### DIFF
--- a/repro/ReproRunner.cxx
+++ b/repro/ReproRunner.cxx
@@ -744,6 +744,7 @@ ReproRunner::createSipStack()
    {
       security->addCAFile(*caFile);
    }
+   BaseSecurity::setAllowWildcardCertificates(mProxyConfig->getConfigBool("AllowWildcardCertificates", false));
 #endif
 
 #ifdef USE_SIGCOMP


### PR DESCRIPTION
A new boolean option AllowWildcardCertificates, helps making repro work with secure Twilio trunks.