### PR TITLE
Add support for building with OpenSSL 3.x

### DIFF
--- a/resip/stack/Helper.cxx
+++ b/resip/stack/Helper.cxx
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <memory>
 #include <utility>
+#include <vector>
+#include <new>
 
 #include "resip/stack/Auth.hxx"
 #include "resip/stack/BasicNonceHelper.hxx"
@@ -1795,7 +1797,27 @@ Helper::validateMessage(const SipMessage& message,resip::Data* reason)
 }
 
 #if defined(USE_SSL) && !defined(OPENSSL_NO_BF)
+#include <openssl/opensslv.h>
 #include <openssl/blowfish.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/evp.h>
+#include <openssl/params.h>
+#include <openssl/core_names.h>
+
+namespace {
+
+struct EVP_CIPHER_CTX_deleter
+{
+   typedef void result_type;
+
+   result_type operator() (EVP_CIPHER_CTX* p) const noexcept
+   {
+      EVP_CIPHER_CTX_free(p);
+   }
+};
+
+} // namespace
+#endif
 
 static const Data sep("[]");
 static const Data pad("\0\0\0\0\0\0\0", 7);
@@ -1818,9 +1840,6 @@ Helper::gruuUserPart(const Data& instanceId,
    ivec[6] = '\x7D';
    ivec[7] = '\x51';
 
-   BF_KEY fish;
-   BF_set_key(&fish, (int)key.size(), (const unsigned char*)key.data());
-
    const Data salt(resip::Random::getRandomHex(saltBytes));
 
    const Data token(salt + instanceId + sep + aor + '\0' +
@@ -1829,18 +1848,71 @@ Helper::gruuUserPart(const Data& instanceId,
                                          sep.size() + 1 
                                          + aor.size() ) % 8))
                                % 8));
-   unique_ptr <unsigned char> out(new unsigned char[token.size()]);
+   std::vector<unsigned char> out;
+
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+   out.resize(token.size());
+
+   BF_KEY fish;
+   BF_set_key(&fish, (int)key.size(), (const unsigned char*)key.data());
+
    BF_cbc_encrypt((const unsigned char*)token.data(),
-                  out.get(),
+                  &out[0],
                   (long)token.size(),
                   &fish,
-                  ivec, 
+                  ivec,
                   BF_ENCRYPT);
+#else
+   const EVP_CIPHER* pCipher = EVP_bf_cbc();
+   std::size_t out_size = token.size();
+   int block_size = EVP_CIPHER_get_block_size(pCipher);
+   if (block_size > 1)
+   {
+      std::size_t tail_size = out_size % block_size;
+      if (tail_size > 0)
+         out_size += block_size - tail_size;
+   }
+   out.resize(out_size);
 
-   return GRUU + Data(out.get(),token.size()).base64encode(true/*safe URL*/);
+   std::unique_ptr<EVP_CIPHER_CTX, EVP_CIPHER_CTX_deleter> pCipherCtx(EVP_CIPHER_CTX_new());
+   if (!pCipherCtx)
+      throw std::bad_alloc();
+
+   std::size_t keylen = key.size();
+   OSSL_PARAM params[2];
+   params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_KEYLEN, &keylen);
+   params[1] = OSSL_PARAM_construct_end();
+   int res = EVP_EncryptInit_ex2(pCipherCtx.get(), pCipher,
+      reinterpret_cast<const unsigned char*>(key.data()), ivec, params);
+   if (res <= 0)
+      throw std::runtime_error("Failed to initialize encryption context");
+
+   resip_assert(static_cast<unsigned int>(EVP_CIPHER_CTX_get_iv_length(pCipherCtx.get())) <= sizeof(ivec));
+
+   int outlen = static_cast<int>(out_size);
+   res = EVP_EncryptUpdate(pCipherCtx.get(), &out[0], &outlen,
+      reinterpret_cast<const unsigned char*>(token.data()), token.size());
+   if (res > 0)
+   {
+      resip_assert(static_cast<unsigned int>(outlen) <= out_size);
+      int outlen2 = static_cast<int>(out_size - outlen);
+      res = EVP_EncryptFinal_ex(pCipherCtx.get(), &out[0] + outlen, &outlen2);
+      if (res > 0)
+      {
+         outlen += outlen2;
+         resip_assert(static_cast<unsigned int>(outlen) <= out_size);
+         out.resize(static_cast<unsigned int>(outlen));
+      }
+   }
+
+   if (res <= 0)
+      throw std::runtime_error("Failed to encrypt GRUU user part");
+#endif
+
+   return GRUU + Data(&out[0], out.size()).base64encode(true/*safe URL*/);
 }
 
