### PR TITLE
Improve URI comparison logic

### DIFF
--- a/resip/stack/Uri.cxx
+++ b/resip/stack/Uri.cxx
@@ -435,6 +435,10 @@ bool Uri::compareUriParametersEqual(Parameter* param1, Parameter* param2)
          return dynamic_cast<UInt32Parameter*>(param1)->value() ==
                 dynamic_cast<UInt32Parameter*>(param2)->value();
 
+      case ParameterTypes::gr:
+         return isEqualNoCase(dynamic_cast<ExistsOrDataParameter*>(param1)->value(),
+                              dynamic_cast<ExistsOrDataParameter*>(param2)->value());
+
       case ParameterTypes::lr:
          // Exists parameters are equal.
          return true;

--- a/resip/stack/Uri.hxx
+++ b/resip/stack/Uri.hxx
@@ -196,6 +196,16 @@ class Uri : public ParserCategory
       static bool compareUriParametersEqual(Parameter* param1, Parameter* param2);
 
       /**
+         @brief Compares two URI parameters to determine if the first is less
+                than the second.
+         @param param1 The first parameter to compare.
+         @param param2 The second parameter to compare.
+         @return `true` if the first parameter is less than the second;
+                 otherwise, `false`.
+      */
+      static bool compareUriParametersLessThan(Parameter* param1, Parameter* param2);
+
+      /**
          @brief Checks if the URI-parameter appearing in only one URI must not
                 be ignored when comparing the URIs.
          @param type The type of the parameter to check.

--- a/resip/stack/Uri.hxx
+++ b/resip/stack/Uri.hxx
@@ -187,6 +187,24 @@ class Uri : public ParserCategory
       bool aorEqual(const Uri& rhs) const;
       void setIsBetweenAngleQuotes(bool value) { mIsBetweenAngleQuotes = value; }
 
+      /**
+         @brief Compares two known URI parameters for equality.
+         @param param1 The first parameter to compare.
+         @param param2 The second parameter to compare.
+         @return `true` if the parameters are equal; otherwise, `false`.
+      */
+      static bool compareUriParametersEqual(Parameter* param1, Parameter* param2);
+
+      /**
+         @brief Checks if the URI-parameter appearing in only one URI must not
+                be ignored when comparing the URIs.
+         @param type The type of the parameter to check.
+         @return `true` if such a parameter must not be ignored;
+                 otherwise, `false`.
+         @note Follows RFC 3261 section 19.1.4.
+      */
+      static bool isSignificantUriParameter(const ParameterTypes::Type type) noexcept;
+
       typedef std::bitset<Uri::uriEncodingTableSize> EncodingTable;
 
       static EncodingTable& getUserEncodingTable()

--- a/resip/stack/test/testUri.cxx
+++ b/resip/stack/test/testUri.cxx
@@ -475,6 +475,45 @@ main(int argc, char* argv[])
       assert (sip1 == sip2);
       assert (sip2 == sip1);
    }
+
+   // Test significant URI params.
+   // user/ttl/method/maddr/transport in one URI only should never match.
+   {
+      Uri uri1("sip:bob@example.com;user=phone");
+      Uri uri2("sip:bob@example.com");
+      assert(uri1 != uri2);
+   }
+
+   {
+      Uri uri1("sip:bob@example.com;ttl=60");
+      Uri uri2("sip:bob@example.com");
+      assert(uri1 != uri2);
+   }
+
+   {
+      Uri uri1("sip:bob@example.com;method=INVITE");
+      Uri uri2("sip:bob@example.com");
+      assert(uri1 != uri2);
+   }
+
+   {
+      Uri uri1("sip:carol@example.com;maddr=192.168.1.1");
+      Uri uri2("sip:carol@example.com");
+      assert(uri1 != uri2);
+   }
+
+   // Other parameters in one URI only should be ignored.
+   {
+      Uri uri1("sip:dave@example.com;lr");
+      Uri uri2("sip:dave@example.com");
+      assert(uri1 == uri2);
+   }
+
+   {
+      Uri uri1("sip:eve@example.com;test=123");
+      Uri uri2("sip:eve@example.com");
+      assert(uri1 == uri2);
+   }
    
 
    // tests from 3261 19.1.4

--- a/resip/stack/test/testUri.cxx
+++ b/resip/stack/test/testUri.cxx
@@ -515,6 +515,43 @@ main(int argc, char* argv[])
       assert(uri1 == uri2);
    }
    
