### PR TITLE
Some small optimizations 

### DIFF
--- a/resip/dum/DialogSet.cxx
+++ b/resip/dum/DialogSet.cxx
@@ -76,12 +76,18 @@ DialogSet::DialogSet(const SipMessage& request, DialogUsageManager& dum) :
    mDum.mMergedRequests.insert(mMergeKey);
    if (request.header(h_RequestLine).method() == INVITE)
    {
-      if(mDum.mCancelMap.count(request.getTransactionId()) != 0)
-      {
-         WarningLog ( << "An endpoint is using the same tid in multiple INVITE requests, ability to match CANCEL requests correctly may be comprimised, tid=" << request.getTransactionId() );
-      }
       mCancelKey = request.getTransactionId();
-      mDum.mCancelMap[mCancelKey] = this;
+
+      auto it = mDum.mCancelMap.find(mCancelKey);
+      if (it != mDum.mCancelMap.end())
+      {
+         WarningLog ( << "An endpoint is using the same tid in multiple INVITE requests, ability to match CANCEL requests correctly may be comprimised, tid=" << mCancelKey );
+         it->second = this;
+      }
+      else
+      {
+         mDum.mCancelMap[mCancelKey] = this;
+      }
    }
    DebugLog ( << " ************* Created DialogSet(UAS) *************: " << mId);
 }

--- a/resip/dum/DialogUsageManager.cxx
+++ b/resip/dum/DialogUsageManager.cxx
@@ -427,7 +427,7 @@ void
 DialogUsageManager::addClientSubscriptionHandler(const Data& eventType, ClientSubscriptionHandler* handler)
 {
    resip_assert(handler);
-   resip_assert(mClientSubscriptionHandlers.count(eventType) == 0);
+   resip_assert(mClientSubscriptionHandlers.find(eventType) == mClientSubscriptionHandlers.end());
    mClientSubscriptionHandlers[eventType] = handler;
 }
 
