### PR TITLE
resip/stack: improve duplicate parameters handling in ParserCategory

### DIFF
--- a/resip/stack/Auth.cxx
+++ b/resip/stack/Auth.cxx
@@ -127,14 +127,22 @@ Auth::parseAuthParameters(ParseBuffer& pb)
          Parameter* p=createParam(type, pb, terminators, getPool());
          if (!p)
          {
-            mUnknownParameters.push_back(new UnknownParameter(keyStart, 
-                                                              int((keyEnd - keyStart)), pb, 
-                                                              terminators));
+            UnknownParameter* unknownParam = new UnknownParameter(keyStart,
+                                                                  int((keyEnd - keyStart)),
+                                                                  pb,
+                                                                  terminators);
+
+            if(!addParameter(unknownParam))
+            {
+               freeParameter(unknownParam);
+            }
          }
          else
          {
-            // invoke the particular factory
-            mParameters.push_back(p);
+            if(!addParameter(p))
+            {
+               freeParameter(p);
+            }
          }
       }
       else

--- a/resip/stack/ParserCategory.hxx
+++ b/resip/stack/ParserCategory.hxx
@@ -266,6 +266,22 @@ class ParserCategory : public LazyParser
    protected:
       ParserCategory(PoolBase* pool=0);
 
+      /**
+         @internal
+         @brief Adds a recognised parameter to the internal ParameterList.
+         @param param The parameter to add.
+         @note Skips duplicate parameters.
+      */
+      bool addParameter(Parameter* param);
+
+      /**
+         @internal
+         @brief Adds an unrecognised parameter to the internal ParameterList.
+         @param unknownParam The parameter to add.
+         @note Skips duplicate parameters.
+      */
+      bool addParameter(UnknownParameter* unknownParam);
+
       Parameter* getParameterByData(const Data& data) const;
       void removeParameterByData(const Data& data);
       inline PoolBase* getPool()


### PR DESCRIPTION
RFC 3261 prohibits any given parameter-name to appear more than once in URIs and header field values. Skip duplicate parameter-names during the parsing procedure.