### PR TITLE
reTurn client: revert DNS result filtering and pass local endpoint protocol to query object

### DIFF
--- a/reTurn/AsyncTcpSocketBase.cxx
+++ b/reTurn/AsyncTcpSocketBase.cxx
@@ -48,15 +48,11 @@ AsyncTcpSocketBase::connect(const std::string& address, unsigned short port)
    // Start an asynchronous resolve to translate the address
    // into a list of endpoints.
    resip::Data service(port);
-#ifdef USE_IPV6
    asio::ip::tcp::resolver::query query(mSocket.local_endpoint().protocol(), address, service.c_str());
-#else
-   asio::ip::tcp::resolver::query query(asio::ip::tcp::v4(), address, service.c_str());   
-#endif
    mResolver.async_resolve(query,
         std::bind(&AsyncSocketBase::handleTcpResolve, shared_from_this(),
                     std::placeholders::_1,
-					std::placeholders::_2));
+                    std::placeholders::_2));
 }
 
 void 

--- a/reTurn/AsyncTcpSocketBase.cxx
+++ b/reTurn/AsyncTcpSocketBase.cxx
@@ -49,7 +49,7 @@ AsyncTcpSocketBase::connect(const std::string& address, unsigned short port)
    // into a list of endpoints.
    resip::Data service(port);
 #ifdef USE_IPV6
-   asio::ip::tcp::resolver::query query(address, service.c_str());   
+   asio::ip::tcp::resolver::query query(mSocket.local_endpoint().protocol(), address, service.c_str());
 #else
    asio::ip::tcp::resolver::query query(asio::ip::tcp::v4(), address, service.c_str());   
 #endif
