### PR TITLE
Enhance the resip::Data feature.

### DIFF
--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -352,6 +352,16 @@ Data::Data(const string& str)
    initFromString(str.c_str(), (Data::size_type)str.size());
 }
 
+#if RESIP_CPP_STANDARD >= 201703L
+/**
+  Creates a data with the contents of the string_view.
+*/
+ Data::Data(const std::string_view sv)
+{
+   initFromString(sv.data(), (Data::size_type)sv.size());
+}
+#endif
+
 Data::Data(const Data& data) 
 {
    initFromString(data.mBuf, data.mSize);
@@ -1050,6 +1060,18 @@ Data::c_str() const
    mBuf[mSize] = 0;
    return mBuf;
 }
+
+std::string Data::toString()
+{
+   return std::string(c_str(), size());
+}
+
+#if RESIP_CPP_STANDARD >= 201703L
+std::string_view Data::toStringView()
+{
+   return std::string_view(c_str(), size());
+}
+#endif
 
 void
 Data::own() const
@@ -1816,8 +1838,8 @@ decimals:
 }
 #endif
 
-bool
-Data::prefix(const Data& pre) const
+const bool
+Data::prefix(const Data& pre) const noexcept
 {
    if (pre.size() > size())
    {
@@ -1827,8 +1849,9 @@ Data::prefix(const Data& pre) const
    return memcmp(data(), pre.data(), pre.size()) == 0;
 }
 
-bool
-Data::postfix(const Data& post) const
+
+const bool
+Data::postfix(const Data& post) const noexcept
 {
    if (post.size() > size())
    {

--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -1840,7 +1840,7 @@ decimals:
 }
 #endif
 
-const bool
+bool
 Data::prefix(const Data& pre) const noexcept
 {
    if (pre.size() > size())
@@ -1852,7 +1852,7 @@ Data::prefix(const Data& pre) const noexcept
 }
 
 
-const bool
+bool
 Data::postfix(const Data& post) const noexcept
 {
    if (post.size() > size())

--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -1061,14 +1061,14 @@ Data::c_str() const
    return mBuf;
 }
 
-const std::string 
+std::string 
 Data::toString() const
 {
    return std::string(c_str(), size());
 }
 
 #if RESIP_CPP_STANDARD >= 201703L
-const std::string_view 
+std::string_view 
 Data::toStringView() const
 {
    return std::string_view(c_str(), size());

--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -1061,13 +1061,15 @@ Data::c_str() const
    return mBuf;
 }
 
-std::string Data::toString()
+const std::string 
+Data::toString() const
 {
    return std::string(c_str(), size());
 }
 
 #if RESIP_CPP_STANDARD >= 201703L
-std::string_view Data::toStringView()
+const std::string_view 
+Data::toStringView() const
 {
    return std::string_view(c_str(), size());
 }

--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -1062,14 +1062,14 @@ Data::c_str() const
 }
 
 std::string 
-Data::toString() const
+Data::toString()
 {
    return std::string(c_str(), size());
 }
 
 #if RESIP_CPP_STANDARD >= 201703L
 std::string_view 
-Data::toStringView() const
+Data::toStringView()
 {
    return std::string_view(c_str(), size());
 }

--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -1062,14 +1062,14 @@ Data::c_str() const
 }
 
 std::string 
-Data::toString()
+Data::toString() const
 {
    return std::string(c_str(), size());
 }
 
 #if RESIP_CPP_STANDARD >= 201703L
 std::string_view 
-Data::toStringView()
+Data::toStringView() const
 {
    return std::string_view(c_str(), size());
 }

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -822,7 +822,7 @@ class Data
         prefix(Data("ab")) would be true; however, prefix(Data("abcd"))
         would be false.
       */
-      const bool prefix(const Data& pre) const noexcept;
+      bool prefix(const Data& pre) const noexcept;
 
       /**
         Returns true if this Data ends with the bytes indicated by
@@ -830,7 +830,7 @@ class Data
         postfix(Data("bc")) would be true; however, postfix(Data("ab"))
         would be false.
       */
