### PR TITLE
Fix macos byteorder

### DIFF
--- a/rutil/Crc32.cxx
+++ b/rutil/Crc32.cxx
@@ -61,6 +61,11 @@ Permission is granted to anyone to use this software for any purpose, including 
   // defines __BYTE_ORDER as __LITTLE_ENDIAN or __BIG_ENDIAN
   #include <sys/param.h>
 
+  // handle clang macos compilation
+  #if defined(__APPLE__) && !defined(__BYTE_ORDER)
+    #define __BYTE_ORDER __DARWIN_BYTE_ORDER
+  #endif
+
   // intrinsics / prefetching
   #ifdef __GNUC__
     #define PREFETCH(location) __builtin_prefetch(location)
@@ -68,11 +73,6 @@ Permission is granted to anyone to use this software for any purpose, including 
     // no prefetching
     #define PREFETCH(location) ;
   #endif
-#endif
-
-// handle clang macos compilation
-#if defined(__APPLE__)
-  #define __BYTE_ORDER __DARWIN_BYTE_ORDER
 #endif
 
 // abort if byte order is undefined

--- a/rutil/Crc32.cxx
+++ b/rutil/Crc32.cxx
@@ -70,6 +70,11 @@ Permission is granted to anyone to use this software for any purpose, including 
   #endif
 #endif
 
+// handle clang macos compilation
+#if defined(__APPLE__)
+  #define __BYTE_ORDER __DARWIN_BYTE_ORDER
+#endif
+
 // abort if byte order is undefined
 #if !defined(__BYTE_ORDER)
 #error undefined byte order, compile with -D__BYTE_ORDER=1234 (if little endian) or -D__BYTE_ORDER=4321 (big endian)


### PR DESCRIPTION
Hi!

Seems like after a boost dependency drop the BYTE_ORDER definition has gone away as well (at least for macOS). My current config -v.11.6 clang 13. Here what is looks like
```
libtool: compile:  g++ -std=gnu++11 -DHAVE_CONFIG_H -I. -I.. -D_REENTRANT -g -O2 -Wall -Wno-deprecated -I/Users/gkorovkin/projects/resiprocate/rutil/dns/ares -MT librutil_la-Crc32.lo -MD -MP -MF .deps/librutil_la-Crc32.Tpo -c Crc32.cxx  -fno-common -DPIC -o .libs/librutil_la-Crc32.o
Crc32.cxx:75:2: error: undefined byte order, compile with -D__BYTE_ORDER=1234 (if little endian) or -D__BYTE_ORDER=4321 (big endian)
#error undefined byte order, compile with -D__BYTE_ORDER=1234 (if little endian) or -D__BYTE_ORDER=4321 (big endian)
```