### PR TITLE
build: set targeted OpenSSL API to 1.1.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,7 @@ AM_CONDITIONAL(USE_SSL, false)
 AC_ARG_WITH(ssl, 
 [  --with-ssl              Link against OpenSSL libraries],
  [AC_DEFINE_UNQUOTED(USE_SSL, , USE_SSL)
+ AC_DEFINE([OPENSSL_API_COMPAT], [0x10101000L], [Oldest OpenSSL API to target (1.1.1)])
  AC_SUBST(LIBSSL_LIBADD, "-lssl -lcrypto")
  AM_CONDITIONAL(USE_SSL, true)],
  [ AC_SUBST(LIBSSL_LIBADD, "")])

--- a/reflow/FlowManager.cxx
+++ b/reflow/FlowManager.cxx
@@ -273,8 +273,8 @@ FlowManager::createCert(const resip::Data& pAor, int expireDays, int keyLen, X50
    resip_assert(ret);
    
    const long duration = 60*60*24*expireDays;   
-   X509_gmtime_adj(X509_get_notBefore(cert),0);
-   X509_gmtime_adj(X509_get_notAfter(cert), duration);
+   X509_gmtime_adj(X509_getm_notBefore(cert),0);
+   X509_gmtime_adj(X509_getm_notAfter(cert), duration);
    
    ret = X509_set_pubkey(cert, privkey);
    resip_assert(ret);

--- a/reflow/FlowManager.cxx
+++ b/reflow/FlowManager.cxx
@@ -21,6 +21,9 @@
 #include "Srtp2Helper.hxx"
 
 #ifdef USE_SSL  
+#include <openssl/bn.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include "FlowDtlsTimerContext.hxx"

--- a/reflow/dtls_wrapper/test/CreateCert.cxx
+++ b/reflow/dtls_wrapper/test/CreateCert.cxx
@@ -58,8 +58,8 @@ int dtls::createCert (const resip::Data& pAor, int expireDays, int keyLen, X509*
    resip_assert(ret);
    
    const long duration = 60*60*24*expireDays;   
-   X509_gmtime_adj(X509_get_notBefore(cert),0);
-   X509_gmtime_adj(X509_get_notAfter(cert), duration);
+   X509_gmtime_adj(X509_getm_notBefore(cert),0);
+   X509_gmtime_adj(X509_getm_notAfter(cert), duration);
    
    ret = X509_set_pubkey(cert, privkey);
    resip_assert(ret);


### PR DESCRIPTION
The oldest supported OpenSSL version is 1.1.1. By setting the OPENSSL_API_COMPAT variable to that version, deprecation warnings with newer OpenSSL versions will be avoided.