### PR TITLE
Attempt to restore resip/recon/unitTests

### DIFF
--- a/apps/reConServer/MyUserAgent.cxx
+++ b/apps/reConServer/MyUserAgent.cxx
@@ -34,9 +34,11 @@ MyUserAgent::MyUserAgent(ReConServerConfig& configParse, ConversationManager* co
 }
 
 void
-MyUserAgent::onApplicationTimer(unsigned int id, unsigned int durationMs, unsigned int seq)
+MyUserAgent::onApplicationTimer(unsigned int id, std::chrono::duration<double> duration, unsigned int seq)
 {
-   InfoLog(<< "onApplicationTimeout: id=" << id << " dur=" << durationMs << " seq=" << seq);
+   InfoLog(<< "onApplicationTimeout: id=" << id
+           << " dur=" << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count()
+           << " seq=" << seq);
 }
 
 void

--- a/apps/reConServer/MyUserAgent.hxx
+++ b/apps/reConServer/MyUserAgent.hxx
@@ -24,7 +24,7 @@ class MyUserAgent : public recon::UserAgent
 {
 public:
    MyUserAgent(reconserver::ReConServerConfig& configParse, recon::ConversationManager* conversationManager, std::shared_ptr<recon::UserAgentMasterProfile> profile);
-   virtual void onApplicationTimer(unsigned int id, unsigned int durationMs, unsigned int seq);
+   void onApplicationTimer(unsigned int id, std::chrono::duration<double> duration, unsigned int seq) override;
    virtual void onSubscriptionTerminated(recon::SubscriptionHandle handle, unsigned int statusCode);
    virtual void onSubscriptionNotify(recon::SubscriptionHandle handle, const resip::Data& notifyData);
    virtual std::shared_ptr<recon::ConversationProfile> getIncomingConversationProfile(const resip::SipMessage& msg);

--- a/apps/telepathy/MyUserAgent.cxx
+++ b/apps/telepathy/MyUserAgent.cxx
@@ -50,9 +50,11 @@ tr::MyUserAgent::MyUserAgent(ConversationManager* conversationManager, std::shar
 }
 
 void
-tr::MyUserAgent::onApplicationTimer(unsigned int id, unsigned int durationMs, unsigned int seq)
+tr::MyUserAgent::onApplicationTimer(unsigned int id, std::chrono::duration<double> duration, unsigned int seq)
 {
-   InfoLog(<< "onApplicationTimeout: id=" << id << " dur=" << durationMs << " seq=" << seq);
+   InfoLog(<< "onApplicationTimeout: id=" << id
+           << " dur=" << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count()
+           << " seq=" << seq);
 }
 
 void

--- a/apps/telepathy/MyUserAgent.hxx
+++ b/apps/telepathy/MyUserAgent.hxx
@@ -38,7 +38,7 @@ class MyUserAgent : public QObject, public recon::UserAgent, public resip::Threa
    Q_OBJECT
 public:
    MyUserAgent(recon::ConversationManager* conversationManager, std::shared_ptr<recon::UserAgentMasterProfile> profile, Connection& connection, std::shared_ptr<MyInstantMessage> instantMessage);
-   virtual void onApplicationTimer(unsigned int id, unsigned int durationMs, unsigned int seq);
+   void onApplicationTimer(unsigned int id, std::chrono::duration<double> duration, unsigned int seq) override;
    virtual void onSubscriptionTerminated(recon::SubscriptionHandle handle, unsigned int statusCode);
    virtual void onSubscriptionNotify(recon::SubscriptionHandle handle, const resip::Data& notifyData);
    virtual void onSuccess(resip::ClientRegistrationHandle h, const resip::SipMessage& response);

--- a/resip/recon/MOHParkServer/Server.cxx
+++ b/resip/recon/MOHParkServer/Server.cxx
@@ -63,7 +63,7 @@ public:
       UserAgent(&server, profile, socketFunc),
       mServer(server) {}
 
-   virtual void onApplicationTimer(unsigned int id, unsigned int durationMs, unsigned int seq)
+   void onApplicationTimer(unsigned int id, std::chrono::duration<double> duration, unsigned int seq) override
    {
       if(id == MAXPARKTIMEOUT)
       {
@@ -71,7 +71,9 @@ public:
       }
       else
       {
-         InfoLog(<< "onApplicationTimeout: id=" << id << " dur=" << durationMs << " seq=" << seq);
+         InfoLog(<< "onApplicationTimeout: id=" << id
+                 << " dur=" << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count()
+                 << " seq=" << seq);
       }
       
    }

--- a/resip/recon/test/testUA.cxx
+++ b/resip/recon/test/testUA.cxx
@@ -94,9 +94,11 @@ public:
    MyUserAgent(ConversationManager* conversationManager, std::shared_ptr<UserAgentMasterProfile> profile) :
       UserAgent(conversationManager, profile) {}
     
-   virtual void onApplicationTimer(unsigned int id, std::chrono::duration<double> duration, unsigned int seq) override
+   void onApplicationTimer(unsigned int id, std::chrono::duration<double> duration, unsigned int seq) override
    {
-      InfoLog(LOG_PREFIX << "onApplicationTimeout: id=" << id << " dur=" << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count() << "ms seq=" << seq);
+      InfoLog(LOG_PREFIX << "onApplicationTimeout: id=" << id
+              << " dur=" << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count()
+              << "ms seq=" << seq);
    }
 
    virtual void onSubscriptionTerminated(SubscriptionHandle handle, unsigned int statusCode) override

--- a/resip/recon/test/unitTests.cxx
+++ b/resip/recon/test/unitTests.cxx
@@ -615,20 +615,22 @@ public:
    MyUserAgent(ConversationManager* conversationManager, std::shared_ptr<UserAgentMasterProfile> profile) :
       UserAgent(conversationManager, profile) {}
 
-   virtual void onApplicationTimer(unsigned int id, unsigned int durationMs, unsigned int seq)
+   void onApplicationTimer(unsigned int id, std::chrono::duration<double> duration, unsigned int seq) override
    {
-      //InfoLog(<< "onApplicationTimeout: id=" << id << " dur=" << durationMs << " seq=" << seq);
+      // InfoLog(<< "onApplicationTimeout: id=" << id
+      //         << " dur=" << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count()
+      //         << " seq=" << seq);
       BobConversationManager* bcm = dynamic_cast<BobConversationManager*>(getConversationManager());
       if(bcm)
       {
-         bcm->onApplicationTimer(id, durationMs, seq);
+         bcm->onApplicationTimer(id, std::chrono::duration_cast<std::chrono::milliseconds>(duration).count(), seq);
       }
       else
       {
          AliceConversationManager* acm = dynamic_cast<AliceConversationManager*>(getConversationManager());
          if(acm)
          {
-            acm->onApplicationTimer(id, durationMs, seq);
+            acm->onApplicationTimer(id, std::chrono::duration_cast<std::chrono::milliseconds>(duration).count(), seq);
          }
       }
    }

--- a/resip/stack/SipStack.cxx
+++ b/resip/stack/SipStack.cxx
@@ -329,8 +329,24 @@ SipStack::reloadCertificates()
 }
 
 void
