### PR TITLE
Improve the implementation of resip::Data interoperability with std::string and std::string_view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ option(BUILD_SHARED_LIBS "Build libraries as shared" ${BUILD_SHARED_LIBS_DEFAULT
 option(USE_CONTRIB "Use libraries from contrib folder" ${USE_CONTRIB_DEFAULT})
 option(USE_NUGET "Use NuGet package manager" ${USE_NUGET_DEFAULT})
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "CXX standard to use")
 
 if(BUILD_TESTING)
     enable_testing()

--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -761,6 +761,20 @@ resip::operator==(const Data& lhs, const char* rhs)
 }
 
 bool
+resip::operator==(const Data& lhs, const std::string& rhs) noexcept
+{
+   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.c_str(), rhs.size()) == 0;
+}
+
+#if RESIP_CPP_STANDARD >= 201703L
+bool
+resip::operator==(const Data& lhs, const std::string_view rhs) noexcept
+{
+   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.data(), rhs.size()) == 0;
+}
+#endif
+
+bool
 resip::operator<(const Data& lhs, const Data& rhs)
 {
    int res = memcmp(lhs.mBuf, rhs.mBuf, resipMin(lhs.mSize, rhs.mSize));

--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -835,6 +835,51 @@ resip::operator<(const char* lhs, const Data& rhs)
    }
 }
 
+bool
+resip::operator<(const Data& lhs, const std::string& rhs) noexcept
+{
+   const Data::size_type l = rhs.size();
+   if (lhs.mSize != l)
+   {
+      return lhs.mSize < l;
+   }
+   return memcmp(lhs.mBuf, rhs.c_str(), lhs.mSize) < 0;
+}
+
+bool
+resip::operator<(const std::string& lhs, const Data& rhs) noexcept
+{
+   const Data::size_type lhsSize = lhs.size();
+   if (lhsSize != rhs.mSize)
+   {
+      return lhsSize < rhs.mSize;
+   }
+   return memcmp(lhs.c_str(), rhs.mBuf, lhsSize) < 0;
+}
+
+#if RESIP_CPP_STANDARD >= 201703L
+bool
+resip::operator<(const Data& lhs, const std::string_view rhs) noexcept
+{
+   const Data::size_type rhsSize = rhs.size();
+   if (lhs.mSize != rhsSize)
+   {
+      return lhs.mSize < rhsSize;
+   }
+   return memcmp(lhs.mBuf, rhs.data(), lhs.mSize) < 0;
+}
+
+bool
+resip::operator<(const std::string_view lhs, const Data& rhs) noexcept
+{
+   const Data::size_type lhsSize = lhs.size();
+   if (lhsSize != rhs.mSize)
+   {
+      return lhsSize < rhs.mSize;
+   }
+   return memcmp(lhs.data(), rhs.mBuf, lhsSize) < 0;
+}
+#endif
 
 
 #if 0

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -417,6 +417,12 @@ class Data
       friend bool operator<(const Data& lhs, const Data& rhs);
       friend bool operator<(const Data& lhs, const char* rhs);
       friend bool operator<(const char* lhs, const Data& rhs);
