### PR TITLE
Fix windows testStack test

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,4 +32,4 @@ jobs:
           --test-dir ${{ github.workspace }}/_build
           --build-config Debug
           --output-on-failure
-          --exclude-regex "(sanityTests|testStack)"
+          --exclude-regex "(sanityTests)"

--- a/resip/stack/test/testStack.cxx
+++ b/resip/stack/test/testStack.cxx
@@ -603,7 +603,7 @@ main(int argc, char* argv[])
    const char* logLevel = "WARNING";
    const char* proto = "tcp";
    const char* bindAddr = "127.0.0.1";
-   const char* domain = "";
+   const char* domain = "resiprocate.test";
    int doListen = 1;
 
    int verbose = 0;


### PR DESCRIPTION
On Systems where `getLocalHostName` only returns a hostname without domain, the `testStack` test asserts and hangs.