@@ -65,26 +65,12 @@ AsyncTcpSocketBase::handleTcpResolve(const asio::error_code& ec,
 {
    if (!ec)
    {
-      // Find the first remote endpoint matching the local endpoint protocol.
-      const asio::ip::tcp& localProtocol = mSocket.local_endpoint().protocol();
-      while (endpoint_iterator != asio::ip::tcp::resolver::iterator())
-      {
-         const asio::ip::tcp& remoteProtocol = endpoint_iterator->endpoint().protocol();
-         if (remoteProtocol == localProtocol)
-         {
-            // Each matching endpoint will be tried until we successfully establish a
-            // connection.
-            mSocket.async_connect(endpoint_iterator->endpoint(),
-                                  std::bind(&AsyncSocketBase::handleConnect,
-                                  shared_from_this(), std::placeholders::_1,
-                                  endpoint_iterator));
-            return;
-         }
-
-         ++endpoint_iterator;
-      }
-
-      onConnectFailure(asio::error::host_not_found);
+      // Attempt a connection to the first endpoint in the list. Each endpoint
+      // will be tried until we successfully establish a connection.
+      //asio::ip::tcp::endpoint endpoint = *endpoint_iterator;
+      mSocket.async_connect(endpoint_iterator->endpoint(),
+                            std::bind(&AsyncSocketBase::handleConnect, shared_from_this(),
+                            std::placeholders::_1, endpoint_iterator));
    }
    else
    {
@@ -105,27 +91,17 @@ AsyncTcpSocketBase::handleConnect(const asio::error_code& ec,
 
       onConnectSuccess();
    }
-   else
+   else if (++endpoint_iterator != asio::ip::tcp::resolver::iterator())
    {
       // The connection failed. Try the next endpoint in the list.
-      const asio::ip::tcp& localProtocol = mSocket.local_endpoint().protocol();
-      while (endpoint_iterator != asio::ip::tcp::resolver::iterator())
-      {
-         const asio::ip::tcp& remoteProtocol = endpoint_iterator->endpoint().protocol();
-         if (remoteProtocol == localProtocol)
-         {
-            asio::error_code ec;
-            mSocket.close(ec);
-            mSocket.async_connect(endpoint_iterator->endpoint(),
-                                  std::bind(&AsyncSocketBase::handleConnect,
-                                  shared_from_this(), std::placeholders::_1,
-                                  endpoint_iterator));
-            return;
-         }
-
-         ++endpoint_iterator;
-      }
-
+      asio::error_code ec;
+      mSocket.close(ec);
+      mSocket.async_connect(endpoint_iterator->endpoint(),
+                            std::bind(&AsyncSocketBase::handleConnect, shared_from_this(),
+                            std::placeholders::_1, endpoint_iterator));
+   }
+   else
+   {
       onConnectFailure(ec);
    }
 }

--- a/reTurn/AsyncTlsSocketBase.cxx
+++ b/reTurn/AsyncTlsSocketBase.cxx
@@ -67,7 +67,7 @@ AsyncTlsSocketBase::connect(const std::string& address, unsigned short port)
    // into a list of endpoints.
    resip::Data service(port);
 #ifdef USE_IPV6
-   asio::ip::tcp::resolver::query query(address, service.c_str());   
+   asio::ip::tcp::resolver::query query(mSocket.lowest_layer().local_endpoint().protocol(), address, service.c_str());
 #else
    asio::ip::tcp::resolver::query query(asio::ip::tcp::v4(), address, service.c_str());   
 #endif
@@ -79,29 +79,16 @@ AsyncTlsSocketBase::connect(const std::string& address, unsigned short port)
 
 void 
 AsyncTlsSocketBase::handleTcpResolve(const asio::error_code& ec,
-                                  asio::ip::tcp::resolver::iterator endpoint_iterator)
+                                     asio::ip::tcp::resolver::iterator endpoint_iterator)
 {
    if (!ec)
    {
-      // Find the first remote endpoint matching the local endpoint protocol.
-      const asio::ip::tcp &localProtocol = mSocket.lowest_layer().local_endpoint().protocol();
-      while (endpoint_iterator != asio::ip::tcp::resolver::iterator())
-      {
-         const asio::ip::tcp &remoteProtocol = endpoint_iterator->endpoint().protocol();
-         if (remoteProtocol == localProtocol)
-         {
-            // Each matching endpoint will be tried until we successfully establish a
-            // connection.
-            mSocket.lowest_layer().async_connect(endpoint_iterator->endpoint(),
-                                   std::bind(&AsyncSocketBase::handleConnect, shared_from_this(),
-                                   std::placeholders::_1, endpoint_iterator));
-            return;
-         }
-
-         ++endpoint_iterator;
-      }
-
-      onConnectFailure(asio::error::host_not_found);
+      // Attempt a connection to the first endpoint in the list. Each endpoint
+      // will be tried until we successfully establish a connection.
+      //asio::ip::tcp::endpoint endpoint = *endpoint_iterator;
+      mSocket.lowest_layer().async_connect(endpoint_iterator->endpoint(),
+                            std::bind(&AsyncSocketBase::handleConnect, shared_from_this(),
+                            std::placeholders::_1, endpoint_iterator));
    }
    else
    {
@@ -120,27 +107,17 @@ AsyncTlsSocketBase::handleConnect(const asio::error_code& ec,
                               std::bind(&AsyncSocketBase::handleClientHandshake, shared_from_this(), 
                                           std::placeholders::_1, endpoint_iterator));
    }
-   else
+   else if (++endpoint_iterator != asio::ip::tcp::resolver::iterator())
    {
       // The connection failed. Try the next endpoint in the list.
-      const asio::ip::tcp &localProtocol = mSocket.lowest_layer().local_endpoint().protocol();
-      while (endpoint_iterator != asio::ip::tcp::resolver::iterator())
-      {
-         const asio::ip::tcp &remoteProtocol = endpoint_iterator->endpoint().protocol();
-         if (remoteProtocol == localProtocol)
-         {
-            asio::error_code ec;
-            mSocket.lowest_layer().close(ec);
-            mSocket.lowest_layer().async_connect(endpoint_iterator->endpoint(),
-                                   std::bind(&AsyncSocketBase::handleConnect, shared_from_this(),
-                                   std::placeholders::_1, endpoint_iterator));
-            return;
-         }
-
-         ++endpoint_iterator;
-      }
-
-
+      asio::error_code ec;
+      mSocket.lowest_layer().close(ec);
+      mSocket.lowest_layer().async_connect(endpoint_iterator->endpoint(),
+                            std::bind(&AsyncSocketBase::handleConnect, shared_from_this(),
+                            std::placeholders::_1, endpoint_iterator));
+   }
+   else
+   {
       onConnectFailure(ec);
    }
 }

--- a/reTurn/AsyncTlsSocketBase.cxx
+++ b/reTurn/AsyncTlsSocketBase.cxx
@@ -66,15 +66,11 @@ AsyncTlsSocketBase::connect(const std::string& address, unsigned short port)
    // Start an asynchronous resolve to translate the address
    // into a list of endpoints.
    resip::Data service(port);
-#ifdef USE_IPV6
    asio::ip::tcp::resolver::query query(mSocket.lowest_layer().local_endpoint().protocol(), address, service.c_str());
-#else
-   asio::ip::tcp::resolver::query query(asio::ip::tcp::v4(), address, service.c_str());   
-#endif
    mResolver.async_resolve(query,
         std::bind(&AsyncSocketBase::handleTcpResolve, shared_from_this(),
                     std::placeholders::_1,
-					std::placeholders::_2));
+                    std::placeholders::_2));
 }
 
 void 