@@ -436,11 +436,15 @@ DialogUsageManager::addServerSubscriptionHandler(const Data& eventType, ServerSu
 {
    resip_assert(handler);
    //default do-nothing server side refer handler can be replaced
-   if (eventType == "refer" && mServerSubscriptionHandlers.count(eventType))
+   if (eventType == "refer")
    {
-      delete mServerSubscriptionHandlers[eventType];
-      mIsDefaultServerReferHandler = false;
-      //mServerSubscriptionHandlers.erase(eventType);
+      auto it = mServerSubscriptionHandlers.find(eventType);
+      if (it != mServerSubscriptionHandlers.end())
+      {
+         delete it->second;
+         mIsDefaultServerReferHandler = false;
+         //mServerSubscriptionHandlers.erase(eventType);
+      }
    }
 
    mServerSubscriptionHandlers[eventType] = handler;
@@ -450,7 +454,7 @@ void
 DialogUsageManager::addClientPublicationHandler(const Data& eventType, ClientPublicationHandler* handler)
 {
    resip_assert(handler);
-   resip_assert(mClientPublicationHandlers.count(eventType) == 0);
+   resip_assert(mClientPublicationHandlers.find(eventType) == mClientPublicationHandlers.end());
    mClientPublicationHandlers[eventType] = handler;
 }
 
@@ -458,7 +462,7 @@ void
 DialogUsageManager::addServerPublicationHandler(const Data& eventType, ServerPublicationHandler* handler)
 {
    resip_assert(handler);
-   resip_assert(mServerPublicationHandlers.count(eventType) == 0);
+   resip_assert(mServerPublicationHandlers.find(eventType) == mServerPublicationHandlers.end());
    mServerPublicationHandlers[eventType] = handler;
 }
 
@@ -466,7 +470,7 @@ void
 DialogUsageManager::addOutOfDialogHandler(MethodTypes type, OutOfDialogHandler* handler)
 {
    resip_assert(handler);
-   resip_assert(mOutOfDialogHandlers.count(type) == 0);
+   resip_assert(mOutOfDialogHandlers.find(type) == mOutOfDialogHandlers.end());
    mOutOfDialogHandlers[type] = handler;
 }
 
@@ -2025,7 +2029,7 @@ DialogUsageManager::mergeRequest(const SipMessage& request)
 
    if (!request.header(h_To).exists(p_tag))
    {
-      if (mMergedRequests.count(MergedRequestKey(request, getMasterProfile()->checkReqUriInMergeDetectionEnabled())))
+      if (mMergedRequests.find(MergedRequestKey(request, getMasterProfile()->checkReqUriInMergeDetectionEnabled())) != mMergedRequests.end())
       {
          SipMessage failure;
          makeResponse(failure, request, 482, "Merged Request");

--- a/resip/dum/DialogUsageManager.hxx
+++ b/resip/dum/DialogUsageManager.hxx
@@ -501,7 +501,7 @@ class DialogUsageManager : public HandleManager, public TransactionUser
       typedef std::set<MergedRequestKey> MergedRequests;
       MergedRequests mMergedRequests;
             
-      typedef std::map<Data, DialogSet*> CancelMap;
+      typedef std::unordered_map<Data, DialogSet*> CancelMap;
       CancelMap mCancelMap;
       
       typedef HashMap<DialogSetId, DialogSet*> DialogSetMap;

--- a/resip/dum/InMemoryRegistrationDatabase.cxx
+++ b/resip/dum/InMemoryRegistrationDatabase.cxx
@@ -87,7 +87,7 @@ InMemoryRegistrationDatabase::lockRecord(const Uri& aor)
     mDatabase[aor];
   }
 
-  while (mLockedRecords.count(aor))
+  while (mLockedRecords.find(aor) != mLockedRecords.end())
   {
     mRecordUnlocked.wait(g2);
   }

--- a/resip/dum/InMemorySyncRegDb.cxx
+++ b/resip/dum/InMemorySyncRegDb.cxx
@@ -263,7 +263,7 @@ InMemorySyncRegDb::lockRecord(const Uri& aor)
       mDatabase[aor];
    }
 
-   while (mLockedRecords.count(aor))
+   while (mLockedRecords.find(aor) != mLockedRecords.end())
    {
       mRecordUnlocked.wait(g2);
    }

--- a/resip/dum/InviteSession.cxx
+++ b/resip/dum/InviteSession.cxx
@@ -3215,7 +3215,7 @@ InviteSession::sendAck(const Contents *answer)
       source = mLastLocalSessionModification;
    }
 
-   resip_assert(mAcks.count(source->getTransactionId()) == 0);
+   resip_assert(mAcks.find(source->getTransactionId()) == mAcks.end());
 
    mDialog.makeRequest(*ack, ACK);
 

--- a/resip/dum/MasterProfile.cxx
+++ b/resip/dum/MasterProfile.cxx
@@ -49,7 +49,7 @@ MasterProfile::addSupportedScheme(const Data& scheme)
 bool 
 MasterProfile::isSchemeSupported(const Data& scheme) const
 {
-   return mSupportedSchemes.count(scheme) != 0;
+   return mSupportedSchemes.find(scheme) != mSupportedSchemes.end();
 }
 
 void 
@@ -86,7 +86,7 @@ MasterProfile::removeSupportedMethod(const MethodTypes& method)
 bool 
 MasterProfile::isMethodSupported(MethodTypes method) const
 {
-   return mSupportedMethodTypes.count(method) != 0;
+   return mSupportedMethodTypes.find(method) != mSupportedMethodTypes.end();
 }
 
 Tokens 

--- a/resip/dum/Profile.cxx
+++ b/resip/dum/Profile.cxx
@@ -465,7 +465,7 @@ Profile::isAdvertisedCapability(const Headers::Type header) const
    {
        return mBaseProfile->isAdvertisedCapability(header);
    }
-   return mAdvertisedCapabilities.count(header) != 0;
+   return mAdvertisedCapabilities.find(header) != mAdvertisedCapabilities.end();
 }
 
 void 

--- a/resip/stack/BasicDomainMatcher.cxx
+++ b/resip/stack/BasicDomainMatcher.cxx
@@ -17,14 +17,14 @@ bool
 BasicDomainMatcher::isMyDomain(const Data& domain) const
 {
    // Domain search should be case insensitive - search in lowercase only
-   return mDomainList.count(Data(domain).lowercase()) > 0;
+   return mDomainList.find(Data(domain).lowercase()) != mDomainList.end();
 }
 
 void
 BasicDomainMatcher::addDomain(const Data& domain)
 {
    // Domain search should be case insensitive - store in lowercase only
-   mDomainList.insert(Data(domain).lowercase());
+   mDomainList.emplace(Data(domain).lowercase());
 }
 
 void

--- a/resip/stack/BasicDomainMatcher.hxx
+++ b/resip/stack/BasicDomainMatcher.hxx
@@ -1,6 +1,8 @@
 #if !defined(RESIP_BASICDOMAINMATCHER_HXX)
 #define RESIP_BASICDOMAINMATCHER_HXX
 
