### PR TITLE
Added a reject method with a Contents object.

### DIFF
--- a/resip/dum/ClientInviteSession.cxx
+++ b/resip/dum/ClientInviteSession.cxx
@@ -266,6 +266,11 @@ ClientInviteSession::reject (int statusCode, WarningCategory *warning)
       {
          auto response = std::make_shared<SipMessage>();
          mDialog.makeResponse(*response, *mLastRemoteSessionModification, statusCode);
+         // In case we wanted to reject the request by including content
+         if (mProposedLocalReject)
+         {
+            response->setContents(mProposedLocalReject.get());
+         }
          if(warning)
          {
             response->header(h_Warnings).push_back(*warning);
@@ -303,6 +308,13 @@ ClientInviteSession::reject (int statusCode, WarningCategory *warning)
          InviteSession::reject(statusCode, warning);
          break;
    }
+}
+
+void
+ClientInviteSession::reject (int code, const Contents& rejectBody, WarningCategory *warning)
+{
+   mProposedLocalReject = std::unique_ptr<Contents>(rejectBody.clone());
+   reject(code, warning);
 }
 
 void

--- a/resip/dum/ClientInviteSession.cxx
+++ b/resip/dum/ClientInviteSession.cxx
@@ -311,7 +311,7 @@ ClientInviteSession::reject (int statusCode, const Contents* contents, WarningCa
          break;
 
       default:
-         InviteSession::reject(statusCode, warning);
+         InviteSession::reject(statusCode, contents, warning);
          break;
    }
 }

--- a/resip/dum/ClientInviteSession.cxx
+++ b/resip/dum/ClientInviteSession.cxx
@@ -258,6 +258,12 @@ ClientInviteSession::end(EndReason reason)
 void
 ClientInviteSession::reject (int statusCode, WarningCategory *warning)
 {
+   reject(statusCode, nullptr, warning);
+}
+
+void
+ClientInviteSession::reject (int statusCode, const Contents* contents, WarningCategory *warning)
+{
    InfoLog (<< toData(mState) << ": reject(" << statusCode << ")");
 
    switch(mState)
@@ -267,9 +273,9 @@ ClientInviteSession::reject (int statusCode, WarningCategory *warning)
          auto response = std::make_shared<SipMessage>();
          mDialog.makeResponse(*response, *mLastRemoteSessionModification, statusCode);
          // In case we wanted to reject the request by including content
-         if (mProposedLocalReject)
+         if (contents)
          {
-            response->setContents(mProposedLocalReject.get());
+            response->setContents(contents);
          }
          if(warning)
          {
@@ -308,13 +314,6 @@ ClientInviteSession::reject (int statusCode, WarningCategory *warning)
          InviteSession::reject(statusCode, warning);
          break;
    }
-}
-
-void
-ClientInviteSession::reject (int code, const Contents& rejectBody, WarningCategory *warning)
-{
-   mProposedLocalReject = std::unique_ptr<Contents>(rejectBody.clone());
-   reject(code, warning);
 }
 
 void

--- a/resip/dum/ClientInviteSession.hxx
+++ b/resip/dum/ClientInviteSession.hxx
@@ -48,7 +48,7 @@ class ClientInviteSession : public InviteSession
           this typically only makes sense, when rejecting an UPDATE request
           that contains an offer in an early dialog. */
       void reject (int statusCode, WarningCategory *warning = nullptr) override;
-      void reject (int statusCode, const Contents& rejectBody, WarningCategory *warning = 0) override;
+      void reject (int statusCode, const Contents* contents, WarningCategory *warning = 0) override;
 
       const Contents& getEarlyMedia() const;
       

--- a/resip/dum/ClientInviteSession.hxx
+++ b/resip/dum/ClientInviteSession.hxx
@@ -48,6 +48,7 @@ class ClientInviteSession : public InviteSession
           this typically only makes sense, when rejecting an UPDATE request
           that contains an offer in an early dialog. */
       void reject (int statusCode, WarningCategory *warning = nullptr) override;