--- a/reTurn/AsyncUdpSocketBase.cxx
+++ b/reTurn/AsyncUdpSocketBase.cxx
@@ -55,7 +55,7 @@ AsyncUdpSocketBase::connect(const std::string& address, unsigned short port)
    // into a list of endpoints.
    resip::Data service(port);
 #ifdef USE_IPV6
-   asio::ip::udp::resolver::query query(address, service.c_str());
+   asio::ip::udp::resolver::query query(mSocket.local_endpoint().protocol(), address, service.c_str());
 #else
    asio::ip::udp::resolver::query query(asio::ip::udp::v4(), address, service.c_str());   
 #endif
@@ -71,25 +71,13 @@ AsyncUdpSocketBase::handleUdpResolve(const asio::error_code& ec,
 {
    if (!ec)
    {
-      // Find the first remote endpoint matching the local endpoint protocol.
-      const asio::ip::udp& localProtocol = mSocket.local_endpoint().protocol();
-      while (endpoint_iterator != asio::ip::udp::resolver::iterator())
-      {
-         const asio::ip::udp::endpoint& ep = endpoint_iterator->endpoint();
-         const asio::ip::udp& remoteProtocol = ep.protocol();
-         if (remoteProtocol == localProtocol)
-         {
-            mConnected = true;
-            mConnectedAddress = ep.address();
-            mConnectedPort = ep.port();
-            onConnectSuccess();
-            return;
-         }
+      // Use the first endpoint in the list.
+      // Nothing to do for UDP except store the connected address/port
+      mConnected = true;
+      mConnectedAddress = endpoint_iterator->endpoint().address();
+      mConnectedPort = endpoint_iterator->endpoint().port();
 
-         ++endpoint_iterator;
-      }
-
-      onConnectFailure(asio::error::host_not_found);
+      onConnectSuccess();
    }
    else
    {

--- a/reTurn/AsyncUdpSocketBase.cxx
+++ b/reTurn/AsyncUdpSocketBase.cxx
@@ -54,15 +54,11 @@ AsyncUdpSocketBase::connect(const std::string& address, unsigned short port)
    // Start an asynchronous resolve to translate the address
    // into a list of endpoints.
    resip::Data service(port);
-#ifdef USE_IPV6
    asio::ip::udp::resolver::query query(mSocket.local_endpoint().protocol(), address, service.c_str());
-#else
-   asio::ip::udp::resolver::query query(asio::ip::udp::v4(), address, service.c_str());   
-#endif
    mResolver.async_resolve(query,
         std::bind(&AsyncSocketBase::handleUdpResolve, shared_from_this(),
                     std::placeholders::_1,
-					std::placeholders::_2));
+                    std::placeholders::_2));
 }
 
 void 

