### PR TITLE
resip/stack: improve p_received handling  without value

### DIFF
--- a/resip/stack/CMakeLists.txt
+++ b/resip/stack/CMakeLists.txt
@@ -101,6 +101,7 @@ set(INCLUDES
    QValue.hxx
    QValueParameter.hxx
    RAckCategory.hxx
+   ReceivedParameter.hxx
    RemoveTransport.hxx
    RequestLine.hxx
    Rlmi.hxx
@@ -276,6 +277,7 @@ add_library(resip
    PrivacyCategory.cxx
    QuotedDataParameter.cxx
    RAckCategory.cxx
+   ReceivedParameter.cxx
    Rlmi.cxx
    RportParameter.cxx
    SERNonceHelper.cxx

--- a/resip/stack/ParameterTypeEnums.hxx
+++ b/resip/stack/ParameterTypeEnums.hxx
@@ -108,7 +108,7 @@ class ParameterTypes
 
          defineParam(realm, "realm", QuotedDataParameter, "RFC ????"),
          defineParam(reason, "reason", DataParameter, "RFC ????"),
-         defineParam(received, "received", DataParameter, "RFC ????"),
+         defineParam(received, "received", ReceivedParameter, "RFC 3261"),
          defineParam(require, "require", ExistsParameter, "RFC 5373"),
          defineParam(response, "response", QuotedDataParameter, "RFC ????"),
          defineParam(retryAfter, "retry-after", UInt32Parameter, "RFC ????"),

--- a/resip/stack/ParameterTypes.cxx
+++ b/resip/stack/ParameterTypes.cxx
@@ -108,7 +108,7 @@ defineParam2(purpose, "purpose", DataParameter, GenericUri, TokenOrQuotedStringC
 defineParam3(q, "q", QValueParameter, NameAddr, Token, Mime, "RFC 3261");
 defineParam(realm, "realm", QuotedDataParameter, Auth, "RFC 2617");
 defineParam(reason, "reason", DataParameter, Token, "RFC 3265");
-defineParam(received, "received", DataParameter, Via, "RFC 3261");
+defineParam(received, "received", ReceivedParameter, Via, "RFC 3261");
 defineParam(require, "require", ExistsParameter, Token, "RFC 5373");
 defineParam(response, "response", QuotedDataParameter, Auth, "RFC 3261");
 defineParam(retryAfter, "retry-after", UInt32Parameter, Token, "RFC 3265");

--- a/resip/stack/ParameterTypes.hxx
+++ b/resip/stack/ParameterTypes.hxx
@@ -10,6 +10,7 @@
 #include "resip/stack/QValueParameter.hxx"
 #include "resip/stack/ExistsParameter.hxx"
 #include "resip/stack/ParameterTypeEnums.hxx"
+#include "resip/stack/ReceivedParameter.hxx"
 #include "resip/stack/RportParameter.hxx"
 #include "resip/stack/Symbols.hxx"
 
@@ -146,7 +147,7 @@ defineParam2(purpose, "purpose", DataParameter, GenericUri, TokenOrQuotedStringC
 defineParam3(q, "q", QValueParameter, NameAddr, Token, Mime, "RFC 3261");
 defineParam(realm, "realm", QuotedDataParameter, Auth, "RFC 2617");
 defineParam(reason, "reason", DataParameter, Token, "RFC 3265");
-defineParam(received, "received", DataParameter, Via, "RFC 3261");
+defineParam(received, "received", ReceivedParameter, Via, "RFC 3261");
 defineParam(require, "require", ExistsParameter, Token, "RFC 5373");
 defineParam(response, "response", QuotedDataParameter, Auth, "RFC 3261");
 defineParam(retryAfter, "retry-after", UInt32Parameter, Token, "RFC 3265");

--- a/resip/stack/ReceivedParameter.cxx
+++ b/resip/stack/ReceivedParameter.cxx
@@ -1,0 +1,75 @@
+#include "resip/stack/ReceivedParameter.hxx"
+#include "resip/stack/Symbols.hxx"
+#include "rutil/ParseBuffer.hxx"
+#include "rutil/Logger.hxx"
+
+using namespace resip;
+
+#define RESIPROCATE_SUBSYSTEM resip::Subsystem::SIP
+
+ReceivedParameter::ReceivedParameter(ParameterTypes::Type type,
+                                     ParseBuffer& pb,
+                                     const std::bitset<256>& terminators) :
+   DataParameter(type)
+{
+   pb.skipWhitespace();
+
+   if (!pb.eof() && *pb.position() == Symbols::EQUALS[0])
+   {
+      // Catch the exception gracefully to handle seeing ";received="
+      try
+      {
+         pb.skipChar();
+         pb.skipWhitespace();
+
+         // Handle cases such as ";received="
+         if(terminators[(unsigned char)(*pb.position())])
+         {
+            ErrLog(<< "Empty value in string-type parameter.");
+            return;
+         }
+
+         const char* pos = pb.position();
+         pb.skipToOneOf(terminators);
+         pb.data(mValue, pos);
+      }
+      catch (const BaseException& e)
+      {
+         ErrLog(<< "Caught exception: " << e);
+      }
+   }
+
+   // The value of p_received will be filled if it is not empty.
+   // Otherwise, no exceptions as the empty parameter is allowed here.
+}
+
+ReceivedParameter::ReceivedParameter(ParameterTypes::Type type) :
+   DataParameter(type)
+{
+}
+
+Parameter* ReceivedParameter::decode(ParameterTypes::Type type,
+                                     ParseBuffer& pb,
+                                     const std::bitset<256>& terminators,
+                                     PoolBase* pool)
+{
+   return new (pool) ReceivedParameter(type, pb, terminators);
+}
+
+Parameter* ReceivedParameter::clone() const
+{
+   return new ReceivedParameter(*this);
+}
+
+EncodeStream&
+ReceivedParameter::encode(EncodeStream& stream) const
+{
+   if (!mValue.empty())
+   {
+      return stream << getName() << Symbols::EQUALS << mValue;
+   }
+   else
+   {
+      return stream << getName();
+   }
+}

--- a/resip/stack/ReceivedParameter.hxx
+++ b/resip/stack/ReceivedParameter.hxx
@@ -1,0 +1,89 @@
+#if !defined(RESIP_RECEIVEDPARAMETER_HXX)
+#define RESIP_RECEIVEDPARAMETER_HXX
+
+#include "resip/stack/DataParameter.hxx"
+#include "resip/stack/ParameterTypeEnums.hxx"
+
+namespace resip
+{
+
+class ParseBuffer;
+
+/**
+   @ingroup sip_grammar
+
+   @brief Represents the "via-received" element in the RFC 3261 grammar.
+*/
+class ReceivedParameter : public DataParameter
+{
+   public:
+      using Type = Data;
+
+      ReceivedParameter(ParameterTypes::Type type,
+                        ParseBuffer& pb,
+                        const std::bitset<256>& terminators);
+      explicit ReceivedParameter(ParameterTypes::Type type);
+
+      static Parameter* decode(ParameterTypes::Type type,
+                               ParseBuffer& pb,
+                               const std::bitset<256>& terminators,
+                               PoolBase* pool);
+
+      Parameter* clone() const override;
+
+      EncodeStream& encode(EncodeStream& stream) const override;
+};
+
+}
+
+#endif   // RESIP_RECEIVEDPARAMETER_HXX
+
+/* ====================================================================
+ * The Vovida Software License, Version 1.0
+ *
+ * Copyright (c) 2000 Vovida Networks, Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The names "VOCAL", "Vovida Open Communication Application Library",
+ *    and "Vovida Open Communication Application Library (VOCAL)" must
+ *    not be used to endorse or promote products derived from this
+ *    software without prior written permission. For written
+ *    permission, please contact vocal@vovida.org.
+ *
+ * 4. Products derived from this software may not be called "VOCAL", nor
+ *    may "VOCAL" appear in their name, without prior written
+ *    permission of Vovida Networks, Inc.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE AND
+ * NON-INFRINGEMENT ARE DISCLAIMED.  IN NO EVENT SHALL VOVIDA
+ * NETWORKS, INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT DAMAGES
+ * IN EXCESS OF $1,000, NOR FOR ANY INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by Vovida
+ * Networks, Inc. and many individuals on behalf of Vovida Networks,
+ * Inc.  For more information on Vovida Networks, Inc., please see
+ * <http://www.vovida.org/>.
+ *
+ */

--- a/resip/stack/Via.cxx
+++ b/resip/stack/Via.cxx
@@ -309,7 +309,7 @@ Via::param(const _enum##_Param& paramType) const                                
 
 defineParam(branch, "branch", BranchParameter, "RFC 3261");
 defineParam(comp, "comp", DataParameter, "RFC 3486");
-defineParam(received, "received", DataParameter, "RFC 3261");
+defineParam(received, "received", ReceivedParameter, "RFC 3261");
 defineParam(rport, "rport", RportParameter, "RFC 3581");
 defineParam(ttl, "ttl", UInt32Parameter, "RFC 3261");
 defineParam(sigcompId, "sigcomp-id", QuotedDataParameter, "RFC 5049");

--- a/resip/stack/Via.hxx
+++ b/resip/stack/Via.hxx
@@ -61,7 +61,7 @@ class Via : public ParserCategory
 
 defineParam(branch, "branch", BranchParameter, "RFC 3261");
 defineParam(comp, "comp", DataParameter, "RFC 3486");
-defineParam(received, "received", DataParameter, "RFC 3261");
+defineParam(received, "received", ReceivedParameter, "RFC 3261");
 defineParam(rport, "rport", RportParameter, "RFC 3581");
 defineParam(ttl, "ttl", UInt32Parameter, "RFC 3261");
 defineParam(sigcompId, "sigcomp-id", QuotedDataParameter, "RFC 5049");

--- a/resip/stack/test/testParserCategories.cxx
+++ b/resip/stack/test/testParserCategories.cxx
@@ -2112,8 +2112,8 @@ main(int arc, char** argv)
    }
 
    {
-      TR _tr("Branch testing 1");
-      const char* viaString = "SIP/2.0/UDP ;branch=z9hG4bKwkl3lkjsdfjklsdjklfdsjlkdklj ;ttl=70";
+      TR _tr("Via testing 1");
+      const char* viaString = "SIP/2.0/UDP ;branch=z9hG4bKwkl3lkjsdfjklsdjklfdsjlkdklj;ttl=70";
       HeaderFieldValue hfv(viaString, strlen(viaString));
       Via via(hfv, Headers::UNKNOWN);
       
@@ -2124,13 +2124,12 @@ main(int arc, char** argv)
       
       via.param(p_rport);
       assert (via.exists(p_rport));      
-      assert (via.exists(p_rport));      
       assert (!via.param(p_rport).hasValue());
    }
 
    {
-      TR _tr("Branch testing 2");
-      const char* viaString = "SIP/2.0/UDP ;branch=z9hG4bKwkl3lkjsdfjklsdjklfdsjlkdklj ;ttl=70;rport";
+      TR _tr("Via testing 2 with empty parameters");
+      const char* viaString = "SIP/2.0/UDP ;branch=z9hG4bKwkl3lkjsdfjklsdjklfdsjlkdklj;ttl=70;rport;received";
       HeaderFieldValue hfv(viaString, strlen(viaString));
       Via via(hfv, Headers::UNKNOWN);
       
@@ -2139,11 +2138,28 @@ main(int arc, char** argv)
       assert (via.param(p_ttl) == 70);
       assert (via.exists(p_rport));
       assert (!via.param(p_rport).hasValue());
+      assert (via.exists(p_received));
+      assert (via.param(p_received).empty());
    }
 
    {
-      TR _tr("Branch testing 3");
-      const char* viaString = "SIP/2.0/UDP ;branch=z9hG4bKwkl3lkjsdfjklsdjklfdsjlkdklj ;ttl=70;rport=100";
+      TR _tr("Via testing 2 with non-RFC empty parameters");
+      const char* viaString = "SIP/2.0/UDP ;branch=z9hG4bKwkl3lkjsdfjklsdjklfdsjlkdklj;ttl=70;rport=;received=";
+      HeaderFieldValue hfv(viaString, strlen(viaString));
+      Via via(hfv, Headers::UNKNOWN);
+
+      assert (via.param(p_branch).hasMagicCookie());
+      assert (via.param(p_branch).getTransactionId() == "wkl3lkjsdfjklsdjklfdsjlkdklj");
+      assert (via.param(p_ttl) == 70);
+      assert (via.exists(p_rport));
+      assert (!via.param(p_rport).hasValue());
+      assert (via.exists(p_received));
+      assert (via.param(p_received).empty());
+   }
+
+   {
+      TR _tr("Via testing 3");
+      const char* viaString = "SIP/2.0/UDP ;branch=z9hG4bKwkl3lkjsdfjklsdjklfdsjlkdklj;ttl=70;rport=100;received=1.2.3.4";
       HeaderFieldValue hfv(viaString, strlen(viaString));
       Via via(hfv, Headers::UNKNOWN);
       
@@ -2153,6 +2169,8 @@ main(int arc, char** argv)
       assert (via.exists(p_rport));
       assert (via.param(p_rport).hasValue());
       assert (via.param(p_rport).port() == 100);
+      assert (via.exists(p_received));
+      assert (via.param(p_received) == "1.2.3.4");
    }
 
    {


### PR DESCRIPTION
The Via parameter "received" is very similar to "rport". Neither RFC3581 nor RFC3261 exactly describes the "received" parameter with no value, while does not reject this possibility. Some User Agents treat both parameters similarly and send an empty "received" parameter in a request.