### PR TITLE
Prevent the throw in constructor

### DIFF
--- a/resip/stack/HEPSipMessageLoggingHandler.cxx
+++ b/resip/stack/HEPSipMessageLoggingHandler.cxx
@@ -19,7 +19,7 @@ using namespace std;
 HEPSipMessageLoggingHandler::HEPSipMessageLoggingHandler(std::shared_ptr<HepAgent> agent)
    : mHepAgent(std::move(agent))
 {
-   if (!agent)
+   if (!mHepAgent)
    {
       ErrLog(<<"agent must not be NULL");
       throw std::runtime_error("agent must not be NULL");

--- a/rutil/hep/HepAgent.hxx
+++ b/rutil/hep/HepAgent.hxx
@@ -26,7 +26,7 @@ class HepAgent
       HepAgent(const Data &captureHost, int capturePort, int captureAgentID);
       virtual ~HepAgent();
       template <class T>
-      void sendToHOMER(const TransportType type, const GenericIPAddress& source, const GenericIPAddress& destination, const HEPEventType eventType, const T& msg, const Data& correlationId)
+      virtual void sendToHOMER(const TransportType type, const GenericIPAddress& source, const GenericIPAddress& destination, const HEPEventType eventType, const T& msg, const Data& correlationId)
       {
          struct hep_generic *hg;
          hep_chunk_ip4_t src_ip4, dst_ip4;


### PR DESCRIPTION
Since the parameter agent is moved to the mHepAgent, the constructor always threw if determine the agent.