### PR TITLE
Fix test crashes in release builds

### DIFF
--- a/resip/dum/test/testPubDocument.cxx
+++ b/resip/dum/test/testPubDocument.cxx
@@ -96,7 +96,8 @@ int main(int argc, const char* argv[])
     XMLCursor xml(pb);
 
     PublicationPersistenceManager::PubDocument reconstituted;
-    assert(reconstituted.deserialize(xml));
+    bool deserialize_res = reconstituted.deserialize(xml);
+    assert(deserialize_res);
 
     assert(reconstituted.mETag == eTag);
     assert(reconstituted.mEventType == eventType);

--- a/resip/stack/test/testSipMessage.cxx
+++ b/resip/stack/test/testSipMessage.cxx
@@ -2048,7 +2048,8 @@ main(int argc, char** argv)
 
       unique_ptr<SipMessage> message(TestSupport::makeMessage(txt));
 
-      assert(message->header(h_MaxForwards).value() == 8);
+      H_MaxForwards::Type& max_forwards = message->header(h_MaxForwards); // creates ParserContainer, must be outside assert()
+      assert(max_forwards.value() == 8);
       message->getRawHeader(Headers::MaxForwards)->getParserContainer()->encode(Headers::getHeaderName(Headers::MaxForwards), resipCerr) << endl;
    }
 


### PR DESCRIPTION
Tests `testSipMessage` and `testPubDocument` execute essential operations as part of their `assert()` expressions. In release builds, when `NDEBUG` is defined, asserts are stripped, which makes the following code invalid.

Move essential operations out of assert expressions.

This addresses the first part of the problem in https://github.com/resiprocate/resiprocate/issues/423.