### PR TITLE
ssl: require OpenSSL 1.1.1

### DIFF
--- a/reTurn/AsyncTlsSocketBase.cxx
+++ b/reTurn/AsyncTlsSocketBase.cxx
@@ -17,15 +17,6 @@
 
 #define RESIPROCATE_SUBSYSTEM ReTurnSubsystem::RETURN
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-
-inline const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x)
-{
-    return ASN1_STRING_data(const_cast< ASN1_STRING* >(x));
-}
-
-#endif // OPENSSL_VERSION_NUMBER < 0x10100000L
-
 using namespace std;
 
 namespace reTurn {

--- a/reTurn/client/TurnTlsSocket.cxx
+++ b/reTurn/client/TurnTlsSocket.cxx
@@ -15,15 +15,6 @@
 
 #define RESIPROCATE_SUBSYSTEM ReTurnSubsystem::RETURN
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-
-inline const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x)
-{
-    return ASN1_STRING_data(const_cast< ASN1_STRING* >(x));
-}
-
-#endif // OPENSSL_VERSION_NUMBER < 0x10100000L
-
 using namespace std;
 
 namespace reTurn {

--- a/reflow/dtls_wrapper/bf_dwrap.cxx
+++ b/reflow/dtls_wrapper/bf_dwrap.cxx
@@ -11,39 +11,6 @@
 #include "rutil/ResipAssert.h"
 #include <memory.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-
-static inline BIO_METHOD *BIO_meth_new(int type, const char *name)
-{
-  BIO_METHOD *biom = (BIO_METHOD*)calloc(1, sizeof(BIO_METHOD));
-
-  if (biom != NULL) {
-    biom->type = type;
-    biom->name = name;
-  }
-  return biom;
-}
-
-static void BIO_meth_free(BIO_METHOD *biom)
-{
-   free(biom);
-}
-
-#define BIO_meth_set_write(b, f) (b)->bwrite = (f)
-#define BIO_meth_set_read(b, f) (b)->bread = (f)
-#define BIO_meth_set_puts(b, f) (b)->bputs = (f)
-#define BIO_meth_set_gets(b, f) (b)->bgets = (f)
-#define BIO_meth_set_ctrl(b, f) (b)->ctrl = (f)
-#define BIO_meth_set_create(b, f) (b)->create = (f)
-#define BIO_meth_set_destroy(b, f) (b)->destroy = (f)
-#define BIO_meth_set_callback_ctrl(b, f) (b)->callback_ctrl = (f)
-
-#define BIO_set_init(b, val) (b)->init = (val)
-#define BIO_set_data(b, val) (b)->ptr = (val)
-#define BIO_get_data(b) (b)->ptr
-
-#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
-
 #define BIO_TYPE_DWRAP       (50 | 0x0400 | 0x0200)
 
 namespace {

--- a/resip/stack/DtlsMessage.hxx
+++ b/resip/stack/DtlsMessage.hxx
@@ -11,8 +11,8 @@
 
 #include <openssl/ssl.h>
 
-#if (OPENSSL_VERSION_NUMBER < 0x0090800fL )
-#error DTLS support requires OpenSSL 0.9.8 or later
+#if (OPENSSL_VERSION_NUMBER < 0x1010100fL )
+#error DTLS support requires OpenSSL 1.1.1 or later
 #endif
 
 namespace resip

--- a/resip/stack/ssl/DtlsTransport.cxx
+++ b/resip/stack/ssl/DtlsTransport.cxx
@@ -70,23 +70,6 @@
 
 #define RESIPROCATE_SUBSYSTEM Subsystem::TRANSPORT
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
-
-static void SSL_set0_rbio(SSL *s, BIO *rbio)
-{
-    BIO_free_all(s->rbio);
-    s->rbio = rbio;
-}
-
-#if !defined(LIBRESSL_VERSION_NUMBER)
-static void BIO_up_ref(BIO *a)
-{
-    CRYPTO_add(&a->references, 1, CRYPTO_LOCK_BIO);
-}
-#endif
-
-#endif
-
 using namespace std;
 using namespace resip;
 

--- a/resip/stack/ssl/TlsBaseTransport.cxx
+++ b/resip/stack/ssl/TlsBaseTransport.cxx
@@ -65,14 +65,11 @@ TlsBaseTransport::TlsBaseTransport(Fifo<TransactionMessage>& fifo,
          break;
       case SecurityTypes::TLSv1:
          DebugLog(<<"Using TLSv1_method");
-#ifndef WIN32
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-         mDomainCtx = mSecurity->createDomainCtx(TLSv1_method(), sipDomain, certificateFilename, privateKeyFilename, privateKeyPassPhrase);
-#ifndef WIN32
-#pragma GCC diagnostic pop
-#endif
+         mDomainCtx = mSecurity->createDomainCtx(TLS_method(), sipDomain, certificateFilename, privateKeyFilename, privateKeyPassPhrase);
+         if (mDomainCtx) {
+            SSL_CTX_set_min_proto_version(mDomainCtx, TLS1_VERSION);
+            SSL_CTX_set_max_proto_version(mDomainCtx, TLS1_VERSION);
+         }
          break;
       default:
          throw invalid_argument("Unrecognised SecurityTypes::SSLType value");

--- a/resip/stack/ssl/TlsConnection.cxx
+++ b/resip/stack/ssl/TlsConnection.cxx
@@ -253,11 +253,9 @@ TlsConnection::checkState()
             StackLog( << "BIO not connected, try later");
             return mTlsState;
 
-#if  ( OPENSSL_VERSION_NUMBER >= 0x0090702fL )
          case SSL_ERROR_WANT_ACCEPT:
             StackLog( << "TLS connection want accept" );
             return mTlsState;
-#endif
 
          case SSL_ERROR_WANT_X509_LOOKUP:
             DebugLog( << "Try later / SSL_ERROR_WANT_X509_LOOKUP");

--- a/resip/stack/test/testSecurity.cxx
+++ b/resip/stack/test/testSecurity.cxx
@@ -21,30 +21,6 @@ using namespace resip;
 
 #define RESIPROCATE_SUBSYSTEM Subsystem::TEST
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-
-static void *OPENSSL_zalloc(size_t num)
-{
-    void *ret = OPENSSL_malloc(num);
-
-    if (ret != NULL)
-        memset(ret, 0, num);
-    return ret;
-}
-
-static EVP_MD_CTX *EVP_MD_CTX_new(void)
-{
-    return (EVP_MD_CTX*)OPENSSL_zalloc(sizeof(EVP_MD_CTX));
-}
-
-static void EVP_MD_CTX_free(EVP_MD_CTX *ctx)
-{
-    EVP_MD_CTX_cleanup(ctx);
-    OPENSSL_free(ctx);
-}
-
-#endif
-
 // the destructor in BaseSecurity started crashing on the Mac and Windows
 // at Revision 5785. The crash can be reproduced by creating 2 security
 // objects, one after another.


### PR DESCRIPTION
Built with `-DOPENSSL_API_COMPAT=0x10101000L -DOPENSSL_NO_DEPRECATED` to enforce OpenSSL 1.1.1 APIs.