-      const bool postfix(const Data& post) const noexcept;
+      bool postfix(const Data& post) const noexcept;
 
       /**
         Copies a portion of this Data into a new Data.

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -425,6 +425,11 @@ class Data
       Data& operator=(Data &&data);
 #endif
 
+      operator std::string() const 
+      {
+         return std::string(c_str(), size());
+      }
+
       /**
         Assigns a null-terminated string to the buffer.
 
@@ -445,6 +450,12 @@ class Data
       }
 
 #if RESIP_CPP_STANDARD >= 201703L
+
+      operator std::string_view() const 
+      {
+         return std::string_view(c_str(), size());
+      }
+
       Data& operator=(const std::string_view sv)
       {
          return copy(sv.data(), static_cast<size_type>(sv.size()));

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -610,13 +610,13 @@ class Data
       /**
         Convert to a C++ string.
       */
-      std::string toString();
+      std::string toString() const;
 
 #if RESIP_CPP_STANDARD >= 201703L
       /**
         Creates a c++ string_view.
       */
-      std::string_view toStringView();
+      std::string_view toStringView() const;
 #endif
 
       /**

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -8,6 +8,9 @@
 #include <iostream>
 #include <string>
 #include <bitset>
+#if RESIP_CPP_STANDARD >= 201703L
+#include <string_view>
+#endif
 #include "rutil/ResipAssert.h"
 
 #include "rutil/compat.hxx"
@@ -180,6 +183,13 @@ class Data
         Creates a data with the contents of the string.
       */
       explicit Data(const std::string& str);
+
+#if RESIP_CPP_STANDARD >= 201703L
+      /**
+        Creates a data with the contents of the string_view.
+      */
+      explicit Data(const std::string_view sv);
+#endif
 
       /**
         Converts the passed in value into ascii-decimal
@@ -585,6 +595,18 @@ class Data
       const char* c_str() const;
 
       /**
+        Convert to a C++ string.
+      */
+      std::string toString();
+
+#if RESIP_CPP_STANDARD >= 201703L
+      /**
+        Creates a c++ string_view.
+      */
+      std::string_view toStringView();
+#endif
+
+      /**
         Returns a pointer to the beginning of the buffer used by the Data.
       */
       const char* begin() const noexcept
@@ -787,7 +809,7 @@ class Data
         prefix(Data("ab")) would be true; however, prefix(Data("abcd"))
         would be false.
       */
-      bool prefix(const Data& pre) const;
+      const bool prefix(const Data& pre) const noexcept;
 
       /**
         Returns true if this Data ends with the bytes indicated by
@@ -795,7 +817,7 @@ class Data
         postfix(Data("bc")) would be true; however, postfix(Data("ab"))
         would be false.
       */
-      bool postfix(const Data& post) const;
+      const bool postfix(const Data& post) const noexcept;
 
       /**
         Copies a portion of this Data into a new Data.
@@ -803,7 +825,7 @@ class Data
         @param first Index of the first byte to copy
         @param count Number of bytes to copy
       */
-      Data substr(size_type first, size_type count = Data::npos) const;
+      Data substr(size_type first, size_type count = Data::npos) const; 
 
       /**
         Finds a specified sequence of bytes in this Data.
@@ -1125,6 +1147,35 @@ bool operator==(const Data& lhs, const char* rhs);
 bool operator<(const Data& lhs, const Data& rhs);
 bool operator<(const Data& lhs, const char* rhs);
 bool operator<(const char* lhs, const Data& rhs);
+
+
+// Overload operator== for resip::Data and std::string
+bool operator==(const resip::Data& lhs, const std::string& rhs)
+{
+   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.c_str(), lhs.size()) == 0;
+}
+
+#if RESIP_CPP_STANDARD >= 201703L
+
+// Overload operator== for resip::Data and std::string_view
+bool operator==(const resip::Data& lhs, const std::string_view rhs)
+{
+   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.data(), lhs.size()) == 0;
+}
+
+// Overload operator!= for resip::Data and std::string
+bool operator!=(const resip::Data& lhs, const std::string& rhs)
+{
+   return !(lhs == rhs);
+}
+
+// Overload operator!= for resip::Data and std::string_view
+bool operator!=(const resip::Data& lhs, const std::string_view rhs)
+{
+   return !(lhs == rhs);
+}
+
+#endif
 
 }
 

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -182,13 +182,13 @@ class Data
       /**
         Creates a data with the contents of the string.
       */