+      void reject (int statusCode, const Contents& rejectBody, WarningCategory *warning = 0) override;
 
       const Contents& getEarlyMedia() const;
       

--- a/resip/dum/InviteSession.cxx
+++ b/resip/dum/InviteSession.cxx
@@ -856,6 +856,7 @@ InviteSession::reject(int statusCode, const Contents* contents, WarningCategory 
          break;
    }
 }
+
 class InviteSessionRejectCommand : public DumCommandAdapter
 {
 public:

--- a/resip/dum/InviteSession.cxx
+++ b/resip/dum/InviteSession.cxx
@@ -822,6 +822,11 @@ InviteSession::reject(int statusCode, WarningCategory *warning)
 
          auto response = std::make_shared<SipMessage>();
          mDialog.makeResponse(*response, *mLastRemoteSessionModification, statusCode);
+         // In case we wanted to reject the request by including content
+         if (mProposedLocalReject)
+         {
+            response->setContents(mProposedLocalReject.get());
+         }
          if(warning)
          {
             response->header(h_Warnings).push_back(*warning);
@@ -846,6 +851,12 @@ InviteSession::reject(int statusCode, WarningCategory *warning)
    }
 }
 
+void 
+InviteSession::reject(int code, const Contents& rejectBody, WarningCategory *warning)
+{
+   mProposedLocalReject = std::unique_ptr<Contents>(rejectBody.clone());
+   reject(code, warning);
+}
 class InviteSessionRejectCommand : public DumCommandAdapter
 {
 public:

--- a/resip/dum/InviteSession.hxx
+++ b/resip/dum/InviteSession.hxx
@@ -77,6 +77,7 @@ class InviteSession : public DialogUsage
       /** Rejects an offer at the SIP level.  Can also be used to 
           send a 488 to a reINVITE or UPDATE */
       virtual void reject(int statusCode, WarningCategory *warning = 0);
+      virtual void reject(int statusCode, const Contents& rejectBody, WarningCategory *warning = 0);
 
       /** will send a reINVITE (current offerAnswer) or UPDATE with new Contact header */
       /** currently only supported when in the Connected state, UAC_Early states are allowed by RFC but not yet supported */
@@ -371,6 +372,8 @@ class InviteSession : public DialogUsage
       State mState;
       NitState mNitState;
       NitState mServerNitState;
+
+      std::unique_ptr<Contents> mProposedLocalReject;        // This get set when we send a reject to the remote end
 
       std::unique_ptr<Contents> mCurrentLocalOfferAnswer;    // This gets set with mProposedLocalOfferAnswer after we receive an SDP answer from the remote end or when we send and SDP answer to the remote end
       std::unique_ptr<Contents> mProposedLocalOfferAnswer;   // This get set when we send an offer to the remote end

--- a/resip/dum/InviteSession.hxx
+++ b/resip/dum/InviteSession.hxx
@@ -77,7 +77,7 @@ class InviteSession : public DialogUsage
       /** Rejects an offer at the SIP level.  Can also be used to 
           send a 488 to a reINVITE or UPDATE */
       virtual void reject(int statusCode, WarningCategory *warning = 0);
-      virtual void reject(int statusCode, const Contents& rejectBody, WarningCategory *warning = 0);
+      virtual void reject(int statusCode, const Contents* contents, WarningCategory *warning = 0);
 
       /** will send a reINVITE (current offerAnswer) or UPDATE with new Contact header */
       /** currently only supported when in the Connected state, UAC_Early states are allowed by RFC but not yet supported */
@@ -137,6 +137,7 @@ class InviteSession : public DialogUsage
       /** Asynchronously rejects an offer at the SIP level.  Can also be used to
           send a 488 to a reINVITE or UPDATE */
       virtual void rejectCommand(int statusCode, WarningCategory *warning = 0);
+      virtual void rejectCommand(int statusCode, const Contents* contents, WarningCategory *warning = 0);
       virtual void referCommand(const NameAddr& referTo, bool referSub = true);
       virtual void referCommand(const NameAddr& referTo, InviteSessionHandle sessionToReplace, bool referSub = true);
       virtual void infoCommand(const Contents& contents);
@@ -372,8 +373,6 @@ class InviteSession : public DialogUsage
       State mState;
       NitState mNitState;
       NitState mServerNitState;
-
-      std::unique_ptr<Contents> mProposedLocalReject;        // This get set when we send a reject to the remote end
 
       std::unique_ptr<Contents> mCurrentLocalOfferAnswer;    // This gets set with mProposedLocalOfferAnswer after we receive an SDP answer from the remote end or when we send and SDP answer to the remote end
       std::unique_ptr<Contents> mProposedLocalOfferAnswer;   // This get set when we send an offer to the remote end

--- a/resip/dum/ServerInviteSession.cxx
+++ b/resip/dum/ServerInviteSession.cxx
@@ -600,6 +600,12 @@ ServerInviteSession::end(EndReason reason)
 void 
 ServerInviteSession::reject(int code, WarningCategory *warning)
 {
+   reject(code, nullptr, warning);
+}
+
+void 
+ServerInviteSession::reject(int code, const Contents* contents, WarningCategory *warning)
+{
    InfoLog (<< toData(mState) << ": reject(" << code << ")");
 
    switch (mState)
@@ -636,9 +642,9 @@ ServerInviteSession::reject(int code, WarningCategory *warning)
          auto response = std::make_shared<SipMessage>();
          mDialog.makeResponse(*response, mFirstRequest, code);
          // In case we wanted to reject the request by including content
-         if (mProposedLocalReject)
+         if (contents)
          {
-            response->setContents(mProposedLocalReject.get());
+            response->setContents(contents);
          }
          if(warning)
          {
@@ -669,13 +675,6 @@ ServerInviteSession::reject(int code, WarningCategory *warning)
          InviteSession::reject(code);
          break;
    }
-}
-
-void 
-ServerInviteSession::reject(int code, const Contents& rejectBody, WarningCategory *warning)
-{
-   mProposedLocalReject = std::unique_ptr<Contents>(rejectBody.clone());
-   reject(code, warning);
 }
 
 void 

--- a/resip/dum/ServerInviteSession.cxx
+++ b/resip/dum/ServerInviteSession.cxx
@@ -635,6 +635,11 @@ ServerInviteSession::reject(int code, WarningCategory *warning)
          // we should send 200PRACK
          auto response = std::make_shared<SipMessage>();
          mDialog.makeResponse(*response, mFirstRequest, code);
+         // In case we wanted to reject the request by including content
+         if (mProposedLocalReject)
+         {
+            response->setContents(mProposedLocalReject.get());
+         }
          if(warning)
          {
             response->header(h_Warnings).push_back(*warning);
@@ -664,6 +669,13 @@ ServerInviteSession::reject(int code, WarningCategory *warning)
          InviteSession::reject(code);
          break;
    }
+}
+
+void 
+ServerInviteSession::reject(int code, const Contents& rejectBody, WarningCategory *warning)
+{
+   mProposedLocalReject = std::unique_ptr<Contents>(rejectBody.clone());
+   reject(code, warning);
 }
 
 void 