+      friend bool operator<(const Data& lhs, const std::string& rhs) noexcept;
+      friend bool operator<(const std::string& lhs, const Data& rhs) noexcept;
+#if RESIP_CPP_STANDARD >= 201703L
+      friend bool operator<(const Data& lhs, const std::string_view rhs) noexcept;
+      friend bool operator<(const std::string_view lhs, const Data& rhs) noexcept;
+#endif
 
       Data& operator=(const Data& data)
       {
@@ -1158,15 +1164,27 @@ inline bool operator<=(const char* lhs, const Data& rhs) { return !(rhs < lhs); 
 inline bool operator>=(const char* lhs, const Data& rhs) { return !(lhs < rhs); }
 
 inline bool operator!=(const Data& lhs, const std::string& rhs) noexcept { return !(lhs == rhs); }
+inline bool operator>(const Data& lhs, const std::string& rhs) { return rhs < lhs; }
+inline bool operator<=(const Data& lhs, const std::string& rhs) { return !(rhs < lhs); }
+inline bool operator>=(const Data& lhs, const std::string& rhs) { return !(lhs < rhs); }
 
 inline bool operator==(const std::string& lhs, const Data& rhs) noexcept { return rhs == lhs; }
 inline bool operator!=(const std::string& lhs, const Data& rhs) noexcept { return !(rhs == lhs); }
+inline bool operator>(const std::string& lhs, const Data& rhs) { return rhs < lhs; }
+inline bool operator<=(const std::string& lhs, const Data& rhs) { return !(rhs < lhs); }
+inline bool operator>=(const std::string& lhs, const Data& rhs) { return !(lhs < rhs); }
 
 #if RESIP_CPP_STANDARD >= 201703L
 inline bool operator!=(const Data& lhs, const std::string_view rhs) noexcept { return !(lhs == rhs); }
+inline bool operator>(const Data& lhs, const std::string_view rhs) { return rhs < lhs; }
+inline bool operator<=(const Data& lhs, const std::string_view rhs) { return !(rhs < lhs); }
+inline bool operator>=(const Data& lhs, const std::string_view rhs) { return !(lhs < rhs); }
 
 inline bool operator==(const std::string_view lhs, const Data& rhs) noexcept { return rhs == lhs; }
 inline bool operator!=(const std::string_view lhs, const Data& rhs) noexcept { return !(rhs == lhs); }
+inline bool operator>(const std::string_view lhs, const Data& rhs) { return rhs < lhs; }
+inline bool operator<=(const std::string_view lhs, const Data& rhs) { return !(rhs < lhs); }
+inline bool operator>=(const std::string_view lhs, const Data& rhs) { return !(lhs < rhs); }
 #endif
 
 #ifndef  RESIP_USE_STL_STREAMS
@@ -1194,6 +1212,12 @@ bool operator==(const Data& lhs, const std::string_view rhs) noexcept;
 bool operator<(const Data& lhs, const Data& rhs);
 bool operator<(const Data& lhs, const char* rhs);
 bool operator<(const char* lhs, const Data& rhs);
+bool operator<(const Data& lhs, const std::string& rhs) noexcept;
+bool operator<(const std::string& lhs, const Data& rhs) noexcept;
+#if RESIP_CPP_STANDARD >= 201703L
+bool operator<(const Data& lhs, const std::string_view rhs) noexcept;
+bool operator<(const std::string_view lhs, const Data& rhs) noexcept;
+#endif
 }
 
 HashValue(resip::Data);

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -409,6 +409,10 @@ class Data
 
       friend bool operator==(const Data& lhs, const Data& rhs);
       friend bool operator==(const Data& lhs, const char* rhs);
+      friend bool operator==(const Data& lhs, const std::string& rhs) noexcept;
+#if RESIP_CPP_STANDARD >= 201703L
+      friend bool operator==(const Data& lhs, const std::string_view rhs) noexcept;
+#endif
 
       friend bool operator<(const Data& lhs, const Data& rhs);
       friend bool operator<(const Data& lhs, const char* rhs);
@@ -1141,15 +1145,30 @@ inline bool operator!=(const Data& lhs, const Data& rhs) { return !(lhs == rhs);
 inline bool operator>(const Data& lhs, const Data& rhs) { return rhs < lhs; }
 inline bool operator<=(const Data& lhs, const Data& rhs) { return !(rhs < lhs); }
 inline bool operator>=(const Data& lhs, const Data& rhs) { return !(lhs < rhs); }
+
 inline bool operator!=(const Data& lhs, const char* rhs) { return !(lhs == rhs); }
 inline bool operator>(const Data& lhs, const char* rhs) { return rhs < lhs; }
 inline bool operator<=(const Data& lhs, const char* rhs) { return !(rhs < lhs); }
 inline bool operator>=(const Data& lhs, const char* rhs) { return !(lhs < rhs); }
+
 inline bool operator==(const char* lhs, const Data& rhs) { return rhs == lhs; }
 inline bool operator!=(const char* lhs, const Data& rhs) { return !(rhs == lhs); }
 inline bool operator>(const char* lhs, const Data& rhs) { return rhs < lhs; }
 inline bool operator<=(const char* lhs, const Data& rhs) { return !(rhs < lhs); }
 inline bool operator>=(const char* lhs, const Data& rhs) { return !(lhs < rhs); }
+
+inline bool operator!=(const Data& lhs, const std::string& rhs) noexcept { return !(lhs == rhs); }
+
+inline bool operator==(const std::string& lhs, const Data& rhs) noexcept { return rhs == lhs; }
+inline bool operator!=(const std::string& lhs, const Data& rhs) noexcept { return !(rhs == lhs); }
+
+#if RESIP_CPP_STANDARD >= 201703L
+inline bool operator!=(const Data& lhs, const std::string_view rhs) noexcept { return !(lhs == rhs); }
+
+inline bool operator==(const std::string_view lhs, const Data& rhs) noexcept { return rhs == lhs; }
+inline bool operator!=(const std::string_view lhs, const Data& rhs) noexcept { return !(rhs == lhs); }
+#endif
+
 #ifndef  RESIP_USE_STL_STREAMS
 EncodeStream& operator<<(EncodeStream& strm, const Data& d);
 #endif
@@ -1167,56 +1186,14 @@ operator+(const char* c, const Data& d)
 
 bool operator==(const Data& lhs, const Data& rhs);
 bool operator==(const Data& lhs, const char* rhs);
+bool operator==(const Data& lhs, const std::string& rhs) noexcept;
+#if RESIP_CPP_STANDARD >= 201703L
+bool operator==(const Data& lhs, const std::string_view rhs) noexcept;
+#endif
 
 bool operator<(const Data& lhs, const Data& rhs);
 bool operator<(const Data& lhs, const char* rhs);
 bool operator<(const char* lhs, const Data& rhs);
-
-
-inline bool operator==(const resip::Data& lhs, const std::string& rhs) noexcept
-{
-   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.c_str(), rhs.size()) == 0;
-}
-
-inline bool operator==(const std::string& lhs, const resip::Data& rhs) noexcept
-{
-   return lhs.size() == rhs.size() && std::memcmp(lhs.c_str(), rhs.data(), rhs.size()) == 0;
-}
-
-inline bool operator!=(const resip::Data& lhs, const std::string& rhs) noexcept
-{
-   return !(lhs == rhs);
-}
-
-inline bool operator!=(const std::string& lhs, const resip::Data& rhs) noexcept
-{
-   return !(lhs == rhs);
-}
-
-#if RESIP_CPP_STANDARD >= 201703L
-
-inline bool operator==(const resip::Data& lhs, const std::string_view rhs) noexcept
-{
-   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.data(), rhs.size()) == 0;
-}
-
-inline bool operator==(const std::string_view lhs, const resip::Data& rhs) noexcept
-{
-   return lhs.size() == rhs.size() && std::memcmp(lhs.data(), rhs.data(), rhs.size()) == 0;
-}
-
-inline bool operator!=(const resip::Data& lhs, const std::string_view rhs) noexcept
-{
-   return !(lhs == rhs);
-}
-
-inline bool operator!=(const std::string_view lhs, const resip::Data& rhs) noexcept
-{
-   return !(lhs == rhs);
-}
-
-#endif
-
 }
 
 HashValue(resip::Data);