-SipStack::addTransportSipMessageLoggingHandler(std::shared_ptr<Transport::SipMessageLoggingHandler> handler) noexcept
+SipStack::setTransportSipMessageLoggingHandler(std::shared_ptr<Transport::SipMessageLoggingHandler> handler)
 {
+   mTransportSipMessageLoggingHandlers.clear();
+
+   if (handler)
+   {
+      mTransportSipMessageLoggingHandlers.push_back(handler);
+   }
+}
+
+void
+SipStack::addTransportSipMessageLoggingHandler(std::shared_ptr<Transport::SipMessageLoggingHandler> handler)
+{
+   if (!handler)
+   {
+      return;
+   }
+
    mTransportSipMessageLoggingHandlers.push_back(handler);
    for(auto& t : mNonSecureTransports)
    {

--- a/resip/stack/SipStack.hxx
+++ b/resip/stack/SipStack.hxx
@@ -308,7 +308,7 @@ class SipStack : public FdSetIOObserver
                                       outbound SIP messages for all transports added
                                       after calling this.
       */
-      void setTransportSipMessageLoggingHandler(std::shared_ptr<Transport::SipMessageLoggingHandler> handler) noexcept { mTransportSipMessageLoggingHandlers.clear(); mTransportSipMessageLoggingHandlers.push_back(handler); }
+      void setTransportSipMessageLoggingHandler(std::shared_ptr<Transport::SipMessageLoggingHandler> handler);
 
       /**
          Used by the application to provide a handler that will get called for all
@@ -323,7 +323,7 @@ class SipStack : public FdSetIOObserver
                                       outbound SIP messages for all transports added
                                       after calling this.
       */
-      void addTransportSipMessageLoggingHandler(std::shared_ptr<Transport::SipMessageLoggingHandler> handler) noexcept;
+      void addTransportSipMessageLoggingHandler(std::shared_ptr<Transport::SipMessageLoggingHandler> handler);
 
       /**
          Used by the application to add in a new built-in transport.  The transport is

--- a/resip/stack/Transport.cxx
+++ b/resip/stack/Transport.cxx
@@ -27,6 +27,44 @@ using namespace std;
 
 #define RESIPROCATE_SUBSYSTEM Subsystem::TRANSPORT
 
+void
+Transport::setSipMessageLoggingHandler(std::shared_ptr<SipMessageLoggingHandler> handler)
+{
+   mSipMessageLoggingHandlers.clear();
+
+   if (handler)
+   {
+      mSipMessageLoggingHandlers.push_back(handler);
+   }
+}
+
+void
+Transport::addSipMessageLoggingHandler(std::shared_ptr<SipMessageLoggingHandler> handler)
+{
+   if (handler)
+   {
+      mSipMessageLoggingHandlers.push_back(handler);
+   }
+}
+
+void
+Transport::setSipMessageLoggingHandlers(const SipMessageLoggingHandlerList& handlers)
+{
+   mSipMessageLoggingHandlers = handlers;
+}
+
+void
+Transport::unsetSipMessageLoggingHandler() noexcept
+{
+   mSipMessageLoggingHandlers.clear();
+}
+
+Transport::SipMessageLoggingHandlerList
+Transport::getSipMessageLoggingHandlers() const noexcept
+{
+   return mSipMessageLoggingHandlers;
+}
+
 Transport::Exception::Exception(const Data& msg, const Data& file, const int line) :
    BaseException(msg,file,line)
 {

--- a/resip/stack/Transport.hxx
+++ b/resip/stack/Transport.hxx
@@ -89,13 +89,14 @@ class Transport : public FdSetIOObserver
           virtual void outboundRetransmit(const Tuple &source, const Tuple &destination, const SendData &data) {}
           virtual void inboundMessage(const Tuple& source, const Tuple& destination, const SipMessage &msg) = 0;
       };
-      typedef std::vector<std::shared_ptr<SipMessageLoggingHandler> > SipMessageLoggingHandlerList;
 
-      void setSipMessageLoggingHandler(std::shared_ptr<SipMessageLoggingHandler> handler) noexcept { mSipMessageLoggingHandlers.clear(); mSipMessageLoggingHandlers.push_back(handler); }
-      void addSipMessageLoggingHandler(std::shared_ptr<SipMessageLoggingHandler> handler) noexcept { mSipMessageLoggingHandlers.push_back(handler); }
-      void setSipMessageLoggingHandlers(const SipMessageLoggingHandlerList& handlers) { mSipMessageLoggingHandlers = handlers; };
-      void unsetSipMessageLoggingHandler() noexcept { mSipMessageLoggingHandlers.clear(); }
-      SipMessageLoggingHandlerList getSipMessageLoggingHandlers() const noexcept { return mSipMessageLoggingHandlers; }
+      using SipMessageLoggingHandlerList = std::vector<std::shared_ptr<SipMessageLoggingHandler> >;
+
+      void setSipMessageLoggingHandler(std::shared_ptr<SipMessageLoggingHandler> handler);
+      void addSipMessageLoggingHandler(std::shared_ptr<SipMessageLoggingHandler> handler);
+      void setSipMessageLoggingHandlers(const SipMessageLoggingHandlerList& handlers);
+      void unsetSipMessageLoggingHandler() noexcept;
+      SipMessageLoggingHandlerList getSipMessageLoggingHandlers() const noexcept;
 
       /**
          @brief General exception class for Transport.


### PR DESCRIPTION
The idea was to fix CI builds. The failed recon unit test revealed the following issues:
- Attempt to execute SIP message logging handler with shared null pointer led to crash.
I believe, the core dump explains it well:
```
0x00007f25a49c6346 in resip::TransportSelector::transmit (this=0x5624802eac50, msg=0x562480382850, target=..., sendData=0x7f2590000df8) at /home/teh/resiprocate/resip/stack/TransportSelector.cxx:1315
1315                handler->outboundMessage(source, target, *msg);
(gdb) bt
#0  0x00007f25a49c6346 in resip::TransportSelector::transmit (this=0x5624802eac50, msg=0x562480382850, target=..., sendData=0x7f2590000df8) at /home/teh/resiprocate/resip/stack/TransportSelector.cxx:1315
#1  0x00007f25a49ba020 in resip::TransactionState::sendCurrentToWire (this=0x7f2590000dc0) at /home/teh/resiprocate/resip/stack/TransactionState.cxx:2609
#2  0x00007f25a49b9b7a in resip::TransactionState::handleSync (this=0x7f2590000dc0, result=0x7f2590001690) at /home/teh/resiprocate/resip/stack/TransactionState.cxx:2490
#3  0x00007f25a49b4d7e in resip::TransactionState::processClientInvite (this=0x7f2590000dc0, msg=0x7f2590001ef0) at /home/teh/resiprocate/resip/stack/TransactionState.cxx:1538
#4  0x00007f25a49b114f in resip::TransactionState::process (controller=..., message=0x7f2590001ef0) at /home/teh/resiprocate/resip/stack/TransactionState.cxx:782
#5  0x00007f25a49a29e5 in resip::TransactionController::process (this=0x5624802ea9e0, timeout=-1) at /home/teh/resiprocate/resip/stack/TransactionController.cxx:153
#6  0x00007f25a4981521 in resip::SipStack::processTimers (this=0x7fff35be1aa8) at /home/teh/resiprocate/resip/stack/SipStack.cxx:1104
#7  0x00007f25a498e3ac in resip::EventStackThread::thread (this=0x7fff35c29b70) at /home/teh/resiprocate/resip/stack/EventStackThread.cxx:84
#8  0x00007f25a44c1501 in operator() (__closure=0x56248030f068) at /home/teh/resiprocate/rutil/ThreadIf.cxx:81
#9  0x00007f25a44c2076 in std::__invoke_impl<void, resip::ThreadIf::run()::<lambda()> >(std::__invoke_other, struct {...} &&) (__f=...) at /usr/include/c++/10/bits/invoke.h:60
#10 0x00007f25a44c202b in std::__invoke<resip::ThreadIf::run()::<lambda()> >(struct {...} &&) (__fn=...) at /usr/include/c++/10/bits/invoke.h:95
#11 0x00007f25a44c1fd8 in std::thread::_Invoker<std::tuple<resip::ThreadIf::run()::<lambda()> > >::_M_invoke<0>(std::_Index_tuple<0>) (this=0x56248030f068) at /usr/include/c++/10/thread:264
#12 0x00007f25a44c1fac in std::thread::_Invoker<std::tuple<resip::ThreadIf::run()::<lambda()> > >::operator()(void) (this=0x56248030f068) at /usr/include/c++/10/thread:271
#13 0x00007f25a44c1f90 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<resip::ThreadIf::run()::<lambda()> > > >::_M_run(void) (this=0x56248030f060) at /usr/include/c++/10/thread:215
#14 0x00007f25a3f30ed0 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#15 0x00007f25a3538ea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
#16 0x00007f25a3c2ba6f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```
- The changes in [the previous commit](https://github.com/resiprocate/resiprocate/commit/88746fd8601f2ffe5bd3cec6d1765bfbd60becab) created the issue with timeout when `MyUserAgent::onApplicationTimer()` is not executed at all due to the wrong argument type for the derived class. 
I think It is a good example to explain how the keyword `override` should work :)