### PR TITLE
C++20 support on macOS

### DIFF
--- a/resip/dum/ClientInviteSession.hxx
+++ b/resip/dum/ClientInviteSession.hxx
@@ -40,7 +40,7 @@ class ClientInviteSession : public InviteSession
 
       /** Makes the specific dialog end. Will send a BYE (not a CANCEL) */
       void end(const Data& userReason) override;
-      void end(const ParserContainer<Token>& endReasons);
+      void end(const ParserContainer<Token>& endReasons) override;
       void end(EndReason reason) override;
       void end() override;
 

--- a/resip/dum/MasterProfile.hxx
+++ b/resip/dum/MasterProfile.hxx
@@ -35,7 +35,7 @@ class MasterProfile : public UserProfile
 
       /// Default is none. Do not use to enable PRACK(100rel) support. 
       virtual void addSupportedOptionTag(const Token& tag);        
-      virtual Tokens getUnsupportedOptionsTags(const Tokens& requires); // Returns list of unsupported option tags
+      virtual Tokens getUnsupportedOptionsTags(const Tokens& requiresOptionTags); // Returns list of unsupported option tags
       virtual Tokens getSupportedOptionTags() const;
       virtual void clearSupportedOptionTags() noexcept;
 

--- a/resip/stack/DialogInfoContents.hxx
+++ b/resip/stack/DialogInfoContents.hxx
@@ -107,7 +107,7 @@ public:
       };
 
       Dialog() : mDirection(MaxOrUnsetDirection), mState(Trying), mStateEvent(MaxOrUnsetDialogStateEvent), mStateCode(0), mDuration(0),
-         mHasDuration(false), mHasAppearance(false), mAppearance(0), mExclusive(false), mHasExclusive(false) {}
+         mHasDuration(false), mAppearance(0), mHasAppearance(false), mExclusive(false), mHasExclusive(false) {}
 
       // Accesors for data
       void setId(const Data& id) { mId = id; }

--- a/resip/stack/ParserContainer.hxx
+++ b/resip/stack/ParserContainer.hxx
@@ -177,10 +177,8 @@ class ParserContainer : public ParserContainerBase
             iterator operator++(int) {iterator it(mIt++,mRef); return it;}
             iterator operator--() {iterator it(--mIt,mRef); return it;}
             iterator operator--(int) {iterator it(mIt--,mRef); return it;}
-            bool operator!=(const iterator& rhs) { return mIt != rhs.mIt; }
-            bool operator==(const iterator& rhs) { return mIt == rhs.mIt; }
-            bool operator!=(const const_iterator& rhs) { return mIt != rhs.mIt; }
-            bool operator==(const const_iterator& rhs) { return mIt == rhs.mIt; }
+            friend bool operator!=(const iterator& lhs, const iterator& rhs) { return lhs.mIt != rhs.mIt; }
+            friend bool operator==(const iterator& lhs, const iterator& rhs) { return lhs.mIt == rhs.mIt; }
             iterator& operator=(const iterator& rhs) 
             {
                mIt = rhs.mIt; 
@@ -212,10 +210,8 @@ class ParserContainer : public ParserContainerBase
             const_iterator operator++(int) {const_iterator it(mIt++,mRef); return it;}
             const_iterator operator--() {const_iterator it(--mIt,mRef); return it;}
             const_iterator operator--(int) {const_iterator it(mIt--,mRef); return it;}
-            bool operator!=(const const_iterator& rhs) { return mIt != rhs.mIt; }
-            bool operator==(const const_iterator& rhs) { return mIt == rhs.mIt; }
-            bool operator!=(const iterator& rhs) { return mIt != rhs.mIt; }
-            bool operator==(const iterator& rhs) { return mIt == rhs.mIt; }
+            friend bool operator!=(const const_iterator& lhs, const const_iterator& rhs) { return lhs.mIt != rhs.mIt; }
+            friend bool operator==(const const_iterator& lhs, const const_iterator& rhs) { return lhs.mIt == rhs.mIt; }
             const_iterator& operator=(const const_iterator& rhs) 
             {
                mIt = rhs.mIt;

--- a/rutil/IntrusiveListElement.hxx
+++ b/rutil/IntrusiveListElement.hxx
@@ -111,14 +111,14 @@ class IntrusiveListElement
                return *this;
             }
 
-            bool operator==(const iterator& rhs)
+            friend bool operator==(const iterator& lhs, const iterator& rhs)
             {
-               return mPos == rhs.mPos;
+               return lhs.mPos == rhs.mPos;
             }
 
-            bool operator!=(const iterator& rhs)
+            friend bool operator!=(const iterator& lhs, const iterator& rhs)
             {
-               return mPos != rhs.mPos;
+               return lhs.mPos != rhs.mPos;
             }
 
             P operator*()
@@ -248,14 +248,14 @@ class IntrusiveListElement1
                return *this;
             }
 
-            bool operator==(const iterator& rhs)
+            friend bool operator==(const iterator& lhs, const iterator& rhs)
             {
-               return mPos == rhs.mPos;
+               return lhs.mPos == rhs.mPos;
             }
 
-            bool operator!=(const iterator& rhs)
+            friend bool operator!=(const iterator& lhs, const iterator& rhs)
             {
-               return mPos != rhs.mPos;
+               return lhs.mPos != rhs.mPos;
             }
 
             P operator*()
@@ -385,14 +385,14 @@ class IntrusiveListElement2
                return *this;
             }
 
-            bool operator==(const iterator& rhs)
+            friend bool operator==(const iterator& lhs, const iterator& rhs)
             {
-               return mPos == rhs.mPos;
+               return rhs.mPos == rhs.mPos;
             }
 
-            bool operator!=(const iterator& rhs)
+            friend bool operator!=(const iterator& lhs, const iterator& rhs)
             {
-               return mPos != rhs.mPos;
+               return rhs.mPos != rhs.mPos;
             }
 
             P operator*()
@@ -522,14 +522,14 @@ class IntrusiveListElement3
                return *this;
             }
 
-            bool operator==(const iterator& rhs)
+            friend bool operator==(const iterator& lhs, const iterator& rhs)
             {
-               return mPos == rhs.mPos;
+               return lhs.mPos == rhs.mPos;
             }
 
-            bool operator!=(const iterator& rhs)
+            friend bool operator!=(const iterator& lhs, const iterator& rhs)
             {
-               return mPos != rhs.mPos;
+               return lhs.mPos != rhs.mPos;
             }
 
             P operator*()

--- a/rutil/StlPoolAllocator.hxx
+++ b/rutil/StlPoolAllocator.hxx
@@ -83,7 +83,7 @@ class StlPoolAllocator
          return &ref;
       }
 
-      pointer allocate(size_type n, std::allocator<void>::const_pointer hint=0)
+      pointer allocate(size_type n, const void* hint=0)
       {
          return (pointer)(allocate_raw(n*sizeof(T)));
       }


### PR DESCRIPTION
This PR makes resiprocate compile with C++20 on macOS. At should be backwards compatible down to C++11.