### PR TITLE
Allow defining custom status codes and messages for authentication errors

### DIFF
--- a/resip/dum/ServerAuthManager.cxx
+++ b/resip/dum/ServerAuthManager.cxx
@@ -148,7 +148,18 @@ ServerAuthManager::handleUserAuthInfo(UserAuthInfo* userAuth)
    {
       InfoLog (<< "Error in auth procedure for " << userAuth->getUser() << " in " << userAuth->getRealm());
       auto response = std::make_shared<SipMessage>();
-      Helper::makeResponse(*response, *requestWithAuth, 503, "Server Error.");
+
+      int32_t code = 0;
+      resip::Data statusText;
+
+#if RESIP_CPP_STANDARD >= 201703L
+      std::tie(code, statusText) = userAuth->getErrorInfo();
+#else
+      userAuth->getErrorInfo(code, statusText);
+#endif
+
+      Helper::makeResponse(*response, *requestWithAuth, code, statusText);
+
       mDum.send(response);
       onAuthFailure(Error, *requestWithAuth);
       delete requestWithAuth;

--- a/resip/dum/UserAuthInfo.hxx
+++ b/resip/dum/UserAuthInfo.hxx
@@ -2,6 +2,7 @@
 #define RESIP_USER_AUTH_INFO_HXX 
 
 #include "rutil/Data.hxx"
+#include "rutil/compat.hxx"
 #include "resip/dum/DumFeatureMessage.hxx"
 
 namespace resip
@@ -44,7 +45,13 @@ class UserAuthInfo : public resip::DumFeatureMessage
       const resip::Data& getRealm() const;
       const resip::Data& getUser() const;
 
-      void setMode(InfoMode mode);
+#if RESIP_CPP_STANDARD >= 201703L
+      const std::tuple<int32_t, resip::Data> getErrorInfo() const;
+#else
+      const void getErrorInfo(int32_t & errorCode, resip::Data & errorStatusText) const;
+#endif
+
+      void setMode(InfoMode mode, int32_t errorCode = 0, const resip::Data & statusText = resip::Data::Empty);
       void setA1(const resip::Data& a1);
 
       virtual resip::Message* clone() const;
@@ -57,6 +64,8 @@ class UserAuthInfo : public resip::DumFeatureMessage
       resip::Data mUser;
       resip::Data mRealm;
       resip::Data mA1;
+      int32_t mErrorCode;
+      resip::Data mErrorStatusText;
 };
 
 EncodeStream& 

--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -352,6 +352,16 @@ Data::Data(const string& str)
    initFromString(str.c_str(), (Data::size_type)str.size());
 }
 
+#if RESIP_CPP_STANDARD >= 201703L
+/**
+  Creates a data with the contents of the string_view.
+*/
+ Data::Data(const std::string_view sv)
+{
+   initFromString(sv.data(), (Data::size_type)sv.size());
+}
+#endif
+
 Data::Data(const Data& data) 
 {
    initFromString(data.mBuf, data.mSize);
@@ -1050,6 +1060,18 @@ Data::c_str() const
    mBuf[mSize] = 0;
    return mBuf;
 }
+
+std::string Data::toString()
+{
+   return std::string(c_str(), size());
+}
+
+#if RESIP_CPP_STANDARD >= 201703L
+std::string_view Data::toStringView()
+{
+   return std::string_view(c_str(), size());
+}
+#endif
 
 void
 Data::own() const
@@ -1816,8 +1838,8 @@ decimals:
 }
 #endif
 