--- a/rutil/test/testData.cxx
+++ b/rutil/test/testData.cxx
@@ -1499,46 +1499,46 @@ class TestData
             std::string str1 = "resip";
             resip::Data d1(str1);
 
-            resip_assert(d1 == str1);
-            resip_assert(str1 == d1);
-            resip_assert(d1.toString() == str1);
+            assert(d1 == str1);
+            assert(str1 == d1);
+            assert(d1.toString() == str1);
          }
 
          {
             std::string str1 = "resip";
             resip::Data d1 = str1;
 
-            resip_assert(d1 == str1);
-            resip_assert(str1 == d1);
-            resip_assert(d1.toString() == str1);
+            assert(d1 == str1);
+            assert(str1 == d1);
+            assert(d1.toString() == str1);
          }
 
 
          {
             std::string str1 = "resip";
             resip::Data d1 = "resipr";
-            resip_assert(d1 != str1);
-            resip_assert(str1 != d1);
-            resip_assert(d1.toString() != str1);
+            assert(d1 != str1);
+            assert(str1 != d1);
+            assert(d1.toString() != str1);
 
             resip::Data d2(std::string("resipr"));
-            resip_assert(d2 != str1);
-            resip_assert(str1 != d2);
-            resip_assert(d2.toString() != str1);
+            assert(d2 != str1);
+            assert(str1 != d2);
+            assert(d2.toString() != str1);
          }
 
          {
             resip::Data d1("resip");
             std::string str1 = d1;
-            resip_assert(str1 == d1);
-            resip_assert(d1 == str1);
+            assert(str1 == d1);
+            assert(d1 == str1);
          }
 
          {
             resip::Data d1("resip");
             std::string str1(d1);
-            resip_assert(str1 == d1);
-            resip_assert(d1 == str1);
+            assert(str1 == d1);
+            assert(d1 == str1);
          }
 
          {
@@ -1546,8 +1546,8 @@ class TestData
             std::string str1 = d1;
 
             resip::Data d2("resip2");
-            resip_assert(str1 != d2);
-            resip_assert(d2 != str1);
+            assert(str1 != d2);
+            assert(d2 != str1);
          }
 
          {
@@ -1555,8 +1555,8 @@ class TestData
             std::string str1(d1);
 
             resip::Data d2("resip2");
-            resip_assert(str1 != d2);
-            resip_assert(d2 != str1);
+            assert(str1 != d2);
+            assert(d2 != str1);
          }
 
 