-std::pair<Data,Data> 
+std::pair<Data, Data>
 Helper::fromGruuUserPart(const Data& gruuUserPart,
                          const Data& key)
 {
@@ -1855,33 +1927,69 @@ Helper::fromGruuUserPart(const Data& gruuUserPart,
    ivec[6] = '\x7D';
    ivec[7] = '\x51';
 
-   static const std::pair<Data, Data> empty;
-
    if (gruuUserPart.size() < GRUU.size())
    {
-      return empty;
+      return std::pair<Data, Data>();
    }
 
    const Data gruu = gruuUserPart.substr(GRUU.size());
+   const Data decoded = gruu.base64decode();
+   std::vector<unsigned char> out(gruuUserPart.size() + 1);
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
    BF_KEY fish;
    BF_set_key(&fish, (int)key.size(), (const unsigned char*)key.data());
 
-   const Data decoded = gruu.base64decode();
-
-   unique_ptr <unsigned char> out(new unsigned char[gruuUserPart.size()+1]);
    BF_cbc_encrypt((const unsigned char*)decoded.data(),
-                  out.get(),
+                  &out[0],
                   (long)decoded.size(),
                   &fish,
-                  ivec, 
+                  ivec,
                   BF_DECRYPT);
-   const Data pair(out.get(), decoded.size());
+#else
+   std::unique_ptr<EVP_CIPHER_CTX, EVP_CIPHER_CTX_deleter> pCipherCtx(EVP_CIPHER_CTX_new());
+   if (!pCipherCtx)
+      throw std::bad_alloc();
+
+   std::size_t keylen = key.size();
+   OSSL_PARAM params[2] = {
+       OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_KEYLEN, &keylen),
+       OSSL_PARAM_construct_end()
+   };
+   int res = EVP_DecryptInit_ex2(pCipherCtx.get(), EVP_bf_cbc(),
+      reinterpret_cast<const unsigned char*>(key.data()), ivec, params);
+   if (res <= 0)
+      throw std::runtime_error("Failed to initialize decryption context");
+
+   resip_assert(static_cast<unsigned int>(EVP_CIPHER_CTX_get_iv_length(pCipherCtx.get())) <= sizeof(ivec));
+
+   const std::size_t out_size = out.size();
+   int outlen = static_cast<int>(out_size);
+   res = EVP_DecryptUpdate(pCipherCtx.get(), &out[0], &outlen,
+      reinterpret_cast<const unsigned char*>(decoded.data()), decoded.size());
+   if (res > 0)
+   {
+      resip_assert(static_cast<unsigned int>(outlen) <= out_size);
+      int outlen2 = static_cast<int>(out_size - outlen);
+      res = EVP_DecryptFinal_ex(pCipherCtx.get(), &out[0] + outlen, &outlen2);
+      if (res > 0)
+      {
+         outlen += outlen2;
+         resip_assert(static_cast<unsigned int>(outlen) <= out_size);
+         out.resize(static_cast<unsigned int>(outlen));
+      }
+   }
+
+   if (res <= 0)
+      throw std::runtime_error("Failed to decrypt GRUU user part");
+#endif
+
+   const Data pair(&out[0], out.size());
 
    Data::size_type pos = pair.find(sep);
    if (pos == Data::npos)
    {
-      return empty;
+      return std::pair<Data, Data>();
    }
 
    return std::make_pair(pair.substr(2*saltBytes, pos), // strip out the salt

--- a/resip/stack/ssl/Security.hxx
+++ b/resip/stack/ssl/Security.hxx
@@ -223,7 +223,7 @@ class BaseSecurity
        */
       SSL_CTX*       mTlsCtx;
       SSL_CTX*       mSslCtx;
-      static void dumpAsn(char*, Data);
+      static void dumpAsn(const char*, Data);
 
       CipherList mCipherList;
       Data mDefaultPrivateKeyPassPhrase;

--- a/resip/stack/ssl/TlsConnection.cxx
+++ b/resip/stack/ssl/TlsConnection.cxx
@@ -36,7 +36,11 @@ inline bool handleOpenSSLErrorQueue(int ret, unsigned long err, const char* op)
       const char* file;
       int line;
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
       unsigned long code = ERR_get_error_line(&file,&line);
+#else
+      unsigned long code = ERR_get_error_all(&file, &line, NULL, NULL, NULL);
+#endif
       if ( code == 0 )
       {
          break;

--- a/rutil/ssl/OpenSSLInit.cxx
+++ b/rutil/ssl/OpenSSLInit.cxx
@@ -75,7 +75,7 @@ OpenSSLInit::OpenSSLInit()
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
 	CRYPTO_malloc_debug_init();
 	CRYPTO_set_mem_debug_options(V_CRYPTO_MDEBUG_ALL);
-#elsif (OPENSSL_VERSION_NUMBER < 0x30000000L)
+#elif (OPENSSL_VERSION_NUMBER < 0x30000000L)
 	CRYPTO_set_mem_debug(1);
 #endif
 

--- a/rutil/ssl/SHA1Stream.cxx
+++ b/rutil/ssl/SHA1Stream.cxx
@@ -1,3 +1,8 @@
+#include <cstddef>
+#include <cstring>
+#include <new>
+#include <stdexcept>
+#include <algorithm>
 #include "rutil/ResipAssert.h"
 
 #if defined(HAVE_CONFIG_H)
@@ -10,6 +15,8 @@
 #if defined(USE_SSL)
 #include "rutil/ssl/SHA1Stream.hxx"
 
+#include "openssl/evp.h"
+
 // Remove warning about 'this' use in initiator list - pointer is only stored
 # if defined(WIN32) && !defined(__GNUC__)
 #   pragma warning( disable : 4355 ) // using this in base member initializer list 
@@ -17,13 +24,24 @@
 
 using namespace resip;
 
-SHA1Buffer::SHA1Buffer()
-        : mContext(new SHA_CTX()),
-          mBuf(SHA_DIGEST_LENGTH),
-          mBlown(false)
+inline SHA1Buffer::EVP_MD_CTX_deleter::result_type
+SHA1Buffer::EVP_MD_CTX_deleter::operator() (EVP_MD_CTX* p) const noexcept
 {
-   SHA1_Init(mContext.get());
-   setp(&mBuf[0], (&mBuf[mBuf.size()-1])+1);
+   EVP_MD_CTX_free(p);
+}
+
+SHA1Buffer::SHA1Buffer()
+        : mBlown(false)
+{
+   std::memset(mBuf, 0, sizeof(mBuf));
+   setp(mBuf, mBuf + sizeof(mBuf));
+
+   mContext.reset(EVP_MD_CTX_new());
+   if (!mContext)
+      throw std::bad_alloc();
+   int res = EVP_DigestInit_ex(mContext.get(), EVP_sha1(), NULL);
+   if (!res)
+      throw std::runtime_error("Failed to initialize SHA1 context");
 }
 
 SHA1Buffer::~SHA1Buffer()
@@ -33,12 +51,12 @@ SHA1Buffer::~SHA1Buffer()
 int
 SHA1Buffer::sync()
 {
-   size_t len = pptr() - pbase();
-   if (len > 0) 
+   std::size_t len = pptr() - pbase();
+   if (len > 0)
    {
-      SHA1_Update(mContext.get(), reinterpret_cast <unsigned const char*>(pbase()), len);
+      EVP_DigestUpdate(mContext.get(), reinterpret_cast<unsigned const char*>(pbase()), len);
       // reset the put buffer
-      setp(&mBuf[0], (&mBuf[mBuf.size()-1])+1);
+      setp(mBuf, mBuf + sizeof(mBuf));
    }
    return 0;
 }
@@ -47,7 +65,7 @@ int
 SHA1Buffer::overflow(int c)
 {
    sync();
-   if (c != -1) 
+   if (c != -1)
    {
       mBuf[0] = c;
       pbump(1);
@@ -56,25 +74,30 @@ SHA1Buffer::overflow(int c)
    return 0;
 }
 
-Data 
+Data
 SHA1Buffer::getHex()
 {
    resip_assert(mBlown == false);
-   SHA1_Final((unsigned char*)&mBuf[0], mContext.get());
+   unsigned char md_value[EVP_MAX_MD_SIZE];
+   unsigned int md_len = 0u;
+   EVP_DigestFinal_ex(mContext.get(), md_value, &md_len);
    mBlown = true;
-   Data digest(Data::Share, (const char*)&mBuf[0], mBuf.size());
-   return digest.hex();   
+   Data digest(Data::Share, reinterpret_cast<const char*>(md_value), md_len);
+   return digest.hex();
 }
 
 Data
 SHA1Buffer::getBin(unsigned int bits)
 {
    resip_assert(mBlown == false);
-   resip_assert (bits % 8 == 0);
-   resip_assert (bits / 8 <= mBuf.size());
-   SHA1_Final((unsigned char*)&mBuf[0], mContext.get());
+   resip_assert(bits % 8 == 0);
+   resip_assert(bits / 8 <= EVP_MAX_MD_SIZE);
+   unsigned char md_value[EVP_MAX_MD_SIZE];
+   unsigned int md_len = 0u;
+   EVP_DigestFinal_ex(mContext.get(), md_value, &md_len);
    mBlown = true;
-   return Data(&mBuf[20-bits/8], bits / 8);
+   unsigned int len = std::min(bits / 8u, md_len);
+   return Data(md_value + (md_len - len), len);
 }
 
 SHA1Stream::SHA1Stream()

--- a/rutil/ssl/SHA1Stream.hxx
+++ b/rutil/ssl/SHA1Stream.hxx
@@ -5,26 +5,17 @@
   #include "config.h"
 #endif
 
-#include <iostream>
 #include <memory>
-#include <vector>
+#include <iostream>
 #include "rutil/Data.hxx"
 
 // This will not be compiled or installed if USE_SSL isn't set. If you are 
 // including this file from a source tree, and you are getting link errors, you 
 // are probably trying to link against libs that were built without SSL support. 
-// Either stop trying to use this file, or re-build the libs with ssl support 
+// Either stop trying to use this file, or re-build the libs with SSL support
 // enabled.
-//#if defined (USE_SSL)
-//# include "openssl/sha.h"
-//#else
-//// !kh!
-//// so it would compile without openssl.
-//// also see my comment below.
-//typedef int SHA_CTX;
-//#endif // USE_SSL
 
-# include "openssl/sha.h"
+#include "openssl/ossl_typ.h"  // for EVP_MD_CTX
 
 namespace resip
 {
@@ -34,6 +25,14 @@ namespace resip
  */
 class SHA1Buffer : public std::streambuf
 {
+   private:
+      struct EVP_MD_CTX_deleter
+      {
+         typedef void result_type;
+
+         result_type operator() (EVP_MD_CTX* p) const noexcept;
+      };
+
    public:
       SHA1Buffer();
       virtual ~SHA1Buffer();
@@ -51,13 +50,8 @@ class SHA1Buffer : public std::streambuf
       virtual int sync();
       virtual int overflow(int c = -1);
    private:
-      // !kh!
-      // used pointers to keep the same object layout.
-      // this adds overhead, two additional new/delete.
-      // could get rid of the overhead if, sizeof(SHA_CTX) and SHA_DIGEST_LENGTH are known and FIXED.
-      // could use pimpl to get rid of one new/delete pair.
-      std::unique_ptr<SHA_CTX> mContext;
-      std::vector<char> mBuf;
+      std::unique_ptr<EVP_MD_CTX, EVP_MD_CTX_deleter> mContext;
+      char mBuf[64];
       bool mBlown;
 };
 
@@ -83,7 +77,6 @@ class SHA1Stream : private SHA1Buffer, public std::ostream
 
       /** Calls getBin(32) and converts to a UInt32 */
       uint32_t getUInt32();
-      
 };
 
 }


### PR DESCRIPTION
Removed the use of deprecated and removed APIs in OpenSSL 3.x. Also fix a few bugs in the affected code:

- Fixed incorrect delete operator being called for output buffers in `gruuUserPart` methods and use a fixed buffer in `SHA1Buffer`.
- Use SHA256 hash function in `BaseSecurity` identity functions, which matches the RSA signing hash function.
- Use constant strings when calling `Security::dumpAsn`.