### PR TITLE
rutil: fix Data::npos incompatibility with std::string and string_view

### DIFF
--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -26,7 +26,7 @@ using namespace resip;
 using namespace std;
 
 const Data Data::Empty("", 0);
-const Data::size_type Data::npos = UINT_MAX;
+const Data::size_type Data::npos = std::string::npos;
 
 Data::PreallocateType::PreallocateType(int)
 {}

--- a/rutil/test/testData.cxx
+++ b/rutil/test/testData.cxx
@@ -1700,6 +1700,14 @@ class TestData
          }
 #endif
 
+         {
+            assert(Data::npos == std::string::npos);
+
+#if RESIP_HAVE_STRING_VIEW
+            assert(Data::npos == std::string_view::npos);
+#endif
+         }
+
          std::cerr << "All OK" << endl;
          return 0;
       }


### PR DESCRIPTION
Commit 495defc changed `Data::npos` type from `uint32_t` to `size_t`, but it remained initialized with `UINT_MAX`. This caused equivalence checks with `std::string::npos` and `std::string_view::npos` to fail.

Now `Data::npos` is initialized with `std::string::npos` for correct compatibility.