@@ -1566,47 +1566,47 @@ class TestData
             std::string_view sv1 = "resip";
             resip::Data d1(sv1);
 
-            resip_assert(d1 == sv1);
-            resip_assert(sv1 == d1);
-            resip_assert(d1.toStringView() == sv1);
+            assert(d1 == sv1);
+            assert(sv1 == d1);
+            assert(d1.toStringView() == sv1);
          }
 
          {
             std::string_view sv1 = "resip";
             resip::Data d1 = sv1;
 
-            resip_assert(d1 == sv1);
-            resip_assert(sv1 == d1);
-            resip_assert(d1.toStringView() == sv1);
+            assert(d1 == sv1);
+            assert(sv1 == d1);
+            assert(d1.toStringView() == sv1);
          }
 
 
          {
             std::string_view sv1 = "resip";
             resip::Data d1 = "resipr";
-            resip_assert(d1 != sv1);
-            resip_assert(sv1 != d1);
-            resip_assert(d1.toStringView() != sv1);
+            assert(d1 != sv1);
+            assert(sv1 != d1);
+            assert(d1.toStringView() != sv1);
 
 
             resip::Data d2(std::string_view("resipr"));
-            resip_assert(d2 != sv1);
-            resip_assert(sv1 != d2);
-            resip_assert(d2.toStringView() != sv1);
+            assert(d2 != sv1);
+            assert(sv1 != d2);
+            assert(d2.toStringView() != sv1);
          }
 
          {
             resip::Data d1("resip");
             std::string_view str1 = d1;
-            resip_assert(str1 == d1);
-            resip_assert(d1 == str1);
+            assert(str1 == d1);
+            assert(d1 == str1);
          }
 
          {
             resip::Data d1("resip");
             std::string_view str1(d1);
-            resip_assert(str1 == d1);
-            resip_assert(d1 == str1);
+            assert(str1 == d1);
+            assert(d1 == str1);
          }
 
          {
@@ -1614,8 +1614,8 @@ class TestData
             std::string_view str1 = d1;
 
             resip::Data d2("resip2");
-            resip_assert(str1 != d2);
-            resip_assert(d2 != str1);
+            assert(str1 != d2);
+            assert(d2 != str1);
          }
 
          {
@@ -1623,8 +1623,8 @@ class TestData
             std::string_view str1(d1);
 
             resip::Data d2("resip2");
-            resip_assert(str1 != d2);
-            resip_assert(d2 != str1);
+            assert(str1 != d2);
+            assert(d2 != str1);
          }
 #endif
 

