### PR TITLE
Add support for dynamic timers B & C for each of the client transactions

### DIFF
--- a/repro/Proxy.cxx
+++ b/repro/Proxy.cxx
@@ -558,12 +558,16 @@ Proxy::addClientTransaction(const Data& transactionId, RequestContext* rc)
 }
 
 void
-Proxy::postTimerC(std::unique_ptr<TimerCMessage> tc)
+Proxy::postTimerC(std::unique_ptr<TimerCMessage> tc, int customDelayMs)
 {
-   if(mTimerC > 0)
+   // Convert ms to seconds
+   int delay = customDelayMs > 0 ? std::round(customDelayMs / 1000) : 0;
+   // Fall back to TimerC value from configuration if no custom delay is supplied
+   delay = delay > 0 ? delay : mTimerC;
+   if (delay > 0)
    {
-      InfoLog(<<"Posting timer C");
-      mStack.post(*tc,mTimerC,this);
+      InfoLog(<<"Posting timer C (" << delay << "sec)");
+      mStack.post(*tc, delay, this);
    }
 }
 

--- a/repro/Proxy.hxx
+++ b/repro/Proxy.hxx
@@ -89,7 +89,7 @@ class Proxy : public resip::TransactionUser, public resip::ThreadIf
       void send(const resip::SipMessage& msg);
       void addClientTransaction(const resip::Data& transactionId, RequestContext* rc);
 
-      void postTimerC(std::unique_ptr<TimerCMessage> tc);
+      void postTimerC(std::unique_ptr<TimerCMessage> tc, int customDelayMs = 0);
 
       void postMS(std::unique_ptr<resip::ApplicationMessage> msg, int msec);
 

--- a/repro/RequestContext.cxx
+++ b/repro/RequestContext.cxx
@@ -890,12 +890,12 @@ RequestContext::getDigestIdentity() const
 }
 
 void
-RequestContext::updateTimerC()
+RequestContext::updateTimerC(int customDelayMs)
 {
    InfoLog(<<"Updating timer C.");
    mTCSerial++;
    TimerCMessage* tc = new TimerCMessage(this->getTransactionId(),mTCSerial);
-   mProxy.postTimerC(std::unique_ptr<TimerCMessage>(tc));
+   mProxy.postTimerC(std::unique_ptr<TimerCMessage>(tc), customDelayMs);
 }
 
 void

--- a/repro/RequestContext.hxx
+++ b/repro/RequestContext.hxx
@@ -67,8 +67,8 @@ class RequestContext
 
       virtual void forwardAck200(const resip::SipMessage& ack);
       void postAck200Done();
-      
-      void updateTimerC();
+
+      void updateTimerC(int customDelayMs = 0);
       bool mInitialTimerCSet;
 
       void setSessionCreatedEventSent() { mSessionCreatedEventSent = true; }

--- a/repro/ResponseContext.cxx
+++ b/repro/ResponseContext.cxx
@@ -492,7 +492,7 @@ ResponseContext::beginClientTransaction(repro::Target* target)
    resip_assert(target->status() == Target::Candidate);
 
    SipMessage& orig=mRequestContext.getOriginalRequest();
-   SipMessage request(orig);
+   SipMessage request(orig, target->mSipMessageOptions);
 
    // If the target has a ;lr parameter, then perform loose routing
    if(target->uri().exists(p_lr))

--- a/repro/ResponseContext.cxx
+++ b/repro/ResponseContext.cxx
@@ -584,7 +584,7 @@ ResponseContext::beginClientTransaction(repro::Target* target)
       mRequestContext.getOriginalRequest().method()==INVITE)
    {
       mRequestContext.mInitialTimerCSet=true;
-      mRequestContext.updateTimerC();
+      mRequestContext.updateTimerC(target->mSipMessageOptions.mTxOptions.mTimerC);
    }
    
    // the rest of 16.6 is implemented by the transaction layer of resip
@@ -1109,7 +1109,8 @@ ResponseContext::processResponse(SipMessage& response)
       case 1:
          if(mRequestContext.getOriginalRequest().method() == INVITE)
          {
-            mRequestContext.updateTimerC();
+            auto currentTargetPtr = i->second;
+            mRequestContext.updateTimerC(currentTargetPtr->mSipMessageOptions.mTxOptions.mTimerC);
          }
 
          if  (!mRequestContext.mHaveSentFinalResponse)

--- a/repro/Target.cxx
+++ b/repro/Target.cxx
@@ -17,30 +17,33 @@ Target::Target()
    mKeyValueStore(*Proxy::getTargetKeyValueStoreKeyAllocator())
 {}
 
-Target::Target(const resip::Uri& uri)
+Target::Target(const resip::Uri& uri, const resip::SipMessageOptions &sipMessageOpts)
    :mPriorityMetric(0),
    mShouldAutoProcess(true),
    mStatus(Candidate),
    mKeyValueStore(*Proxy::getTargetKeyValueStoreKeyAllocator())
 {  
    mRec.mContact.uri()=uri;
+   mSipMessageOptions = sipMessageOpts;
 }
 
-Target::Target(const resip::NameAddr& target)
+Target::Target(const resip::NameAddr& target, const resip::SipMessageOptions &sipMessageOpts)
    :mPriorityMetric(0),
    mShouldAutoProcess(true),
    mStatus(Candidate),
    mKeyValueStore(*Proxy::getTargetKeyValueStoreKeyAllocator())
 {
    mRec.mContact=target;
+   mSipMessageOptions = sipMessageOpts;
 }
 