+   // Test known `gr` URI parameter.
+   {
+      Uri sip1("sip:janet@example.com");
+      Uri sip2("sip:janet@example.com;gr=urn:uuid:123");
+      assert(sip1 == sip2);  // Ignored when appearing in only one URI.
+   }
+
+   {
+      Uri sip1("sip:janet@example.com;gr=urn:uuid:123");
+      Uri sip2("sip:janet@example.com;gr=urn:uuid:321");
+      assert(sip1 != sip2);  // Considered when appearing in both URIs.
+   }
+
+   {
+      Uri sip1("sip:janet@example.com;gr=urn:uuid:123");
+      Uri sip2("sip:janet@example.com;gr=urn:uuid:123");
+      assert(sip1 == sip2);
+   }
+
+   {
+      Uri sip1("sip:janet@example.com");
+      Uri sip2("sip:janet@example.com;gr");
+      assert(sip1 == sip2);
+   }
+
+   {
+      Uri sip1("sip:janet@example.com;gr");
+      Uri sip2("sip:janet@example.com;gr");
+      assert(sip1 == sip2);
+   }
+
+   {
+      Uri sip1("sip:janet@example.com;gr");
+      Uri sip2("sip:janet@example.com;gr=urn:uuid:123");
+      assert(sip1 != sip2);
+   }
+
 
    // tests from 3261 19.1.4
    {

--- a/resip/stack/test/testUri.cxx
+++ b/resip/stack/test/testUri.cxx
@@ -552,6 +552,101 @@ main(int argc, char* argv[])
       assert(sip1 != sip2);
    }
 
+   // Test parameters ordering.
+   {
+      // Known significant parameter single URI.
+      Uri sip1("sip:janet@example.com");
+      Uri sip2("sip:janet@example.com;ttl=5");
+
+      assert(sip1 != sip2);
+      assert((sip1 < sip2) == false);
+      assert(sip2 < sip1);
+   }
+
+   {
+      // Known significant parameter both URIs.
+      Uri sip1("sip:janet@example.com;ttl=5");
+      Uri sip2("sip:janet@example.com;ttl=5");
+      Uri sip3("sip:janet@example.com;ttl=17");
+
+      assert((sip1 < sip2) == false);
+      assert((sip2 < sip1) == false);
+      assert(sip1 == sip2);
+
+      assert(sip2 < sip3);
+      assert((sip3 < sip2) == false);
+      assert(sip2 != sip3);
+   }
+
+   {
+      // Known parameter single URI.
+      Uri sip1("sip:janet@example.com");
+      Uri sip2("sip:janet@example.com;gr=urn:uuid:123");
+
+      assert((sip1 < sip2) == false);
+      assert((sip2 < sip1) == false);
+      assert(sip1 == sip2);
+   }
+
+   {
+      // Known parameter both URIs.
+      Uri sip1("sip:janet@example.com;gr=urn:uuid:123");
+      Uri sip2("sip:janet@example.com;gr=urn:uuid:123");
+      Uri sip3("sip:janet@example.com;gr=urn:uuid:321");
+
+      assert((sip1 < sip2) == false);
+      assert((sip2 < sip1) == false);
+      assert(sip1 == sip2);
+
+      assert(sip2 < sip3);
+      assert((sip3 < sip2) == false);
+      assert(sip2 != sip3);
+   }
+
+   {
+      // Unknown parameter single URI.
+      Uri sip1("sip:janet@example.com");
+      Uri sip2("sip:janet@example.com;test=135");
+
+      assert((sip1 < sip2) == false);
+      assert((sip2 < sip1) == false);
+      assert(sip1 == sip2);
+   }
+
+   {
+      // Unknown parameter both URIs.
+      Uri sip1("sip:janet@example.com;test=135");
+      Uri sip2("sip:janet@example.com;test=135");
+      Uri sip3("sip:janet@example.com;test=531");
+
+      assert((sip1 < sip2) == false);
+      assert((sip2 < sip1) == false);
+      assert(sip1 == sip2);
+
+      assert(sip2 < sip3);
+      assert((sip3 < sip2) == false);
+      assert(sip2 != sip3);
+   }
+
+   {
+      // Mixed params.
+      Uri sip1("sip:janet@example.com;ttl=5;gr=urn:uuid:123");
+      Uri sip2("sip:janet@example.com;ttl=5;gr=urn:uuid:123;test=135");
+      Uri sip3("sip:janet@example.com;ttl=17;gr=urn:uuid:123;test=135");
+
+      assert((sip1 < sip2) == false);
+      assert((sip2 < sip1) == false);
+      assert(sip1 == sip2);
+
+      assert(sip1 < sip3);
+      assert((sip3 < sip1) == false);
+      assert(sip1 != sip3);
+
+      assert(sip2 < sip3);
+      assert((sip3 < sip2) == false);
+      assert(sip2 != sip3);
+   }
+
 
    // tests from 3261 19.1.4
    {


### PR DESCRIPTION
- Extract repetetive code into separate functions to improve maintainability and extensibility.
- According to RFC 3261 and RFC5627, `gr` parameter should be considered in URI comparison if it appears in both compared URIs.
-  Consider URI parameters in Uri's `operator<` to ensure correct logic, consistent with Uri's `operator==`.