-      explicit Data(const std::string& str);
+      Data(const std::string& str);
 
 #if RESIP_CPP_STANDARD >= 201703L
       /**
         Creates a data with the contents of the string_view.
       */
-      explicit Data(const std::string_view sv);
+      Data(const std::string_view sv);
 #endif
 
       /**
@@ -438,6 +438,19 @@ class Data
          return copy(str, (size_type)strlen(str));
       }
 
+
+      Data& operator=(const std::string& str)
+      {
+         return copy(str.c_str(), static_cast<size_type>(str.size()));
+      }
+
+#if RESIP_CPP_STANDARD >= 201703L
+      Data& operator=(const std::string_view sv)
+      {
+         return copy(sv.data(), static_cast<size_type>(sv.size()));
+      }
+#endif
+
       /**
         Concatenates two Data objects.
       */
@@ -597,13 +610,13 @@ class Data
       /**
         Convert to a C++ string.
       */
-      std::string toString();
+      const std::string toString() const;
 
 #if RESIP_CPP_STANDARD >= 201703L
       /**
         Creates a c++ string_view.
       */
-      std::string_view toStringView();
+      const std::string_view toStringView() const;
 #endif
 
       /**
@@ -1149,28 +1162,44 @@ bool operator<(const Data& lhs, const char* rhs);
 bool operator<(const char* lhs, const Data& rhs);
 
 
-// Overload operator== for resip::Data and std::string
-bool operator==(const resip::Data& lhs, const std::string& rhs)
+inline bool operator==(const resip::Data& lhs, const std::string& rhs) noexcept
 {
-   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.c_str(), lhs.size()) == 0;
+   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.c_str(), rhs.size()) == 0;
 }
 
-#if RESIP_CPP_STANDARD >= 201703L
-
-// Overload operator== for resip::Data and std::string_view
-bool operator==(const resip::Data& lhs, const std::string_view rhs)
+inline bool operator==(const std::string& lhs, const resip::Data& rhs) noexcept
 {
-   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.data(), lhs.size()) == 0;
+   return lhs.size() == rhs.size() && std::memcmp(lhs.c_str(), rhs.data(), rhs.size()) == 0;
 }
 
-// Overload operator!= for resip::Data and std::string
-bool operator!=(const resip::Data& lhs, const std::string& rhs)
+inline bool operator!=(const resip::Data& lhs, const std::string& rhs) noexcept
 {
    return !(lhs == rhs);
 }
 
-// Overload operator!= for resip::Data and std::string_view
-bool operator!=(const resip::Data& lhs, const std::string_view rhs)
+inline bool operator!=(const std::string& lhs, const resip::Data& rhs) noexcept
+{
+   return !(lhs == rhs);
+}
+
+#if RESIP_CPP_STANDARD >= 201703L
+
+inline bool operator==(const resip::Data& lhs, const std::string_view rhs) noexcept
+{
+   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.data(), rhs.size()) == 0;
+}
+
+inline bool operator==(const std::string_view lhs, const resip::Data& rhs) noexcept
+{
+   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.data(), rhs.size()) == 0;
+}
+
+inline bool operator!=(const resip::Data& lhs, const std::string_view rhs) noexcept
+{
+   return !(lhs == rhs);
+}
+
+inline bool operator!=(const std::string_view lhs, const resip::Data& rhs) noexcept
 {
    return !(lhs == rhs);
 }

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -610,13 +610,13 @@ class Data
       /**
         Convert to a C++ string.
       */