-Target::Target(const resip::ContactInstanceRecord& rec)
+Target::Target(const resip::ContactInstanceRecord& rec, const resip::SipMessageOptions &sipMessageOpts)
    :mPriorityMetric(0),
    mShouldAutoProcess(true),
    mStatus(Candidate),
    mRec(rec)
 {
+    mSipMessageOptions = sipMessageOpts;
 }
 
 Target::~Target()

--- a/repro/Target.hxx
+++ b/repro/Target.hxx
@@ -7,6 +7,7 @@
 #include "resip/stack/Uri.hxx"
 #include "resip/stack/NameAddr.hxx"
 #include "rutil/Data.hxx"
+#include "resip/stack/SipMessage.hxx"
 #include "resip/stack/Via.hxx"
 #include "resip/dum/ContactInstanceRecord.hxx"
 #include "rutil/KeyValueStore.hxx"
@@ -28,9 +29,9 @@ class Target
       } Status;
    
       Target();
-      Target(const resip::Uri& uri);
-      Target(const resip::NameAddr& target);
-      Target(const resip::ContactInstanceRecord& record);
+      Target(const resip::Uri &uri, const resip::SipMessageOptions &sipMessageOpts = {});
+      Target(const resip::NameAddr &target, const resip::SipMessageOptions &sipMessageOpts = {});
+      Target(const resip::ContactInstanceRecord &record, const resip::SipMessageOptions &sipMessageOpts = {});
 
       virtual ~Target();
       
@@ -67,6 +68,7 @@ class Target
       */
       int mPriorityMetric;
       bool mShouldAutoProcess;
+      resip::SipMessageOptions mSipMessageOptions;
       
    protected:
       Status mStatus;

--- a/resip/stack/SipMessage.hxx
+++ b/resip/stack/SipMessage.hxx
@@ -33,6 +33,16 @@ class Contents;
 class ExtensionHeader;
 class SecurityAttributes;
 
+struct TxOptions
+{
+    int mTimerB = 0;
+};
+
+struct SipMessageOptions
+{
+    TxOptions mTxOptions;
+};
+
 /**
    @ingroup resip_crit
    @ingroup message_passing_tu
@@ -163,6 +173,7 @@ class SipMessage : public TransactionMessage
       explicit SipMessage(const Tuple *receivedTransport = 0);
       /// @todo .dlb. public, allows pass by value to compile.
       SipMessage(const SipMessage& message);
+      SipMessage(const SipMessage &message, const SipMessageOptions &opts);
 
       /// @todo .dlb. sure would be nice to have overloaded return value here..
       virtual Message* clone() const;
@@ -171,6 +182,8 @@ class SipMessage : public TransactionMessage
       
       /// Returns the transaction id from the branch or if 2543, the computed hash.
       virtual const Data& getTransactionId() const;
+
+      int getTimerB() const override;
 
       /**
          @brief Calculates an MD5 hash over the Request-URI, To tag (for
@@ -736,6 +749,8 @@ class SipMessage : public TransactionMessage
       std::unique_ptr<SecurityAttributes> mSecurityAttributes;
 
       std::vector<MessageDecorator*> mOutboundDecorators;
+
+      SipMessageOptions mOpts;
 
       friend class TransportSelector;
 };

--- a/resip/stack/SipMessage.hxx
+++ b/resip/stack/SipMessage.hxx
@@ -36,6 +36,7 @@ class SecurityAttributes;
 struct TxOptions
 {
     int mTimerB = 0;
+    int mTimerC = 0;
 };
 
 struct SipMessageOptions

--- a/resip/stack/TransactionMessage.hxx
+++ b/resip/stack/TransactionMessage.hxx
@@ -4,6 +4,7 @@
 #include "rutil/ResipAssert.h"
 #include "resip/stack/Message.hxx"
 #include "rutil/HeapInstanceCounter.hxx"
+#include "rutil/Timer.hxx"
 
 namespace resip
 {
@@ -17,7 +18,10 @@ class TransactionMessage : public Message
 
       // indicates this message is associated with a Client Transaction for the
       // purpose of determining which TransactionMap to use
-      virtual bool isClientTransaction() const = 0; 
+      virtual bool isClientTransaction() const = 0;
+
+      // Allows to customise TimerB value independently for each of the client TXs.
+      virtual int getTimerB() const { return Timer::TB; }
 
       virtual Message* clone() const {resip_assert(false); return NULL;}
 };

--- a/resip/stack/TransactionState.cxx
+++ b/resip/stack/TransactionState.cxx
@@ -1228,7 +1228,7 @@ TransactionState::processClientInvite(TransactionMessage* msg)
             {
                resetNextTransmission(sip);
                saveOriginalContactAndVia(*sip);
-               mController.mTimers.add(Timer::TimerB, mId, Timer::TB );
+               mController.mTimers.add(Timer::TimerB, mId, msg->getTimerB());
                sendCurrentToWire();
             }
             else


### PR DESCRIPTION
### Rationale

I'm evaluating Repro for it's suitability to be used as a foundation for ESRP ([Emergency Service Routing Proxy](https://www.nena.org/page/Glossary)). In the world of emergency service providers, it is not uncommon for providers, as well as governmental agencies overseeing those providers to express requirements for the upper bound of the call connection time. Those requirements are typically much stricter than the Timer B/Timer C values specified in the RFC 3261 and often vary based on the destination agency and a number of other call parameters.

As such, I'm looking for ability to specify custom TimerB and TimerC values for each of the Repro targets (serially forked). This PR proposes a solution to the problem.