### PR TITLE
fix SDL compatibility

### DIFF
--- a/rutil/ParseBuffer.cxx
+++ b/rutil/ParseBuffer.cxx
@@ -683,6 +683,10 @@ ParseBuffer::integer()
       fail(__FILE__, __LINE__,msg);
    }
 
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable : 4146)
+#endif
    // The absolute value limit depending on the detected sign
    const unsigned int absoluteLimit = negative ? -(unsigned int)INT_MIN : INT_MAX;
    // maximum value for full number except last digit
@@ -705,6 +709,9 @@ ParseBuffer::integer()
         num = -num;
     }
     return num;
+#ifdef _MSC_VER
+#pragma warning( pop ) 
+#endif
 }
 
 uint8_t

--- a/rutil/WinCompat.cxx
+++ b/rutil/WinCompat.cxx
@@ -251,7 +251,9 @@ WinCompat::determineSourceInterfaceWithIPv6(const GenericIPAddress& destination)
    DWORD flags = GAA_FLAG_INCLUDE_PREFIX | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER;
    unsigned short family = destination.isVersion6() ? AF_INET6 : AF_INET;
    dwRet = (instance()->getAdaptersAddresses)(family, flags, NULL, NULL, &dwSize);
-   if (dwRet == ERROR_BUFFER_OVERFLOW)  // expected error
+   if (dwRet != ERROR_BUFFER_OVERFLOW)  // expected error
+      throw Exception("Unexpected return code", __FILE__, __LINE__);
+
    {
       // Allocate memory
       pAdapterAddresses = (IP_ADAPTER_ADDRESSES *) LocalAlloc(LMEM_ZEROINIT,dwSize);


### PR DESCRIPTION
Visual Studio compiler has special SDL option to enforce certain additional checks. 
[Read about it here](https://learn.microsoft.com/en-us/cpp/build/reference/sdl-enable-additional-security-checks?view=msvc-170)

Resiprocate code almost complies with it excluding these two issues. 
First one is a mere warning suppress.

Second is more problematic if returned error is not expected pAdapterAddresses is undefined and app will crash