+#include <unordered_set>
+
 #include "resip/stack/DomainMatcher.hxx"
 #include "rutil/Data.hxx"
 #include "rutil/HashMap.hxx"
@@ -22,7 +24,7 @@ class BasicDomainMatcher : public DomainMatcher
 
    private:
 
-      typedef std::set<Data> DomainList;
+      typedef std::unordered_set<Data> DomainList;
       DomainList mDomainList;
 };
 

--- a/resip/stack/ContentsFactoryBase.cxx
+++ b/resip/stack/ContentsFactoryBase.cxx
@@ -6,20 +6,23 @@
 using namespace resip;
 using namespace std;
 
-HashMap<Mime, ContentsFactoryBase*>* ContentsFactoryBase::FactoryMap = 0;
+HashMap<Mime, ContentsFactoryBase*>* ContentsFactoryBase::FactoryMap = nullptr;
 
 ContentsFactoryBase::ContentsFactoryBase(const Mime& contentType)
    : mContentType(contentType)
 {
    // .amr. Due to multiple static initializers, this can be called more than once for a mimetype
    // so gracefully handle it
-   if(ContentsFactoryBase::getFactoryMap().count(contentType) == 0)
-      ContentsFactoryBase::getFactoryMap()[contentType] = this;
+   auto& factoryMap = ContentsFactoryBase::getFactoryMap();
+   if (factoryMap.find(contentType) == factoryMap.end())
+   {
+      factoryMap[contentType] = this;
+   }
 }
 
 ContentsFactoryBase::~ContentsFactoryBase()
 {
-   if (ContentsFactoryBase::FactoryMap == 0)
+   if (!ContentsFactoryBase::FactoryMap)
       return;
 	
    HashMap<Mime, ContentsFactoryBase*>::iterator i;
@@ -27,17 +30,17 @@ ContentsFactoryBase::~ContentsFactoryBase()
    // .amr.	Need to check if iterator is valid since on some STL instances erase(i) will crash if i is invalid.
    if (i != ContentsFactoryBase::getFactoryMap().end())
       ContentsFactoryBase::getFactoryMap().erase(i);
-   if (ContentsFactoryBase::getFactoryMap().size() == 0)
+   if (ContentsFactoryBase::getFactoryMap().empty())
    {
       delete &ContentsFactoryBase::getFactoryMap();
-      ContentsFactoryBase::FactoryMap = 0;
+      ContentsFactoryBase::FactoryMap = nullptr;
    }
 }
 
 HashMap<Mime, ContentsFactoryBase*>& 
 ContentsFactoryBase::getFactoryMap()
 {
-   if (ContentsFactoryBase::FactoryMap == 0)
+   if (!ContentsFactoryBase::FactoryMap)
    {
       ContentsFactoryBase::FactoryMap = new HashMap<Mime, ContentsFactoryBase*>();
    }

--- a/resip/stack/DnsInterface.cxx
+++ b/resip/stack/DnsInterface.cxx
@@ -146,14 +146,16 @@ bool
 DnsInterface::isSupported(const Data& service)
 {
    Lock lock(mSupportedMutex);
-   return mSupportedNaptrs.count(service) != 0;
+   return mSupportedNaptrs.find(service) != mSupportedNaptrs.end();
 }
 
 bool
 DnsInterface::isSupported(TransportType t, IpVersion version)
 {
+   auto ts = std::make_pair(t, version);
+
    Lock lock(mSupportedMutex);
-   return mSupportedTransports.find(std::make_pair(t, version)) != mSupportedTransports.end();
+   return mSupportedTransports.find(ts) != mSupportedTransports.end();
 }
 
 bool

--- a/resip/stack/ExtendedDomainMatcher.cxx
+++ b/resip/stack/ExtendedDomainMatcher.cxx
@@ -22,21 +22,21 @@ ExtendedDomainMatcher::isMyDomain(const Data& domain) const
       return true;
    }
 
-   // Domain search should be case insensitive - search in lowercase only
-   Data _domain(domain);
-   _domain.lowercase();
-
-   if(mDomainSuffixList.empty())
+   if (mDomainSuffixList.empty())
    {
       return false;
    }
