### PR TITLE
Update FileSystem.cxx

### DIFF
--- a/rutil/FileSystem.cxx
+++ b/rutil/FileSystem.cxx
@@ -145,7 +145,8 @@ FileSystem::Directory::create() const
 #else
 
 FileSystem::Directory::iterator::iterator() :
-   mWinSearch(0)
+   mWinSearch(0),
+   mIsDirectory(false)
 {
 }
 
@@ -172,6 +173,7 @@ FileSystem::Directory::iterator::iterator(const Directory& dir)
    {
       mFile = fileData.cFileName;
       mFullFilename = mPath + '/' + mFile;
+      mIsDirectory = (fileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) > 0;
    }
 }
 
@@ -202,7 +204,7 @@ FileSystem::Directory::iterator::operator++()
    {
       mFile = fileData.cFileName;
       mFullFilename = mPath + '/' + mFile;
-      mIsDirectory = (fileData.dwFileAttributes & FILE_ATTRIBUTE_DEVICE) > 0;
+      mIsDirectory = (fileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) > 0;
    }  
    return *this;
 }


### PR DESCRIPTION
FILE_ATTRIBUTE_DIRECTORY is the correct attribute to test in order to figure out if file find returned data is director or not.
In addition, mIsDirectory must be initialized in the constructor along with the other fields.