### PR TITLE
Improve logs in DUM for easier tracking error

### DIFF
--- a/resip/dum/ClientInviteSession.cxx
+++ b/resip/dum/ClientInviteSession.cxx
@@ -771,8 +771,8 @@ ClientInviteSession::dispatchStart (const SipMessage& msg)
       case On2xx:
       {
          sendAck();
-         sendBye();
          InfoLog (<< "Failure:  2xx with no answer: " << msg.brief());
+         sendBye();
          transition(Terminated);
          onFailureAspect(getHandle(), msg);
          handler->onTerminated(getSessionHandle(), InviteSessionHandler::Error, &msg);


### PR DESCRIPTION
In ClientInviteSession::dispatchStart, case On2xx:, moving the log statement above the sendBye(); Currently placing the log after sendBye can lead to confusion, as it makes it unclear why the BYE was sent unless we continue checking later logs.

Typically, when troubleshooting, we focus on the logs which are before the event, so having the log before the sendBye() call provides better context and clarity.