+
+   // Domain search should be case insensitive - search in lowercase only
+   Data _domain(domain);
+   _domain.lowercase();
 
    static const Data dot(".");
    Data::size_type i = 0;
    for(i = _domain.find(dot, i); i < _domain.size() && i != Data::npos; i++)
    {
       Data _search = _domain.substr(i);
-      if(mDomainSuffixList.count(_search) > 0)
+      if (mDomainSuffixList.find(_search) != mDomainSuffixList.end())
       {
          return true;
       }
@@ -48,7 +48,7 @@ void
 ExtendedDomainMatcher::addDomainSuffix(const Data& domainSuffix)
 {
    // Domain search should be case insensitive - store in lowercase only
-   mDomainSuffixList.insert(Data(domainSuffix).lowercase());
+   mDomainSuffixList.emplace(Data(domainSuffix).lowercase());
 }
 
 void

--- a/resip/stack/ExtendedDomainMatcher.hxx
+++ b/resip/stack/ExtendedDomainMatcher.hxx
@@ -1,6 +1,8 @@
 #if !defined(RESIP_EXTENDEDDOMAINMATCHER_HXX)
 #define RESIP_EXTENDEDDOMAINMATCHER_HXX
 
+#include<unordered_set>
+
 #include "resip/stack/BasicDomainMatcher.hxx"
 #include "rutil/Data.hxx"
 #include "rutil/HashMap.hxx"
@@ -22,7 +24,7 @@ class ExtendedDomainMatcher : public BasicDomainMatcher
 
    private:
 
-      typedef std::set<Data> DomainSuffixList;
+      typedef std::unordered_set<Data> DomainSuffixList;
       DomainSuffixList mDomainSuffixList;
 };
 

