### PR TITLE
rutil: fix thread race in DnsUtil::getLocalHostName() static initialization

### DIFF
--- a/rutil/DnsUtil.cxx
+++ b/rutil/DnsUtil.cxx
@@ -113,73 +113,73 @@ DnsUtil::lookupARecords(const Data& host)
    }
 }
 
-// The following statics ensure we can initialize the static storage of
-// localHostName at runtime, instead of at global static initialization time.
-// Under windows, when building a DLL you cannot call initNetwork and 
-// other socket API's reliably from DLLMain, so we need to delay this call.
-// We use the gate bool to ensure we don't need to do a mutex check everytime
-// and we use a Mutex to ensure that multiple threads can invokve getLocalHostName
-// for the first time, at the same time.
-static Mutex getLocalHostNameInitializerMutex;
-static bool  getLocalHostNameInitializerGate = false;
-static Data localHostName;
 const Data&
 DnsUtil::getLocalHostName()
 {
-   if(!getLocalHostNameInitializerGate)
-   {
-      Lock lock(getLocalHostNameInitializerMutex);
-      char buffer[MAXHOSTNAMELEN + 1];
-      initNetwork();
-      // can't assume the name is NUL terminated when truncation occurs,
-      // so insert trailing NUL here
-      buffer[0] = buffer[MAXHOSTNAMELEN] = '\0';
-      if (gethostname(buffer,sizeof(buffer)-1) == -1)
-      {
-         int err = getErrno();
-         switch (err)
-         {
-// !RjS! This makes no sense for non-windows. The
-//       current hack (see the #define in .hxx) needs
-//       to be reworked.
-            case WSANOTINITIALISED:
-               CritLog( << "could not find local hostname because network not initialized:" << strerror(err) );
-               break;
-            default:
-               CritLog( << "could not find local hostname:" << strerror(err) );
-               break;
-         }
-         throw Exception("could not find local hostname",__FILE__,__LINE__);
-      }
-
-      struct addrinfo* result=0;
-      struct addrinfo hints;
-      memset(&hints, 0, sizeof(hints));
-      hints.ai_flags |= AI_CANONNAME;
-      hints.ai_family |= AF_UNSPEC;
-      int res = getaddrinfo(buffer, 0, &hints, &result);
-      if (!res) 
-      {
-         // !jf! this should really use the Data class 
-         if (strchr(result->ai_canonname, '.') != 0) 
-         {
-            snprintf(buffer, sizeof(buffer), "%s", result->ai_canonname);
-         }
-         else 
-         {
-            InfoLog( << "local hostname does not contain a domain part " << buffer);
-         }
-         freeaddrinfo(result);
-      }
-      else
-      {
-         InfoLog (<< "Couldn't determine local hostname. Error was: " << gai_strerror(res) << ". Returning empty string");
-      }
-   
-      localHostName = buffer;
-      getLocalHostNameInitializerGate = true;
-   }
+   // The function-local static ensures we can initialize the static storage of
+   // localHostName at runtime, instead of at global static initialization time.
+   // Under windows, when building a DLL you cannot call initNetwork and 
+   // other socket API's reliably from DLLMain, so we need to delay this call.
+   // We rely on C++11 thread-safe initialization guarantees for local statics
+   // to ensure that the localHostName is initialized in a thread-safe
+   // manner exactly once before use, even if the initial getLocalHostName() is
+   // invoked by multiple threads. Since localHostName is immutable, the returned
+   // variable reference can be safely read by multiple threads.
+   static const Data localHostName = lookupLocalHostName();
    return localHostName;
+}
+
+Data
+DnsUtil::lookupLocalHostName()
+{
+   char buffer[MAXHOSTNAMELEN + 1];
+   initNetwork();
+   // can't assume the name is NUL terminated when truncation occurs,
+   // so insert trailing NUL here
+   buffer[0] = buffer[MAXHOSTNAMELEN] = '\0';
+   if (gethostname(buffer,sizeof(buffer)-1) == -1)
+   {
+      int err = getErrno();
+      switch (err)
+      {
+         // !RjS! This makes no sense for non-windows. The
+         //       current hack (see the #define in .hxx) needs
+         //       to be reworked.
+         case WSANOTINITIALISED:
+            CritLog( << "could not find local hostname because network not initialized:" << strerror(err) );
+            break;
+         default:
+            CritLog( << "could not find local hostname:" << strerror(err) );
+            break;
+      }
+         throw Exception("could not find local hostname",__FILE__,__LINE__);
+   }
+
+   struct addrinfo* result=0;
+   struct addrinfo hints;
+   memset(&hints, 0, sizeof(hints));
+   hints.ai_flags |= AI_CANONNAME;
+   hints.ai_family |= AF_UNSPEC;
+   int res = getaddrinfo(buffer, 0, &hints, &result);
+   if (!res) 
+   {
+      // !jf! this should really use the Data class 
+      if (strchr(result->ai_canonname, '.') != 0) 
+      {
+         snprintf(buffer, sizeof(buffer), "%s", result->ai_canonname);
+      }
+      else 
+      {
+         InfoLog( << "local hostname does not contain a domain part " << buffer);
+      }
+      freeaddrinfo(result);
+   }
+   else
+   {
+      InfoLog (<< "Couldn't determine local hostname. Error was: " << gai_strerror(res) << ". Returning empty string");
+   }
+
+   return buffer;
 }
 
 Data

--- a/rutil/DnsUtil.hxx
+++ b/rutil/DnsUtil.hxx
@@ -149,6 +149,9 @@ class DnsUtil
       /// Used to synchronously query A records - only for test code usage
       static std::list<Data> lookupARecords(const Data& host);
 
+   private:
+      /// Used to synchronously query the local hostname
+      static Data lookupLocalHostName();
 };
 
 }


### PR DESCRIPTION
The previous code used only a single gate check before acquiring the lock,
which can lead to the case where multiple threads enter the
initialization block, with subsequent threads re-allocating the buffer of
the localHostName static member, leading to use-after-free memory reads.
This was detected by ASAN.

The fix is to rely on C++11 thread safe initialization guarantees for
local statics.