--- a/rutil/test/testData.cxx
+++ b/rutil/test/testData.cxx
@@ -1497,7 +1497,7 @@ class TestData
 
          {
             std::string str1 = "resip";
-            resip::Data d1(str1);
+            Data d1(str1);
 
             assert(d1 == str1);
             assert(str1 == d1);
@@ -1506,7 +1506,7 @@ class TestData
 
          {
             std::string str1 = "resip";
-            resip::Data d1 = str1;
+            Data d1 = str1;
 
             assert(d1 == str1);
             assert(str1 == d1);
@@ -1516,45 +1516,45 @@ class TestData
 
          {
             std::string str1 = "resip";
-            resip::Data d1 = "resipr";
+            Data d1 = "resipr";
             assert(d1 != str1);
             assert(str1 != d1);
             assert(d1.toString() != str1);
 
-            resip::Data d2(std::string("resipr"));
+            Data d2(std::string("resipr"));
             assert(d2 != str1);
             assert(str1 != d2);
             assert(d2.toString() != str1);
          }
 
          {
-            resip::Data d1("resip");
+            Data d1("resip");
             std::string str1 = d1;
             assert(str1 == d1);
             assert(d1 == str1);
          }
 
          {
-            resip::Data d1("resip");
+            Data d1("resip");
             std::string str1(d1);
             assert(str1 == d1);
             assert(d1 == str1);
          }
 
          {
-            resip::Data d1("resip");
+            Data d1("resip");
             std::string str1 = d1;
 
-            resip::Data d2("resip2");
+            Data d2("resip2");
             assert(str1 != d2);
             assert(d2 != str1);
          }
 
          {
-            resip::Data d1("resip");
+            Data d1("resip");
             std::string str1(d1);
 
-            resip::Data d2("resip2");
+            Data d2("resip2");
             assert(str1 != d2);
             assert(d2 != str1);
          }
@@ -1564,7 +1564,7 @@ class TestData
 
          {
             std::string_view sv1 = "resip";
-            resip::Data d1(sv1);
+            Data d1(sv1);
 
             assert(d1 == sv1);
             assert(sv1 == d1);
@@ -1573,7 +1573,7 @@ class TestData
 
          {
             std::string_view sv1 = "resip";
-            resip::Data d1 = sv1;
+            Data d1 = sv1;
 
             assert(d1 == sv1);
             assert(sv1 == d1);
@@ -1583,46 +1583,46 @@ class TestData
 
          {
             std::string_view sv1 = "resip";
-            resip::Data d1 = "resipr";
+            Data d1 = "resipr";
             assert(d1 != sv1);
             assert(sv1 != d1);
             assert(d1.toStringView() != sv1);
 
 
-            resip::Data d2(std::string_view("resipr"));
+            Data d2(std::string_view("resipr"));
             assert(d2 != sv1);
             assert(sv1 != d2);
             assert(d2.toStringView() != sv1);
          }
 
          {
-            resip::Data d1("resip");
+            Data d1("resip");
             std::string_view str1 = d1;
             assert(str1 == d1);
             assert(d1 == str1);
          }
 
          {
-            resip::Data d1("resip");
+            Data d1("resip");
             std::string_view str1(d1);
             assert(str1 == d1);
             assert(d1 == str1);
          }
 
          {
-            resip::Data d1("resip");
+            Data d1("resip");
             std::string_view str1 = d1;
 
-            resip::Data d2("resip2");
+            Data d2("resip2");
             assert(str1 != d2);
             assert(d2 != str1);
          }
 
          {
-            resip::Data d1("resip");
+            Data d1("resip");
             std::string_view str1(d1);
 
-            resip::Data d2("resip2");
+            Data d2("resip2");
             assert(str1 != d2);
             assert(d2 != str1);
          }

--- a/rutil/test/testData.cxx
+++ b/rutil/test/testData.cxx
@@ -1559,6 +1559,40 @@ class TestData
             assert(d2 != str1);
          }
 
+         {
+            Data data("abc");
+            std::string strA = "abc";
+            std::string strB = "abcd";
+
+            // Test `<`
+            assert((data < strB) == true);
+            assert((data < strA) == false);
+
+            assert((strB < data) == false);
+            assert((strA < data) == false);
+
+            // Test `>`
+            assert((data > strB) == false);
+            assert((data > strA) == false);
+
+            assert((strB > data) == true);
+            assert((strA > data) == false);
+
+            // Test `<=`
+            assert((data <= strB) == true);
+            assert((data <= strA) == true);
+
+            assert((strB <= data) == false);
+            assert((strA <= data) == true);
+
+            // Test `>=`
+            assert((data >= strB) == false);
+            assert((data >= strA) == true);
+
+            assert((strB >= data) == true);
+            assert((strA >= data) == true);
+         }
+
 
 #if RESIP_CPP_STANDARD >= 201703L
 
@@ -1625,6 +1659,40 @@ class TestData
             Data d2("resip2");
             assert(str1 != d2);
             assert(d2 != str1);
+         }
+
+         {
+            Data data("abc");
+            std::string_view viewA = "abc";
+            std::string_view viewB = "abcd";
+
+            // Test `<`
+            assert((data < viewB) == true);
+            assert((data < viewA) == false);
+
+            assert((viewB < data) == false);
+            assert((viewA < data) == false);
+
+            // Test `>`
+            assert((data > viewB) == false);
+            assert((data > viewA) == false);
+
+            assert((viewB > data) == true);
+            assert((viewA > data) == false);
+
+            // Test `<=`
+            assert((data <= viewB) == true);
+            assert((data <= viewA) == true);
+
+            assert((viewB <= data) == false);
+            assert((viewA <= data) == true);
+
+            // Test `>=`
+            assert((data >= viewB) == false);
+            assert((data >= viewA) == true);
+
+            assert((viewB >= data) == true);
+            assert((viewA >= data) == true);
          }
 #endif
 


### PR DESCRIPTION
Add a complete set of comparison operators (<, >, <=, >=) to resip::Data for interoperability with std::string and std::string_view.
Other small improvements.