-bool
-Data::prefix(const Data& pre) const
+const bool
+Data::prefix(const Data& pre) const noexcept
 {
    if (pre.size() > size())
    {
@@ -1827,8 +1849,9 @@ Data::prefix(const Data& pre) const
    return memcmp(data(), pre.data(), pre.size()) == 0;
 }
 
-bool
-Data::postfix(const Data& post) const
+
+const bool
+Data::postfix(const Data& post) const noexcept
 {
    if (post.size() > size())
    {

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -8,6 +8,9 @@
 #include <iostream>
 #include <string>
 #include <bitset>
+#if RESIP_CPP_STANDARD >= 201703L
+#include <string_view>
+#endif
 #include "rutil/ResipAssert.h"
 
 #include "rutil/compat.hxx"
@@ -180,6 +183,13 @@ class Data
         Creates a data with the contents of the string.
       */
       explicit Data(const std::string& str);
+
+#if RESIP_CPP_STANDARD >= 201703L
+      /**
+        Creates a data with the contents of the string_view.
+      */
+      explicit Data(const std::string_view sv);
+#endif
 
       /**
         Converts the passed in value into ascii-decimal
@@ -585,6 +595,18 @@ class Data
       const char* c_str() const;
 
       /**
+        Convert to a C++ string.
+      */
+      std::string toString();
+
+#if RESIP_CPP_STANDARD >= 201703L
+      /**
+        Creates a c++ string_view.
+      */
+      std::string_view toStringView();
+#endif
+
+      /**
         Returns a pointer to the beginning of the buffer used by the Data.
       */
       const char* begin() const noexcept
@@ -787,7 +809,7 @@ class Data
         prefix(Data("ab")) would be true; however, prefix(Data("abcd"))
         would be false.
       */
-      bool prefix(const Data& pre) const;
+      const bool prefix(const Data& pre) const noexcept;
 
       /**
         Returns true if this Data ends with the bytes indicated by
@@ -795,7 +817,7 @@ class Data
         postfix(Data("bc")) would be true; however, postfix(Data("ab"))
         would be false.
       */
-      bool postfix(const Data& post) const;
+      const bool postfix(const Data& post) const noexcept;
 
       /**
         Copies a portion of this Data into a new Data.
@@ -803,7 +825,7 @@ class Data
         @param first Index of the first byte to copy
         @param count Number of bytes to copy
       */
-      Data substr(size_type first, size_type count = Data::npos) const;
+      Data substr(size_type first, size_type count = Data::npos) const; 
 
       /**
         Finds a specified sequence of bytes in this Data.
@@ -1125,6 +1147,35 @@ bool operator==(const Data& lhs, const char* rhs);
 bool operator<(const Data& lhs, const Data& rhs);
 bool operator<(const Data& lhs, const char* rhs);
 bool operator<(const char* lhs, const Data& rhs);
+
+
+// Overload operator== for resip::Data and std::string
+bool operator==(const resip::Data& lhs, const std::string& rhs)
+{
+   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.c_str(), lhs.size()) == 0;
+}
+
+#if RESIP_CPP_STANDARD >= 201703L
+
+// Overload operator== for resip::Data and std::string_view
+bool operator==(const resip::Data& lhs, const std::string_view rhs)
+{
+   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.data(), lhs.size()) == 0;
+}
+
+// Overload operator!= for resip::Data and std::string
+bool operator!=(const resip::Data& lhs, const std::string& rhs)
+{
+   return !(lhs == rhs);
+}
+
+// Overload operator!= for resip::Data and std::string_view
+bool operator!=(const resip::Data& lhs, const std::string_view rhs)
+{
+   return !(lhs == rhs);
+}
+
+#endif
 
 }
 

--- a/rutil/compat.hxx
+++ b/rutil/compat.hxx
@@ -323,6 +323,27 @@ hton64(const uint64_t input)
 #define _CVTBUFSIZE 309+40
 #endif
 
+// Detect the compiler and define the C++ standard version macro
+
+#if defined(_MSC_VER)
+    // For Visual Studio
+
+    // Ensure _MSVC_LANG is defined
+#ifndef _MSVC_LANG
+#define _MSVC_LANG 0
+#endif
+
+// Use _MSVC_LANG to detect the C++ standard version
+#define RESIP_CPP_STANDARD _MSVC_LANG
+
+#else
+    // For GCC or Clang
+
+    // Use __cplusplus to detect the C++ standard version
+#define RESIP_CPP_STANDARD __cplusplus
+
+#endif
+
 #endif
 
 /* ====================================================================


### PR DESCRIPTION
SHA-1: f8763d1d27ae2683d5132ca4660be593c8f956f1

* - Enhanced the setMode method in the userAuthInfo class by adding errorCode and errorStatusText for more granular error handling.
- Introduced the getErrorInfo method in the userAuthInfo class to retrieve specific error details.

These modifications allow defining custom status codes and messages for authentication errors.