--- a/resip/dum/ServerInviteSession.cxx
+++ b/resip/dum/ServerInviteSession.cxx
@@ -672,7 +672,7 @@ ServerInviteSession::reject(int code, const Contents* contents, WarningCategory 
          break;
 
       default:
-         InviteSession::reject(code);
+         InviteSession::reject(code, contents, warning);
          break;
    }
 }

--- a/resip/dum/ServerInviteSession.hxx
+++ b/resip/dum/ServerInviteSession.hxx
@@ -60,6 +60,7 @@ class ServerInviteSession: public InviteSession
       /** Rejects an offer at the SIP level. So this can send a 488 to a
           reINVITE or UPDATE */
       virtual void reject(int statusCode, WarningCategory *warning = 0);
+      virtual void reject(int statusCode, const Contents& rejectBody, WarningCategory *warning = 0);
 
       /** accept an initial invite (2xx) - this is only applicable to the UAS */
       void accept(int statusCode=200);

--- a/resip/dum/ServerInviteSession.hxx
+++ b/resip/dum/ServerInviteSession.hxx
@@ -60,7 +60,7 @@ class ServerInviteSession: public InviteSession
       /** Rejects an offer at the SIP level. So this can send a 488 to a
           reINVITE or UPDATE */
       virtual void reject(int statusCode, WarningCategory *warning = 0);