-      const std::string toString() const;
+      std::string toString() const;
 
 #if RESIP_CPP_STANDARD >= 201703L
       /**
         Creates a c++ string_view.
       */
-      const std::string_view toStringView() const;
+      std::string_view toStringView() const;
 #endif
 
       /**

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -610,13 +610,13 @@ class Data
       /**
         Convert to a C++ string.
       */
-      std::string toString() const;
+      std::string toString();
 
 #if RESIP_CPP_STANDARD >= 201703L
       /**
         Creates a c++ string_view.
       */
-      std::string_view toStringView() const;
+      std::string_view toStringView();
 #endif
 
       /**

--- a/rutil/compat.hxx
+++ b/rutil/compat.hxx
@@ -323,6 +323,26 @@ hton64(const uint64_t input)
 #define _CVTBUFSIZE 309+40
 #endif
 
+// Detect the compiler and define the C++ standard version macro
+#if defined(_MSC_VER)
+    // For Visual Studio
+
+    // Ensure _MSVC_LANG is defined
+#ifndef _MSVC_LANG
+#define _MSVC_LANG 0
+#endif
+
+// Use _MSVC_LANG to detect the C++ standard version
+#define RESIP_CPP_STANDARD _MSVC_LANG
+
+#else
+    // For GCC or Clang
+
+    // Use __cplusplus to detect the C++ standard version
+#define RESIP_CPP_STANDARD __cplusplus
+
+#endif
+
 #endif
 
 /* ====================================================================

--- a/rutil/test/testData.cxx
+++ b/rutil/test/testData.cxx
@@ -1500,6 +1500,7 @@ class TestData
             resip::Data d1(str1);
 
             resip_assert(d1 == str1);
+            resip_assert(str1 == d1);
             resip_assert(d1.toString() == str1);
          }
 
@@ -1508,6 +1509,7 @@ class TestData
             resip::Data d1 = str1;
 
             resip_assert(d1 == str1);
+            resip_assert(str1 == d1);
             resip_assert(d1.toString() == str1);
          }
 
@@ -1516,10 +1518,12 @@ class TestData
             std::string str1 = "resip";
             resip::Data d1 = "resipr";
             resip_assert(d1 != str1);
+            resip_assert(str1 != d1);
             resip_assert(d1.toString() != str1);
 
             resip::Data d2(std::string("resipr"));
             resip_assert(d2 != str1);
+            resip_assert(str1 != d2);
             resip_assert(d2.toString() != str1);
          }
 
@@ -1531,6 +1535,7 @@ class TestData
             resip::Data d1(sv1);
 
             resip_assert(d1 == sv1);
+            resip_assert(sv1 == d1);
             resip_assert(d1.toStringView() == sv1);
          }
 
@@ -1539,6 +1544,7 @@ class TestData
             resip::Data d1 = sv1;
 
             resip_assert(d1 == sv1);
+            resip_assert(sv1 == d1);
             resip_assert(d1.toStringView() == sv1);
          }
 
@@ -1547,11 +1553,13 @@ class TestData
             std::string_view sv1 = "resip";
             resip::Data d1 = "resipr";
             resip_assert(d1 != sv1);
+            resip_assert(sv1 != d1);
             resip_assert(d1.toStringView() != sv1);
 
 
             resip::Data d2(std::string_view("resipr"));
             resip_assert(d2 != sv1);
+            resip_assert(sv1 != d2);
             resip_assert(d2.toStringView() != sv1);
          }
 

--- a/rutil/test/testData.cxx
+++ b/rutil/test/testData.cxx
@@ -1527,6 +1527,38 @@ class TestData
             resip_assert(d2.toString() != str1);
          }
 
+         {
+            resip::Data d1("resip");
+            std::string str1 = d1;
+            resip_assert(str1 == d1);
+            resip_assert(d1 == str1);
+         }
+
+         {
+            resip::Data d1("resip");
+            std::string str1(d1);
+            resip_assert(str1 == d1);
+            resip_assert(d1 == str1);
+         }
+
+         {
+            resip::Data d1("resip");
+            std::string str1 = d1;
+
+            resip::Data d2("resip2");
+            resip_assert(str1 != d2);
+            resip_assert(d2 != str1);
+         }
+
+         {
+            resip::Data d1("resip");
+            std::string str1(d1);
+
+            resip::Data d2("resip2");
+            resip_assert(str1 != d2);
+            resip_assert(d2 != str1);
+         }
+
 
 #if RESIP_CPP_STANDARD >= 201703L
 
@@ -1563,6 +1595,37 @@ class TestData
             resip_assert(d2.toStringView() != sv1);
          }
 
+         {
+            resip::Data d1("resip");
+            std::string_view str1 = d1;
+            resip_assert(str1 == d1);
+            resip_assert(d1 == str1);
+         }
+
+         {
+            resip::Data d1("resip");
+            std::string_view str1(d1);
+            resip_assert(str1 == d1);
+            resip_assert(d1 == str1);
+         }
+
+         {
+            resip::Data d1("resip");
+            std::string_view str1 = d1;
+
+            resip::Data d2("resip2");
+            resip_assert(str1 != d2);
+            resip_assert(d2 != str1);
+         }
+
+         {
+            resip::Data d1("resip");
+            std::string_view str1(d1);
+
+            resip::Data d2("resip2");
+            resip_assert(str1 != d2);
+            resip_assert(d2 != str1);
+         }
 #endif
 
          std::cerr << "All OK" << endl;

--- a/rutil/test/testData.cxx
+++ b/rutil/test/testData.cxx
@@ -1557,8 +1557,6 @@ class TestData
 
 #endif
 
-         }
-
          std::cerr << "All OK" << endl;
          return 0;
       }

--- a/rutil/test/testData.cxx
+++ b/rutil/test/testData.cxx
@@ -1,6 +1,7 @@
 #include "rutil/Data.hxx"
 #include "rutil/DataStream.hxx"
 #include "rutil/Log.hxx"
+#include "rutil/compat.hxx"
 #include "assert.h"
 #include <iostream>
 #include <limits>
@@ -1394,32 +1395,32 @@ class TestData
             Data u4(Data::Share, ubuf4+3, 16-i);
 
             // All of these point to the same data, but aligned differently.
-            assert(d1.hash()==d2.hash());
-            assert(d1.hash()==d3.hash());
-            assert(d1.hash()==d4.hash());
+            assert(d1.hash() == d2.hash());
+            assert(d1.hash() == d3.hash());
+            assert(d1.hash() == d4.hash());
 
-            assert(d1.hash()!=u1.hash());
-            assert(d1.hash()!=u2.hash());
-            assert(d1.hash()!=u3.hash());
-            assert(d1.hash()!=u4.hash());
+            assert(d1.hash() != u1.hash());
+            assert(d1.hash() != u2.hash());
+            assert(d1.hash() != u3.hash());
+            assert(d1.hash() != u4.hash());
 
-            assert(d1.caseInsensitivehash()==d2.caseInsensitivehash());
-            assert(d1.caseInsensitivehash()==d3.caseInsensitivehash());
-            assert(d1.caseInsensitivehash()==d4.caseInsensitivehash());
+            assert(d1.caseInsensitivehash() == d2.caseInsensitivehash());
+            assert(d1.caseInsensitivehash() == d3.caseInsensitivehash());
+            assert(d1.caseInsensitivehash() == d4.caseInsensitivehash());
 
-            assert(d1.caseInsensitivehash()==u1.caseInsensitivehash());
-            assert(d1.caseInsensitivehash()==u2.caseInsensitivehash());
-            assert(d1.caseInsensitivehash()==u3.caseInsensitivehash());
-            assert(d1.caseInsensitivehash()==u4.caseInsensitivehash());
+            assert(d1.caseInsensitivehash() == u1.caseInsensitivehash());
+            assert(d1.caseInsensitivehash() == u2.caseInsensitivehash());
+            assert(d1.caseInsensitivehash() == u3.caseInsensitivehash());
+            assert(d1.caseInsensitivehash() == u4.caseInsensitivehash());
 
-            assert(d1.caseInsensitiveTokenHash()==d2.caseInsensitiveTokenHash());
-            assert(d1.caseInsensitiveTokenHash()==d3.caseInsensitiveTokenHash());
-            assert(d1.caseInsensitiveTokenHash()==d4.caseInsensitiveTokenHash());
+            assert(d1.caseInsensitiveTokenHash() == d2.caseInsensitiveTokenHash());
+            assert(d1.caseInsensitiveTokenHash() == d3.caseInsensitiveTokenHash());
+            assert(d1.caseInsensitiveTokenHash() == d4.caseInsensitiveTokenHash());
 
-            assert(d1.caseInsensitiveTokenHash()==u1.caseInsensitiveTokenHash());
-            assert(d1.caseInsensitiveTokenHash()==u2.caseInsensitiveTokenHash());
-            assert(d1.caseInsensitiveTokenHash()==u3.caseInsensitiveTokenHash());
-            assert(d1.caseInsensitiveTokenHash()==u4.caseInsensitiveTokenHash());
+            assert(d1.caseInsensitiveTokenHash() == u1.caseInsensitiveTokenHash());
+            assert(d1.caseInsensitiveTokenHash() == u2.caseInsensitiveTokenHash());
+            assert(d1.caseInsensitiveTokenHash() == u3.caseInsensitiveTokenHash());
+            assert(d1.caseInsensitiveTokenHash() == u4.caseInsensitiveTokenHash());
 
             assert(d1.caseInsensitiveTokenCompare(d1));
             assert(d1.caseInsensitiveTokenCompare(d2));
@@ -1493,6 +1494,71 @@ class TestData
             assert(u4.caseInsensitiveTokenCompare(u3));
             assert(u4.caseInsensitiveTokenCompare(u4));
          }
+
+         {
+            std::string str1 = "resip";
+            resip::Data d1(str1);
+
+            resip_assert(d1 == str1);
+            resip_assert(d1.toString() == str1);
+         }
+
+         {
+            std::string str1 = "resip";
+            resip::Data d1 = str1;
+
+            resip_assert(d1 == str1);
+            resip_assert(d1.toString() == str1);
+         }
+
+
+         {
+            std::string str1 = "resip";
+            resip::Data d1 = "resipr";
+            resip_assert(d1 != str1);
+            resip_assert(d1.toString() != str1);
+
+            resip::Data d2(std::string("resipr"));
+            resip_assert(d2 != str1);
+            resip_assert(d2.toString() != str1);
+         }
+
+
+#if RESIP_CPP_STANDARD >= 201703L
+
+         {
+            std::string_view sv1 = "resip";
+            resip::Data d1(sv1);
+
+            resip_assert(d1 == sv1);
+            resip_assert(d1.toStringView() == sv1);
+         }
+
+         {
+            std::string_view sv1 = "resip";
+            resip::Data d1 = sv1;
+
+            resip_assert(d1 == sv1);
+            resip_assert(d1.toStringView() == sv1);
+         }
+
+
+         {
+            std::string_view sv1 = "resip";
+            resip::Data d1 = "resipr";
+            resip_assert(d1 != sv1);
+            resip_assert(d1.toStringView() != sv1);
+
+
+            resip::Data d2(std::string_view("resipr"));
+            resip_assert(d2 != sv1);
+            resip_assert(d2.toStringView() != sv1);
+         }
+
+#endif
+
+         }
+
          std::cerr << "All OK" << endl;
          return 0;
       }


### PR DESCRIPTION
- Added support for constructing resip::Data from a std::string_view when using C++17 or higher.
- Override ==, !=, and += operators for resip::Data to enable seamless comparison and concatenation with std::string and std::string_view.