--- a/reTurn/client/TurnTcpSocket.cxx
+++ b/reTurn/client/TurnTcpSocket.cxx
@@ -34,11 +34,7 @@ TurnTcpSocket::connect(const std::string& address, unsigned short port)
    // Get a list of endpoints corresponding to the server name.
    asio::ip::tcp::resolver resolver(mIOService);
    resip::Data service(port);
-#ifdef USE_IPV6
    asio::ip::tcp::resolver::query query(mSocket.local_endpoint().protocol(), address, service.c_str());
-#else
-   asio::ip::tcp::resolver::query query(asio::ip::tcp::v4(), address, service.c_str());   
-#endif
    asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
    const asio::ip::tcp::resolver::iterator end;
 

--- a/reTurn/client/TurnTlsSocket.cxx
+++ b/reTurn/client/TurnTlsSocket.cxx
@@ -63,11 +63,7 @@ TurnTlsSocket::connect(const std::string& address, unsigned short port)
    // Get a list of endpoints corresponding to the server name.
    asio::ip::tcp::resolver resolver(mIOService);
    resip::Data service(port);
-#ifdef USE_IPV6
    asio::ip::tcp::resolver::query query(mSocket.lowest_layer().local_endpoint().protocol(), address, service.c_str());
-#else
-   asio::ip::tcp::resolver::query query(asio::ip::tcp::v4(), address, service.c_str());   
-#endif
    asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
    const asio::ip::tcp::resolver::iterator end;
 

--- a/reTurn/client/TurnTlsSocket.cxx
+++ b/reTurn/client/TurnTlsSocket.cxx
@@ -64,7 +64,7 @@ TurnTlsSocket::connect(const std::string& address, unsigned short port)
    asio::ip::tcp::resolver resolver(mIOService);
    resip::Data service(port);
 #ifdef USE_IPV6
-   asio::ip::tcp::resolver::query query(address, service.c_str());   
+   asio::ip::tcp::resolver::query query(mSocket.lowest_layer().local_endpoint().protocol(), address, service.c_str());
 #else
    asio::ip::tcp::resolver::query query(asio::ip::tcp::v4(), address, service.c_str());   
 #endif
@@ -72,42 +72,35 @@ TurnTlsSocket::connect(const std::string& address, unsigned short port)
    const asio::ip::tcp::resolver::iterator end;
 
    // Try each endpoint until we successfully establish a connection.