-      virtual void reject(int statusCode, const Contents& rejectBody, WarningCategory *warning = 0);
+      virtual void reject(int statusCode, const Contents* contents, WarningCategory *warning = 0);
 
       /** accept an initial invite (2xx) - this is only applicable to the UAS */
       void accept(int statusCode=200);

--- a/tfm/tfdum/TestInviteSession.cxx
+++ b/tfm/tfdum/TestInviteSession.cxx
@@ -53,7 +53,7 @@ CommonAction*
 TestInviteSession::reject(int statusCode, resip::WarningCategory* warning)
 {
    return new CommonAction(mUa, "InviteSession::reject",
-                           std::bind(&InviteSession::reject, std::bind<InviteSession*>(static_cast<InviteSession*(InviteSessionHandle::*)()>(&InviteSessionHandle::get), std::ref(mSessionHandle)),
+                           std::bind(static_cast<void (resip::InviteSession::*)(int, resip::WarningCategory*)>(&InviteSession::reject), std::bind<InviteSession*>(static_cast<InviteSession*(InviteSessionHandle::*)()>(&InviteSessionHandle::get), std::ref(mSessionHandle)),
                                        statusCode, warning));
 }
  
@@ -302,7 +302,7 @@ CommonAction*
 TestClientInviteSession::reject(int statusCode, resip::WarningCategory* warning)
 {
    return new CommonAction(mUa, "ClientInviteSession::reject",
-                           std::bind(&ClientInviteSession::reject, std::bind<ClientInviteSession*>(static_cast<ClientInviteSession*(ClientInviteSessionHandle::*)()>(&ClientInviteSessionHandle::get), std::ref(mHandle)),
+                           std::bind(static_cast<void (resip::ClientInviteSession::*)(int, resip::WarningCategory*)>(&ClientInviteSession::reject), std::bind<ClientInviteSession*>(static_cast<ClientInviteSession*(ClientInviteSessionHandle::*)()>(&ClientInviteSessionHandle::get), std::ref(mHandle)),
                                        statusCode, warning));
 }
 
@@ -384,7 +384,7 @@ CommonAction*
 TestServerInviteSession::reject(int statusCode, resip::WarningCategory* warning)
 {
    return new CommonAction(mUa, "ServerInviteSession::reject",
-                           std::bind(&ServerInviteSession::reject, std::bind<ServerInviteSession*>(static_cast<ServerInviteSession*(ServerInviteSessionHandle::*)()>(&ServerInviteSessionHandle::get), std::ref(mHandle)),
+                           std::bind(static_cast<void (resip::ServerInviteSession::*)(int, resip::WarningCategory*)>(&ServerInviteSession::reject), std::bind<ServerInviteSession*>(static_cast<ServerInviteSession*(ServerInviteSessionHandle::*)()>(&ServerInviteSessionHandle::get), std::ref(mHandle)),
                                        statusCode, warning));
 }
  


### PR DESCRIPTION
This method allows you to include a body in a reject response without affecting the DUM offer/answer state machine. 