### PR TITLE
resip/stack: fix and improve TLS transports selection

### DIFF
--- a/resip/stack/SipStack.cxx
+++ b/resip/stack/SipStack.cxx
@@ -548,8 +548,7 @@ SipStack::addTransport(std::unique_ptr<Transport> transport)
    }
    else
    {
-      tuple.setTargetDomain(transport->tlsDomain());
-      TransportSelector::TlsTransportKey tlsKey(tuple);
+      TransportSelector::TlsTransportKey tlsKey(transport->tlsDomain(), tuple);
       if(mSecureTransports.count(tlsKey) == 0)
       {
          // All is good - assign key to transport then add to mNonSecureTransports list
@@ -560,7 +559,8 @@ SipStack::addTransport(std::unique_ptr<Transport> transport)
       else
       {
          // Secure transport collision with existing transport
-         ErrLog(<< "Failed to add secure transport, transport with similar properties already exists: " << tuple);
+         ErrLog(<< "Failed to add secure transport, transport with similar properties already exists: "
+                << tuple << " (domain=" << transport->tlsDomain() << ")");
          throw Transport::Exception("Failed to add secure transport, transport with similar properties already exists.", __FILE__,__LINE__);
          return;
       }

--- a/resip/stack/TransportSelector.hxx
+++ b/resip/stack/TransportSelector.hxx
@@ -161,36 +161,18 @@ class TransportSelector
       class TlsTransportKey
       {
          public:
-            TlsTransportKey(const resip::Tuple& tuple) : mTuple(tuple) {}
-            TlsTransportKey(const resip::Data& domainName, resip::TransportType type, resip::IpVersion version) :
-               mTuple(Data::Empty, 0, version, type, domainName) {}
-            TlsTransportKey(const TlsTransportKey& orig) { mTuple = orig.mTuple; }
-            ~TlsTransportKey(){}
+            TlsTransportKey() = delete;
+            TlsTransportKey(const resip::Data& domainName, const resip::Tuple& tuple);
+            TlsTransportKey(const resip::Data& domainName, resip::TransportType type, resip::IpVersion version);
+            TlsTransportKey(const TlsTransportKey&) = default;
+            TlsTransportKey& operator=(const TlsTransportKey&) = default;
+            TlsTransportKey(TlsTransportKey&&) = default;
+            TlsTransportKey& operator=(TlsTransportKey&&) = default;
+            ~TlsTransportKey() = default;
 
-            bool operator<(const TlsTransportKey& rhs) const
-            {
-               if(mTuple.getTargetDomain() < rhs.mTuple.getTargetDomain())
-               {
-                  return true;
-               }
-               else if(mTuple.getTargetDomain() == rhs.mTuple.getTargetDomain())
-               {
-                  if(mTuple.getType() < rhs.mTuple.getType())
-                  {
-                     return true;
-                  }
-                  else if(mTuple.getType() == rhs.mTuple.getType())
-                  {
-                     return mTuple.ipVersion() < rhs.mTuple.ipVersion();
-                  }
-               }
-               return false;
-            }
+            bool operator<(const TlsTransportKey& rhs) const;
 
             resip::Tuple mTuple;
-
-         private:
-            TlsTransportKey();
       };
 
    protected:  // for unit tests (testTransportSelector)

--- a/resip/stack/TransportSelector.hxx
+++ b/resip/stack/TransportSelector.hxx
@@ -163,14 +163,20 @@ class TransportSelector
          public:
             TlsTransportKey() = delete;
             TlsTransportKey(const resip::Data& domainName, const resip::Tuple& tuple);
-            TlsTransportKey(const resip::Data& domainName, resip::TransportType type, resip::IpVersion version);
             TlsTransportKey(const TlsTransportKey&) = default;
             TlsTransportKey& operator=(const TlsTransportKey&) = default;
             TlsTransportKey(TlsTransportKey&&) = default;
             TlsTransportKey& operator=(TlsTransportKey&&) = default;
             ~TlsTransportKey() = default;
 
+            // Comparison operators which follow strict rules.
             bool operator<(const TlsTransportKey& rhs) const;
+            bool strictEq(const TlsTransportKey& rhs) const;
+            bool strictEqWithoutDomain(const resip::Tuple& tuple) const;
+
+            // Comparison operators which follow relaxed rules.
+            bool relaxEq(const TlsTransportKey& rhs) const;
+            bool relaxEqWithoutDomain(const resip::Tuple& tuple) const;
 
             resip::Tuple mTuple;
       };
@@ -184,7 +190,7 @@ class TransportSelector
       Connection* findConnection(const Tuple& dest) const;
       Transport* findLoopbackTransportBySource(bool ignorePort, Tuple& src) const;
       Transport* findTransportByVia(SipMessage* msg, const Tuple& dest, Tuple& src) const;
-      Transport* findTlsTransport(const Data& domain,TransportType type,IpVersion ipv) const;
+      Transport* findTlsTransport(const Data& domain, const Tuple& search) const;
       Tuple determineSourceInterface(SipMessage* msg, const Tuple& dest) const;
       void rebuildAnyPortTransportMaps(void);
 


### PR DESCRIPTION
The current pull request includes two changes:
- fix TLS transports lookup if only IP addresses are used. All TLS related transports independently of domain name availability are added to `TransportSelector::mTlsTransports`. In accordance, any TLS transport lookup must be done there as well.
- improve TLS transports searching if a domain name is used for TLS transport whether the same IP address with different ports, such as service listen to different ports, or different IP addresses in case the wildcard domain is used. It takes effect for TLS transports with IP addresses only as well.

For example,
- `TLS:192.168.1.1:5060:sip.example.com, TLS:192.168.1.1:5080:sip.example.com`
- `TLS:192.168.1.1:5060:*.example.com, TLS:192.168.1.2:5060:*.example.com`
- `TLS:192.168.1.1:5060, TLS:192.168.1.1:5080, TLS:192.168.1.2:5060`
