### PR TITLE
Push rejection for multiple values in a single-value header into PEDANTIC_STACK mode

### DIFF
--- a/resip/stack/SipMessage.cxx
+++ b/resip/stack/SipMessage.cxx
@@ -1232,6 +1232,7 @@ SipMessage::addHeader(Headers::Type header, const char* headerName, int headerLe
       }
       else
       {
+#ifdef PEDANTIC_STACK
          if(hfvl->size()==1)
          {
             if(!mReason)
@@ -1248,7 +1249,11 @@ SipMessage::addHeader(Headers::Type header, const char* headerName, int headerLe
             (*mReason)+=Headers::getHeaderName(header);
             return;
          }
-         hfvl->push_back(start ? start : Data::Empty.data(), len, false);
+#endif
+         if (hfvl->empty())
+         {
+            hfvl->push_back(start ? start : Data::Empty.data(), len, false);
+         }
       }
 
    }

--- a/resip/stack/test/testSipMessage.cxx
+++ b/resip/stack/test/testSipMessage.cxx
@@ -616,7 +616,40 @@ main(int argc, char** argv)
        msg->header(h_ContentDisposition);
        assert( msg->header(h_ContentLength).value() == 4 );
     }
-   {
+    {
+       resipCerr << "test single header validation\n";
+
+       Data txt(
+          "UPDATE sip:bob@biloxi.com SIP/2.0\r\n"
+          "Via: SIP/2.0/UDP pc33.atlanta.com;branch=z9hG4bKnashds8\r\n"
+          "To: Bob <sip:bob@biloxi.com>;tag=73b1cb2b\r\n"
+          "From: Alice <sip:alice@atlanta.com>;tag=A76BD40B-11F7\r\n"
+          "Call-ID: a84b4c76e66710\r\n"
+          "CSeq: 51 UPDATE\r\n"
+          "Max-Forwards: 69\r\n"
+          "Contact: <sip:alice@pc33.atlanta.com>;+sip.src\r\n"
+          "Require: siprec\r\n"
+          "Content-Disposition: session;handling=required,recording-session\r\n"
+          "Content-Type: application/rs-metadata\r\n"
+          "Content-Length: 4\r\n"
+          "\r\n"
+          "test"
+       );
+
+       std::unique_ptr<SipMessage> msg(TestSupport::makeMessage(txt.c_str()));
+
+#ifdef PEDANTIC_STACK
+       assert(msg->isInvalid());
+#else
+       assert(!msg->isInvalid());
+#endif
+       assert(msg->exists(h_ContentDisposition));
+       assert(msg->header(h_ContentDisposition).value() == "session");
+       assert(msg->header(h_ContentLength).value() == 4);
+
+       resipCerr << "msg->header(h_ContentDisposition).value() == " << msg->header(h_ContentDisposition).value() << '\n';
+    }
+    {
       // exercise header remove
       const char* txt = ("INVITE sip:ext101@192.168.2.220:5064;transport=UDP SIP/2.0\r\n"
                    "Allow-Events: foo\r\n"


### PR DESCRIPTION
Came across a version of ASBCE which produces requests containing multiple Content-Disposition values.

We're unable to get the ASBCE fixed, and while this behaviour is non-conformant; it doesn't really cause a problem. In the interest of interoperability, I've pushed the validation into PEDANTIC_STACK mode and ensured that only the first value seen is used. Added a test to confirm.