### PR TITLE
Allow ACK to be handled in the SentReInvite state

### DIFF
--- a/resip/dum/InviteSession.cxx
+++ b/resip/dum/InviteSession.cxx
@@ -1729,6 +1729,11 @@ InviteSession::dispatchSentReinvite(const SipMessage& msg)
          handler->onOfferRejected(getSessionHandle(), &msg);
          break;
 
+      case OnAck:
+      case OnAckAnswer:
+         mCurrentRetransmit200 = 0; //stop the 200 retransmit timer
+      break;
+
       default:
          dispatchOthers(msg);
          break;

--- a/resip/dum/InviteSession.cxx
+++ b/resip/dum/InviteSession.cxx
@@ -2148,6 +2148,7 @@ InviteSession::dispatchOthers(const SipMessage& msg)
 {
    // handle OnGeneralFailure
    // handle OnRedirect
+   InviteSessionHandler* handler = mDum.mInviteSessionHandler;
 
    switch (msg.header(h_CSeq).method())
    {
@@ -2184,6 +2185,7 @@ InviteSession::dispatchOthers(const SipMessage& msg)
          else
          {
             mCurrentRetransmit200 = 0; // stop the 200 retransmit timer
+            handler->onAckReceived(getSessionHandle(), msg);
          }
          break;
       default:

--- a/resip/dum/InviteSession.cxx
+++ b/resip/dum/InviteSession.cxx
@@ -2148,7 +2148,6 @@ InviteSession::dispatchOthers(const SipMessage& msg)
 {
    // handle OnGeneralFailure
    // handle OnRedirect
-   InviteSessionHandler* handler = mDum.mInviteSessionHandler;
 
    switch (msg.header(h_CSeq).method())
    {
@@ -2185,7 +2184,6 @@ InviteSession::dispatchOthers(const SipMessage& msg)
          else
          {
             mCurrentRetransmit200 = 0; // stop the 200 retransmit timer
-            handler->onAckReceived(getSessionHandle(), msg);
          }
          break;
       default:


### PR DESCRIPTION
We found a problem interworking with an Oracle SBC.

We had received an INVITE and responded with the 200OK (a=inactive) indicating we are not ready for audio. 
But before receiving the the ACK, we had sent a Re-INVITE (a=recvonly) to request the audio.

This Re-INVITE moved the session into the 'SentReInvite' state.
So the ACK arrives into InviteSession::dispatchSentReinvite, where there was no case to handle it.
This resulted in the 200OK re-transmit timer not being cancelled.

This change adds a case to handle the ACK and cancel the 200OK re-transmit timer, when in the 'SentReInvite' state