### PR TITLE
Allow to reject calls with a body content.

### DIFF
--- a/resip/dum/ServerInviteSession.cxx
+++ b/resip/dum/ServerInviteSession.cxx
@@ -635,6 +635,14 @@ ServerInviteSession::reject(int code, WarningCategory *warning)
          // we should send 200PRACK
          auto response = std::make_shared<SipMessage>();
          mDialog.makeResponse(*response, mFirstRequest, code);
+         if (mProposedLocalOfferAnswer)
+         {
+            setOfferAnswer(*response, mProposedLocalOfferAnswer.get());
+         }
+         else if (mCurrentLocalOfferAnswer)
+         {
+            setOfferAnswer(*response, mCurrentLocalOfferAnswer.get());
+         }
          if(warning)
          {
             response->header(h_Warnings).push_back(*warning);


### PR DESCRIPTION
3GPP TS 24 229 describes the possibility of including a multipart/mixed body in 486 (Busy Here), 600 (Busy Everywhere) or 603 (Decline) response to the INVITE request.