-   const asio::ip::tcp &localProtocol = mSocket.lowest_layer().local_endpoint().protocol();
    asio::error_code errorCode = asio::error::host_not_found;
    while (errorCode && endpoint_iterator != end)
    {
-      const asio::ip::tcp &remoteProtocol = endpoint_iterator->endpoint().protocol();
-      if(remoteProtocol == localProtocol)
+      mSocket.lowest_layer().close();
+      mSocket.lowest_layer().connect(*endpoint_iterator, errorCode);
+      if(!errorCode)
       {
-         mSocket.lowest_layer().close();
-         mSocket.lowest_layer().connect(*endpoint_iterator, errorCode);
-
+         DebugLog(<< "Connected!");
+         mSocket.handshake(asio::ssl::stream_base::client, errorCode);
          if(!errorCode)
          {
-            DebugLog(<< "Connected!");
-            mSocket.handshake(asio::ssl::stream_base::client, errorCode);
-            if(!errorCode)
-            {
-               DebugLog(<< "Handshake complete!");
+            DebugLog(<< "Handshake complete!");
 
-               // Validate that hostname in cert matches connection hostname
-               if(!mValidateServerCertificateHostname || validateServerCertificateHostname(address))
-               {
-                  mConnected = true;
-                  mConnectedTuple.setTransportType(StunTuple::TLS);
-                  mConnectedTuple.setAddress(endpoint_iterator->endpoint().address());
-                  mConnectedTuple.setPort(endpoint_iterator->endpoint().port());
-               }
-               else
-               {
-                  WarningLog(<< "Hostname in certificate does not match connection hostname!");
-                  mSocket.lowest_layer().close();
-                  errorCode = asio::error::operation_aborted;
-               }
+            // Validate that hostname in cert matches connection hostname
+            if(!mValidateServerCertificateHostname || validateServerCertificateHostname(address))
+            {
+               mConnected = true;
+               mConnectedTuple.setTransportType(StunTuple::TLS);
+               mConnectedTuple.setAddress(endpoint_iterator->endpoint().address());
+               mConnectedTuple.setPort(endpoint_iterator->endpoint().port());
+            }
+            else
+            {
+               WarningLog(<< "Hostname in certificate does not match connection hostname!");
+               mSocket.lowest_layer().close();
+               errorCode = asio::error::operation_aborted;
             }
          }
       }
-
       endpoint_iterator++;
    }
 

--- a/reTurn/client/TurnUdpSocket.cxx
+++ b/reTurn/client/TurnUdpSocket.cxx
@@ -31,11 +31,7 @@ TurnUdpSocket::connect(const std::string& address, unsigned short port)
    // Get a list of endpoints corresponding to the server name.
    asio::ip::udp::resolver resolver(mIOService);
    resip::Data service(port);
-#ifdef USE_IPV6
    asio::ip::udp::resolver::query query(mSocket.local_endpoint().protocol(), address, service.c_str());
-#else
-   asio::ip::udp::resolver::query query(asio::ip::udp::v4(), address, service.c_str());   
-#endif
    asio::ip::udp::resolver::iterator endpoint_iterator = resolver.resolve(query);
    const asio::ip::udp::resolver::iterator end;
 

--- a/reTurn/client/TurnUdpSocket.cxx
+++ b/reTurn/client/TurnUdpSocket.cxx
@@ -32,36 +32,28 @@ TurnUdpSocket::connect(const std::string& address, unsigned short port)
    asio::ip::udp::resolver resolver(mIOService);
    resip::Data service(port);
 #ifdef USE_IPV6
-   asio::ip::udp::resolver::query query(address, service.c_str());   
+   asio::ip::udp::resolver::query query(mSocket.local_endpoint().protocol(), address, service.c_str());
 #else
    asio::ip::udp::resolver::query query(asio::ip::udp::v4(), address, service.c_str());   
 #endif
    asio::ip::udp::resolver::iterator endpoint_iterator = resolver.resolve(query);
    const asio::ip::udp::resolver::iterator end;
 
-   // Find the first remote endpoint matching the local endpoint protocol.
-   const asio::ip::udp &localProtocol = mSocket.local_endpoint().protocol();
-   while (endpoint_iterator != end)
+   // Use first endpoint in list
+   if(endpoint_iterator == end)
    {
-      const asio::ip::udp::endpoint &ep = endpoint_iterator->endpoint();
-      const asio::ip::udp &remoteProtocol = ep.protocol();
-      if (remoteProtocol == localProtocol)
-      {
-         // Store the remote endpoint
-         mRemoteEndpoint = ep;
-
-         mConnected = true;
-         mConnectedTuple.setTransportType(StunTuple::UDP);
-         mConnectedTuple.setAddress(mRemoteEndpoint.address());
-         mConnectedTuple.setPort(mRemoteEndpoint.port());
-
-         return asio::error_code();
-      }
-
-      ++endpoint_iterator;
+      return asio::error::host_not_found;
    }
 
-   return asio::error::host_not_found;
+   // Nothing to do for UDP except store the remote endpoint
+   mRemoteEndpoint = endpoint_iterator->endpoint();
+
+   mConnected = true;
+   mConnectedTuple.setTransportType(StunTuple::UDP);
+   mConnectedTuple.setAddress(mRemoteEndpoint.address());
+   mConnectedTuple.setPort(mRemoteEndpoint.port());
+
+   return errorCode;
 }
 
 asio::error_code 


### PR DESCRIPTION
Revert previous changes (except for some minor clean-up) and request the right protocol when initiating the DNS resolve query.