--- a/resip/stack/SipStack.cxx
+++ b/resip/stack/SipStack.cxx
@@ -531,7 +531,7 @@ SipStack::addTransport(std::unique_ptr<Transport> transport)
                transport->netNs());
    if(!isSecure(transport->transport()))
    {
-      if(mNonSecureTransports.count(tuple) == 0)
+      if(mNonSecureTransports.find(tuple) == mNonSecureTransports.end())
       {
          // All is good - assign key to transport then add to mNonSecureTransports list
          transport->setKey(mNextTransportKey++);
@@ -549,7 +549,7 @@ SipStack::addTransport(std::unique_ptr<Transport> transport)
    else
    {
       TransportSelector::TlsTransportKey tlsKey(transport->tlsDomain(), tuple);
-      if(mSecureTransports.count(tlsKey) == 0)
+      if(mSecureTransports.find(tlsKey) == mSecureTransports.end())
       {
          // All is good - assign key to transport then add to mNonSecureTransports list
          transport->setKey(mNextTransportKey++);
@@ -839,16 +839,18 @@ SipStack::getHostAddress()
 bool
 SipStack::isMyDomain(const Data& domain, int port) const
 {
+   auto key = domain + ":" +
+      Data(port == 0 ? Symbols::DefaultSipPort : port);
+
    Lock lock(mDomainsMutex);
-   return (mDomains.count(domain + ":" +
-                          Data(port == 0 ? Symbols::DefaultSipPort : port)) != 0);
+   return mDomains.find(key) != mDomains.end();
 }
 
 bool
 SipStack::isMyPort(int port) const
 {
    Lock lock(mPortsMutex);
-   return mPorts.count(port) != 0;
+   return mPorts.find(port) != mPorts.end();
 }
 
 const Uri&

--- a/resip/stack/SipStack.hxx
+++ b/resip/stack/SipStack.hxx
@@ -1213,7 +1213,7 @@ class SipStack : public FdSetIOObserver
       /** @brief store all domains that this stack is responsible for.
           @note Controlled by addAlias and addTransport interface
           and checks can be made with isMyDomain() */
-      typedef std::map<Data, unsigned int> DomainsMap;
+      typedef std::unordered_map<Data, unsigned int> DomainsMap;
       DomainsMap mDomains;  // Second item (unsigned int) is for reference counting
       Uri mUri;
       mutable Mutex mDomainsMutex;  // Protects both mDomains and mUri, since they are related

--- a/resip/stack/ssl/Security.cxx
+++ b/resip/stack/ssl/Security.cxx
@@ -1615,8 +1615,8 @@ BaseSecurity::sign(const Data& senderAor, Contents* contents)
    resip_assert(chain);
 
    DebugLog( << "searching for cert/key for <" << senderAor << ">" );
-   if (mUserCerts.count(senderAor) == 0 ||
-       mUserPrivateKeys.count(senderAor) == 0)
+   if (mUserCerts.find(senderAor) == mUserCerts.end() ||
+       mUserPrivateKeys.find(senderAor) == mUserPrivateKeys.end())
    {
       BIO_free(in);
       BIO_free(out);
@@ -1725,7 +1725,7 @@ BaseSecurity::encrypt(Contents* bodyIn, const Data& recipCertName )
    DebugLog( << "created out BIO" );
 
    InfoLog( << "target cert name is <" << recipCertName << ">" );
-   if (mUserCerts.count(recipCertName) == 0)
+   if (mUserCerts.find(recipCertName) == mUserCerts.end())
    {
       BIO_free(in);
       BIO_free(out);
@@ -2062,7 +2062,7 @@ BaseSecurity::decrypt( const Data& decryptorAor, const Pkcs7Contents* contents)
 
       case NID_pkcs7_enveloped:
       {
-         if (mUserPrivateKeys.count(decryptorAor) == 0)
+         if (mUserPrivateKeys.find(decryptorAor) == mUserPrivateKeys.end())
          {
             BIO_free(in);
             BIO_free(out);
@@ -2071,7 +2071,7 @@ BaseSecurity::decrypt( const Data& decryptorAor, const Pkcs7Contents* contents)
             InfoLog( << "Don't have a private key for " << decryptorAor << " for  PKCS7_decrypt" );
             throw Exception("Missing private key", __FILE__, __LINE__);
          }
-         else if (mUserCerts.count(decryptorAor) == 0)
+         else if (mUserCerts.find(decryptorAor) == mUserCerts.end())
          {
             BIO_free(in);
             BIO_free(out);
@@ -2306,7 +2306,7 @@ BaseSecurity::checkSignature(MultipartSignedContents* multi,
    }
    else
    {
-      if (mUserCerts.count( *signedBy ))
+      if (mUserCerts.find( *signedBy ) != mUserCerts.end())
       {
          InfoLog( <<"Adding cert from " <<  *signedBy << " to check sig" );
          X509* cert = mUserCerts[ *signedBy ];
@@ -2996,25 +2996,45 @@ BaseSecurity::dumpAsn(const char* name, Data data)
 X509*     
 BaseSecurity::getDomainCert( const Data& domain )
 {
-   return mDomainCerts.count(domain) ? mDomainCerts[domain] : 0;
+   auto it = mDomainCerts.find(domain);
+   if (it != mDomainCerts.end())
+   {
+      return it->second;
+   }
+   return nullptr;
 }
 
 X509*     
 BaseSecurity::getUserCert( const Data& aor )
 {
-   return mUserCerts.count(aor) ? mUserCerts[aor] : 0;
+   auto it = mUserCerts.find(aor);
+   if (it != mUserCerts.end())
+   {
+      return it->second;
+   }
+   return nullptr;
 }
 
 EVP_PKEY* 
 BaseSecurity::getDomainKey(  const Data& domain )
 {
-   return mDomainPrivateKeys.count(domain) ? mDomainPrivateKeys[domain] : 0;
+   auto it = mDomainPrivateKeys.find(domain);
+   if (it != mDomainPrivateKeys.end())
+   {
+      return it->second;
+   }
+   return nullptr;
 }
 
 EVP_PKEY*
 BaseSecurity::getUserPrivateKey( const Data& aor )
 {
-   return mUserPrivateKeys.count(aor) ? mUserPrivateKeys[aor] : 0;
+   auto it = mUserPrivateKeys.find(aor);
+   if (it != mUserPrivateKeys.end())
+   {
+      return it->second;
+   }
+   return nullptr;
 }
 
 void

--- a/rutil/HeapInstanceCounter.cxx
+++ b/rutil/HeapInstanceCounter.cxx
@@ -89,11 +89,11 @@ HeapInstanceCounter::deallocate(void* addr,
       // WarningLog(<< "deallocated " << ti.name());
       Lock l(allocationMutex);
       const Data name(Data::Share, ti.name(), strlen(ti.name()));
-      if (allocationMap.count(name) != 0)
+      if (allocationMap.find(name) != allocationMap.end())
       {
          InstanceCounts &counts = allocationMap[name];
 
-         if (counts.allocationSizes.count(addr) != 0)
+         if (counts.allocationSizes.find(addr) != counts.allocationSizes.end())
          {
             counts.outstanding -= 1;
             counts.totalBytesOutstanding -= counts.allocationSizes[addr];


### PR DESCRIPTION
- Replace set with unordered_set in BasicDomainMatcher and ExtendedDomainMatcher.
- Use find() instead of count() for element existence checks in STL containers.
- Optimize locking in DnsInterface::isSupported().
- Early return in ExtendedDomainMatcher::isMyDomain() when mDomainSuffixList is empty, preventing unnecessary domain case conversions.