### PR TITLE
repro: restore the behavior of ResponseContext when 503 is received to follow RFC 3261

### DIFF
--- a/repro/RequestContext.hxx
+++ b/repro/RequestContext.hxx
@@ -1,6 +1,7 @@
 #if !defined(RESIP_REQUEST_CONTEXT_HXX)
 #define RESIP_REQUEST_CONTEXT_HXX 
 
+#include <memory>
 #include <vector>
 #include <iosfwd>
 #include "resip/stack/Uri.hxx"
@@ -100,7 +101,7 @@ class RequestContext
       resip::NameAddr mTopRoute;
       bool mTopRouteFlowTupleSet;       // Provided so caller can avoid needing to compare mTopRouteFlowTuple to and empty Tuple() to check if set or not
       resip::Tuple mTopRouteFlowTuple;  // extracted from mTopRoute if valid Flow-Token is present
-      ResponseContext mResponseContext;
+      std::unique_ptr<ResponseContext> mResponseContext;
       bool mSessionCreatedEventSent;
       bool mSessionEstablishedEventSent;
       resip::KeyValueStore mKeyValueStore;

--- a/repro/ResponseContext.cxx
+++ b/repro/ResponseContext.cxx
@@ -1533,8 +1533,8 @@ ResponseContext::forwardBestResponse()
    
    if(mBestResponse.header(h_StatusLine).statusCode() == 503)
    {
-      //See RFC 3261 sec 16.7, page 110, paragraph 2
-      mBestResponse.header(h_StatusLine).statusCode() = 480;
+      // See RFC 3261 sec 16.7, page 111, paragraph 2
+      mBestResponse.header(h_StatusLine).statusCode() = 500;
    }
 
    if(mBestResponse.header(h_StatusLine).statusCode() == 408 &&

--- a/repro/ResponseContext.hxx
+++ b/repro/ResponseContext.hxx
@@ -35,7 +35,7 @@ class ResponseContext
             bool operator()(const resip::SipMessage& lhs, const resip::SipMessage& rhs) const;
       };      
       
-      ~ResponseContext();
+      virtual ~ResponseContext();
 
       /**
          Adds this Target as a SimpleTarget to the collection of Targets.
@@ -228,7 +228,7 @@ class ResponseContext
       std::list<std::list<resip::Data> > mTransactionQueueCollection;
       resip::Data mCurrentResponseTid;
 
-   private:
+   protected:
       // only constructed by RequestContext
       ResponseContext(RequestContext& parent);
 
@@ -285,7 +285,7 @@ class ResponseContext
       static const int TimerCSerialInit = 0;
       std::unordered_map<resip::Data, int> mTimerCSerial; // Keeping track of the latest TimerC for each of the client TXs
 
-      void forwardBestResponse();
+      virtual void forwardBestResponse();
 
       friend class RequestContext;
       friend EncodeStream& operator<<(EncodeStream& strm, const repro::ResponseContext& rc);


### PR DESCRIPTION
[Commit 6cf081f](https://github.com/resiprocate/resiprocate/commit/6cf081f9cbcfbfdb2597b18f81c267b79f9859bb) changed the mentioned logic in ResponseContext a long time ago.

The current patch restores the behaviour to respond with a 500 code when a 503 is received, following [RFC 3261](https://datatracker.ietf.org/doc/html/rfc3261#page-111).
In addition, the possibility to implement your custom logic for `repro::ResponseContext::forwardBestResponse()` by the derived class has been added.

The flow to add the custom logic is the following:
* `repro::Proxy::setRequestContextFactory(CustomRequestContextFactory)`
* `CustomRequestContextFactory::createRequestContext() -> CustomRequestContext`
* `CustomRequestContext().mResponseContext.reset(new CustomResponseContext(*this))`
* `CustomResponseContext::forwardBestResponse()` implements your logic