### PR TITLE
Update for Asio 1.34 and later compatibility

### DIFF
--- a/reTurn/AsyncSocketBase.cxx
+++ b/reTurn/AsyncSocketBase.cxx
@@ -14,7 +14,7 @@ using namespace std;
 
 namespace reTurn {
 
-AsyncSocketBase::AsyncSocketBase(asio::io_service& ioService) : 
+AsyncSocketBase::AsyncSocketBase(asio::io_context& ioService) : 
   mIOService(ioService),
   mReceiving(false),
   mConnected(false),
@@ -31,7 +31,7 @@ void
 AsyncSocketBase::send(const StunTuple& destination, const std::shared_ptr<DataBuffer>& data)
 {
    shared_ptr<AsyncSocketBase> _this = shared_from_this();
-   mIOService.dispatch(std::bind([_this, destination, data](){
+   asio::dispatch(mIOService, std::bind([_this, destination, data](){
 	   _this->doSend(destination, data, 0);
    }));
 }
@@ -40,7 +40,7 @@ void
 AsyncSocketBase::send(const StunTuple& destination, unsigned short channel, const std::shared_ptr<DataBuffer>& data)
 {
    shared_ptr<AsyncSocketBase> _this = shared_from_this();
-   mIOService.dispatch(std::bind([_this, destination, channel, data](){
+   asio::dispatch(mIOService, std::bind([_this, destination, channel, data](){
       _this->doSend(destination, channel, data, 0);
    }));
 }
@@ -113,7 +113,7 @@ AsyncSocketBase::sendFirstQueuedData()
 void 
 AsyncSocketBase::receive()
 {
-   mIOService.post(std::bind(&AsyncSocketBase::doReceive, shared_from_this()));
+   asio::post(mIOService, std::bind(&AsyncSocketBase::doReceive, shared_from_this()));
 }
 
 void
@@ -130,7 +130,7 @@ AsyncSocketBase::doReceive()
 void 
 AsyncSocketBase::framedReceive()
 {
-   mIOService.post(std::bind(&AsyncSocketBase::doFramedReceive, shared_from_this()));
+   asio::post(mIOService, std::bind(&AsyncSocketBase::doFramedReceive, shared_from_this()));
 }
 
 void
@@ -165,7 +165,7 @@ AsyncSocketBase::handleReceive(const asio::error_code& e, const size_t bytesTran
 void 
 AsyncSocketBase::close()
 {
-   mIOService.post(std::bind(&AsyncSocketBase::transportClose, shared_from_this()));
+   asio::post(mIOService, std::bind(&AsyncSocketBase::transportClose, shared_from_this()));
 }
 
 std::shared_ptr<DataBuffer>  

--- a/reTurn/AsyncSocketBase.hxx
+++ b/reTurn/AsyncSocketBase.hxx
@@ -29,7 +29,7 @@ class AsyncSocketBase :
 public:
    using BeforeClosedHandler = std::function<void(unsigned int)>;
 
-   explicit AsyncSocketBase(asio::io_service& ioService);
+   explicit AsyncSocketBase(asio::io_context& ioService);
    virtual ~AsyncSocketBase();
 
    virtual unsigned int getSocketDescriptor() = 0;
@@ -76,18 +76,18 @@ public:
    virtual void stop() { resip_assert(false); }
    virtual void handleReadHeader(const asio::error_code& e) { resip_assert(false); }
    virtual void handleServerHandshake(const asio::error_code& e) { resip_assert(false); }
-   virtual void handleTcpResolve(const asio::error_code& ec, asio::ip::tcp::resolver::iterator endpoint_iterator) { resip_assert(false); }
-   virtual void handleUdpResolve(const asio::error_code& ec, asio::ip::udp::resolver::iterator endpoint_iterator) { resip_assert(false); }
-   virtual void handleConnect(const asio::error_code& ec, asio::ip::tcp::resolver::iterator endpoint_iterator) { resip_assert(false); }
-   virtual void handleClientHandshake(const asio::error_code& ec, asio::ip::tcp::resolver::iterator endpoint_iterator) { resip_assert(false); }
+   virtual void handleTcpResolve(const asio::error_code& ec, const asio::ip::tcp::resolver::results_type& endpoints) { resip_assert(false); }
+   virtual void handleUdpResolve(const asio::error_code& ec, const asio::ip::udp::resolver::results_type& endpoints) { resip_assert(false); }
+   virtual void handleConnect(const asio::error_code& ec, const asio::ip::tcp::endpoint& endpoint) { resip_assert(false); }
+   virtual void handleClientHandshake(const asio::error_code& ec, const asio::ip::tcp::endpoint& endpoint) { resip_assert(false); }
 
 protected:
    /// Handle completion of a sendData operation.
    virtual void handleSend(const asio::error_code& e);
    virtual void handleReceive(const asio::error_code& e, size_t bytesTransferred);
 
-   /// The io_service used to perform asynchronous operations.
-   asio::io_service& mIOService;
+   /// The io_context used to perform asynchronous operations.
+   asio::io_context& mIOService;
 
    /// Receive Buffer and state
    std::shared_ptr<DataBuffer> mReceiveBuffer;

--- a/reTurn/AsyncTcpSocketBase.hxx
+++ b/reTurn/AsyncTcpSocketBase.hxx
@@ -13,7 +13,7 @@ namespace reTurn {
 class AsyncTcpSocketBase : public AsyncSocketBase
 {
 public:
-   explicit AsyncTcpSocketBase(asio::io_service& ioService);
+   explicit AsyncTcpSocketBase(asio::io_context& ioService);
 
    unsigned int getSocketDescriptor() override;
 
@@ -31,8 +31,8 @@ public:
 
 protected:
    void handleReadHeader(const asio::error_code& e) override;
-   void handleTcpResolve(const asio::error_code& ec, asio::ip::tcp::resolver::iterator endpoint_iterator) override;
-   void handleConnect(const asio::error_code& ec, asio::ip::tcp::resolver::iterator endpoint_iterator) override;
+   void handleTcpResolve(const asio::error_code& ec, const asio::ip::tcp::resolver::results_type& endpoints) override;
+   void handleConnect(const asio::error_code& ec, const asio::ip::tcp::endpoint& endpoint) override;
 
    asio::ip::tcp::socket mSocket;
    asio::ip::tcp::resolver mResolver;

--- a/reTurn/AsyncTlsSocketBase.hxx
+++ b/reTurn/AsyncTlsSocketBase.hxx
@@ -17,7 +17,7 @@ namespace reTurn {
 class AsyncTlsSocketBase : public AsyncSocketBase
 {
 public:
-   AsyncTlsSocketBase(asio::io_service& ioService, asio::ssl::context& context, bool validateServerCertificateHostname);
+   AsyncTlsSocketBase(asio::io_context& ioService, asio::ssl::context& context, bool validateServerCertificateHostname);
 
    unsigned int getSocketDescriptor() override;
 
@@ -37,9 +37,9 @@ public:
 protected:
    void handleReadHeader(const asio::error_code& e) override;
    void handleServerHandshake(const asio::error_code& e) override;
-   void handleTcpResolve(const asio::error_code& ec, asio::ip::tcp::resolver::iterator endpoint_iterator) override;
-   void handleConnect(const asio::error_code& ec, asio::ip::tcp::resolver::iterator endpoint_iterator) override;
-   void handleClientHandshake(const asio::error_code& ec, asio::ip::tcp::resolver::iterator endpoint_iterator) override;
+   void handleTcpResolve(const asio::error_code& ec, const asio::ip::tcp::resolver::results_type& endpoints) override;
+   void handleConnect(const asio::error_code& ec, const asio::ip::tcp::endpoint& endpoint) override;
+   void handleClientHandshake(const asio::error_code& ec, const asio::ip::tcp::endpoint& endpoint) override;
    virtual bool validateServerCertificateHostname();
 
    virtual void onServerHandshakeSuccess() { resip_assert(false); }

--- a/reTurn/AsyncUdpSocketBase.hxx
+++ b/reTurn/AsyncUdpSocketBase.hxx
@@ -13,7 +13,7 @@ namespace reTurn {
 class AsyncUdpSocketBase : public AsyncSocketBase
 {
 public:
-   explicit AsyncUdpSocketBase(asio::io_service& ioService);
+   explicit AsyncUdpSocketBase(asio::io_context& ioService);
 
    unsigned int getSocketDescriptor() override;
 
@@ -36,7 +36,7 @@ protected:
    asio::ip::udp::endpoint mSenderEndpoint;
 
    void handleUdpResolve(const asio::error_code& ec,
-                         asio::ip::udp::resolver::iterator endpoint_iterator) override;
+                         const asio::ip::udp::resolver::results_type& endpoints) override;
 
 private:
 

--- a/reTurn/ReTurnConfig.cxx
+++ b/reTurn/ReTurnConfig.cxx
@@ -43,9 +43,9 @@ ReTurnConfig::ReTurnConfig() :
    mTurnPort(3478),
    mTlsTurnPort(5349),
    mAltStunPort(0), // Note:  The default is to disable RFC3489 binding support
-   mTurnAddress(asio::ip::address::from_string("0.0.0.0")),
-   mTurnV6Address(asio::ip::address::from_string("::0")),
-   mAltStunAddress(asio::ip::address::from_string("0.0.0.0")),
+   mTurnAddress(asio::ip::make_address("0.0.0.0")),
+   mTurnV6Address(asio::ip::make_address("::0")),
+   mAltStunAddress(asio::ip::make_address("0.0.0.0")),
    mAuthenticationRealm("reTurn"),
    mUserDatabaseCheckInterval(60),
    mNonceLifetime(3600),            // 1 hour - at least 1 hours is recommended by the RFC
@@ -76,9 +76,9 @@ void ReTurnConfig::parseConfig(int argc, char** argv, const resip::Data& default
    mTurnPort = getConfigUnsignedShort("TurnPort", mTurnPort);
    mTlsTurnPort = getConfigUnsignedShort("TlsTurnPort", mTlsTurnPort);
    mAltStunPort = getConfigUnsignedShort("AltStunPort", mAltStunPort);
-   mTurnAddress = asio::ip::address::from_string(getConfigData("TurnAddress", "0.0.0.0").c_str());
-   mTurnV6Address = asio::ip::address::from_string(getConfigData("TurnV6Address", "::0").c_str());
-   mAltStunAddress = asio::ip::address::from_string(getConfigData("AltStunAddress", "0.0.0.0").c_str());
+   mTurnAddress = asio::ip::make_address(getConfigData("TurnAddress", "0.0.0.0").c_str());
+   mTurnV6Address = asio::ip::make_address(getConfigData("TurnV6Address", "::0").c_str());
+   mAltStunAddress = asio::ip::make_address(getConfigData("AltStunAddress", "0.0.0.0").c_str());
    mAuthenticationRealm = getConfigData("AuthenticationRealm", mAuthenticationRealm);
    mUserDatabaseCheckInterval = getConfigUnsignedShort("UserDatabaseCheckInterval", 60);
    mNonceLifetime = getConfigUnsignedLong("NonceLifetime", mNonceLifetime);
@@ -345,7 +345,7 @@ ReTurnConfig::getUser(const resip::Data& userName, const resip::Data& realm) con
 
 bool ReTurnUserFileScanner::mHup = false;
 
-ReTurnUserFileScanner::ReTurnUserFileScanner(asio::io_service& ioService, ReTurnConfig& reTurnConfig)
+ReTurnUserFileScanner::ReTurnUserFileScanner(asio::io_context& ioService, ReTurnConfig& reTurnConfig)
  : mLoadedTime(time(0)),
    mReTurnConfig(reTurnConfig),
    mLoopInterval(3),
@@ -368,7 +368,7 @@ ReTurnUserFileScanner::start()
 
    if(timerInterval > 0)
    {
-      mTimer.expires_from_now(seconds(timerInterval));
+      mTimer.expires_after(seconds(timerInterval));
       mTimer.async_wait(std::bind(&ReTurnUserFileScanner::timeout, this, std::placeholders::_1));
    }
 }

--- a/reTurn/ReTurnConfig.hxx
+++ b/reTurn/ReTurnConfig.hxx
@@ -99,7 +99,7 @@ private:
 class ReTurnUserFileScanner
 {
    public:
-      ReTurnUserFileScanner(asio::io_service& ioService, ReTurnConfig& reTurnConfig);
+      ReTurnUserFileScanner(asio::io_context& ioService, ReTurnConfig& reTurnConfig);
       void start();
 
    private:

--- a/reTurn/StunMessage.cxx
+++ b/reTurn/StunMessage.cxx
@@ -343,7 +343,7 @@ StunMessage::setStunAtrAddressFromTuple(StunAtrAddress& address, const StunTuple
    {
       // Note:  addr.ipv4 is stored in host byte order
       address.family = StunMessage::IPv4Family;
-      address.addr.ipv4 = tuple.getAddress().to_v4().to_ulong();
+      address.addr.ipv4 = tuple.getAddress().to_v4().to_uint();
    }
 }
 

--- a/reTurn/TcpConnection.cxx
+++ b/reTurn/TcpConnection.cxx
@@ -12,7 +12,7 @@ using namespace resip;
 
 namespace reTurn {
 
-TcpConnection::TcpConnection(asio::io_service& ioService,
+TcpConnection::TcpConnection(asio::io_context& ioService,
     ConnectionManager& manager, RequestHandler& handler)
   : AsyncTcpSocketBase(ioService),
     mConnectionManager(manager),

--- a/reTurn/TcpConnection.hxx
+++ b/reTurn/TcpConnection.hxx
@@ -19,8 +19,8 @@ class TcpConnection
   : public AsyncTcpSocketBase
 {
 public:
-   /// Construct a connection with the given io_service.
-   explicit TcpConnection(asio::io_service& ioService, ConnectionManager& manager, RequestHandler& handler);
+   /// Construct a connection with the given io_context.
+   explicit TcpConnection(asio::io_context& ioService, ConnectionManager& manager, RequestHandler& handler);
    TcpConnection(const TcpConnection&) = delete;
    TcpConnection(TcpConnection&&) = delete;
    ~TcpConnection();

--- a/reTurn/TcpServer.cxx
+++ b/reTurn/TcpServer.cxx
@@ -8,7 +8,7 @@
 
 namespace reTurn {
 
-TcpServer::TcpServer(asio::io_service& ioService, RequestHandler& requestHandler, const asio::ip::address& address, unsigned short port)
+TcpServer::TcpServer(asio::io_context& ioService, RequestHandler& requestHandler, const asio::ip::address& address, unsigned short port)
 : mIOService(ioService),
   mAcceptor(ioService),
   mConnectionManager(),

--- a/reTurn/TcpServer.hxx
+++ b/reTurn/TcpServer.hxx
@@ -20,7 +20,7 @@ public:
   TcpServer& operator=(const TcpServer&) = delete;
 
   /// Create the server to listen on the specified TCP address and port
-  explicit TcpServer(asio::io_service& ioService, RequestHandler& rqeuestHandler, const asio::ip::address& address, unsigned short port);
+  explicit TcpServer(asio::io_context& ioService, RequestHandler& rqeuestHandler, const asio::ip::address& address, unsigned short port);
 
   void start();
 
@@ -28,8 +28,8 @@ private:
   /// Handle completion of an asynchronous accept operation.
   void handleAccept(const asio::error_code& e);
 
-  /// The io_service used to perform asynchronous operations.
-  asio::io_service& mIOService;
+  /// The io_context used to perform asynchronous operations.
+  asio::io_context& mIOService;
 
   /// Acceptor used to listen for incoming connections.
   asio::ip::tcp::acceptor mAcceptor;

--- a/reTurn/TlsConnection.cxx
+++ b/reTurn/TlsConnection.cxx
@@ -22,7 +22,7 @@ using namespace resip;
 
 namespace reTurn {
 
-TlsConnection::TlsConnection(asio::io_service& ioService,
+TlsConnection::TlsConnection(asio::io_context& ioService,
                              ConnectionManager& manager, 
                              RequestHandler& handler, 
                              asio::ssl::context& context)

--- a/reTurn/TlsConnection.hxx
+++ b/reTurn/TlsConnection.hxx
@@ -23,8 +23,8 @@ class TlsConnection
   : public AsyncTlsSocketBase
 {
 public:
-  /// Construct a connection with the given io_service.
-   explicit TlsConnection(asio::io_service& ioService, ConnectionManager& manager, RequestHandler& handler, asio::ssl::context& context);
+  /// Construct a connection with the given io_context.
+   explicit TlsConnection(asio::io_context& ioService, ConnectionManager& manager, RequestHandler& handler, asio::ssl::context& context);
    TlsConnection(const TlsConnection&) = delete;
    TlsConnection(TlsConnection&&) = delete;
    ~TlsConnection();

--- a/reTurn/TlsServer.cxx
+++ b/reTurn/TlsServer.cxx
@@ -15,7 +15,7 @@
 
 namespace reTurn {
 
-TlsServer::TlsServer(asio::io_service& ioService, RequestHandler& requestHandler, const asio::ip::address& address, unsigned short port)
+TlsServer::TlsServer(asio::io_context& ioService, RequestHandler& requestHandler, const asio::ip::address& address, unsigned short port)
 : mIOService(ioService),
   mAcceptor(ioService),
   mContext(asio::ssl::context::sslv23),  // SSLv23 (actually chooses TLS version dynamically)

--- a/reTurn/TlsServer.hxx
+++ b/reTurn/TlsServer.hxx
@@ -24,7 +24,7 @@ public:
   TlsServer& operator=(const TlsServer&) = delete;
 
   /// Create the server to listen on the specified TCP address and port
-  explicit TlsServer(asio::io_service& ioService, RequestHandler& requestHandler, const asio::ip::address& address, unsigned short port);
+  explicit TlsServer(asio::io_context& ioService, RequestHandler& requestHandler, const asio::ip::address& address, unsigned short port);
 
   void start();
 
@@ -35,8 +35,8 @@ private:
   /// Callback for private key password
   std::string getPassword() const;
 
-  /// The io_service used to perform asynchronous operations.
-  asio::io_service& mIOService;
+  /// The io_context used to perform asynchronous operations.
+  asio::io_context& mIOService;
 
   /// Acceptor used to listen for incoming connections.
   asio::ip::tcp::acceptor mAcceptor;

--- a/reTurn/TurnAllocation.cxx
+++ b/reTurn/TurnAllocation.cxx
@@ -123,7 +123,7 @@ TurnAllocation::refresh(unsigned int lifetime)  // update expiration time
    mExpires = time(0) + lifetime;
 
    // start timer
-   mAllocationTimer.expires_from_now(seconds(lifetime));
+   mAllocationTimer.expires_after(seconds(lifetime));
    mAllocationTimer.async_wait(std::bind(&TurnAllocationManager::allocationExpired, &mTurnAllocationManager, std::placeholders::_1, mKey));
 }
 

--- a/reTurn/TurnManager.cxx
+++ b/reTurn/TurnManager.cxx
@@ -11,7 +11,7 @@ using namespace std;
 
 namespace reTurn {
 
-TurnManager::TurnManager(asio::io_service& ioService, const ReTurnConfig& config) : 
+TurnManager::TurnManager(asio::io_context& ioService, const ReTurnConfig& config) : 
    mLastAllocatedUdpPort(config.mAllocationPortRangeMin-1),
    mLastAllocatedTcpPort(config.mAllocationPortRangeMin-1),
    mIOService(ioService),

--- a/reTurn/TurnManager.hxx
+++ b/reTurn/TurnManager.hxx
@@ -14,10 +14,10 @@ namespace reTurn {
 class TurnManager
 {
 public:
-   explicit TurnManager(asio::io_service& ioService, const ReTurnConfig& config);  // ioService used to start timers
+   explicit TurnManager(asio::io_context& ioService, const ReTurnConfig& config);  // ioService used to start timers
    ~TurnManager();
 
-   asio::io_service& getIOService() { return mIOService; }
+   asio::io_context& getIOService() { return mIOService; }
 
    unsigned short allocateAnyPort(StunTuple::TransportType transport);
    unsigned short allocateEvenPort(StunTuple::TransportType transport);
@@ -44,7 +44,7 @@ private:
    PortAllocationMap& getPortAllocationMap(StunTuple::TransportType transport);
    unsigned short advanceLastAllocatedPort(StunTuple::TransportType transport, unsigned int numToAdvance = 1);
 
-   asio::io_service& mIOService;
+   asio::io_context& mIOService;
    const ReTurnConfig& mConfig;
 };
 

--- a/reTurn/UdpRelayServer.cxx
+++ b/reTurn/UdpRelayServer.cxx
@@ -13,7 +13,7 @@ using namespace std;
 
 namespace reTurn {
 
-UdpRelayServer::UdpRelayServer(asio::io_service& ioService, TurnAllocation& turnAllocation)
+UdpRelayServer::UdpRelayServer(asio::io_context& ioService, TurnAllocation& turnAllocation)
 : AsyncUdpSocketBase(ioService),
   mTurnAllocation(turnAllocation),
   mStopping(false),

--- a/reTurn/UdpRelayServer.hxx
+++ b/reTurn/UdpRelayServer.hxx
@@ -18,7 +18,7 @@ class UdpRelayServer
 {
 public:
    /// Create the server to listen on the specified UDP address and port
-   explicit UdpRelayServer(asio::io_service& ioService, TurnAllocation& turnAllocation);
+   explicit UdpRelayServer(asio::io_context& ioService, TurnAllocation& turnAllocation);
    UdpRelayServer(const UdpRelayServer&) = delete;
    UdpRelayServer(UdpRelayServer&&) = delete;
    ~UdpRelayServer();

--- a/reTurn/UdpServer.cxx
+++ b/reTurn/UdpServer.cxx
@@ -19,7 +19,7 @@ using namespace std::chrono;
 
 namespace reTurn {
 
-UdpServer::UdpServer(asio::io_service& ioService, RequestHandler& requestHandler, const asio::ip::address& address, unsigned short port)
+UdpServer::UdpServer(asio::io_context& ioService, RequestHandler& requestHandler, const asio::ip::address& address, unsigned short port)
 : AsyncUdpSocketBase(ioService),
   mRequestHandler(requestHandler),
   mAlternatePortUdpServer(0),
@@ -216,7 +216,7 @@ UdpServer::ResponseEntry::ResponseEntry(UdpServer* requestUdpServer, UdpServer* 
    mCleanupTimer(requestUdpServer->mIOService)
 {
    // start timer
-   mCleanupTimer.expires_from_now(seconds(10));  // Transaction Responses are cached for 10 seconds
+   mCleanupTimer.expires_after(seconds(10));  // Transaction Responses are cached for 10 seconds
    mCleanupTimer.async_wait(std::bind(&UdpServer::cleanupResponseMap, requestUdpServer, std::placeholders::_1, responseMessage->mHeader.magicCookieAndTid));
 }
 

--- a/reTurn/UdpServer.hxx
+++ b/reTurn/UdpServer.hxx
@@ -18,7 +18,7 @@ class UdpServer
 {
 public:
    /// Create the server to listen on the specified UDP address and port
-   explicit UdpServer(asio::io_service& ioService, RequestHandler& requestHandler, const asio::ip::address& address, unsigned short port);
+   explicit UdpServer(asio::io_context& ioService, RequestHandler& requestHandler, const asio::ip::address& address, unsigned short port);
    UdpServer(const UdpServer&) = delete;
    UdpServer(UdpServer&&) = delete;
    ~UdpServer();

--- a/reTurn/client/TurnAsyncSocket.cxx
+++ b/reTurn/client/TurnAsyncSocket.cxx
@@ -31,7 +31,7 @@ unsigned int TurnAsyncSocket::UnspecifiedBandwidth = 0xFFFFFFFF;
 unsigned short TurnAsyncSocket::UnspecifiedToken = 0;
 asio::ip::address TurnAsyncSocket::UnspecifiedIpAddress;
 
-TurnAsyncSocket::TurnAsyncSocket(asio::io_service& ioService, 
+TurnAsyncSocket::TurnAsyncSocket(asio::io_context& ioService,
                                  AsyncSocketBase& asyncSocketBase,
                                  TurnAsyncSocketHandler* turnAsyncSocketHandler,
                                  const asio::ip::address& address, 
@@ -67,7 +67,7 @@ TurnAsyncSocket::disableTurnAsyncHandler()
 void
 TurnAsyncSocket::requestSharedSecret()
 {
-    mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [this] { doRequestSharedSecret(); }));
+    asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [this] { doRequestSharedSecret(); }));
 }
 
 void
@@ -94,7 +94,7 @@ TurnAsyncSocket::doRequestSharedSecret()
 void
 TurnAsyncSocket::setUsernameAndPassword(const char* username, const char* password, bool shortTermAuth)
 {
-   mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSetUsernameAndPassword(new Data(username), new Data(password), shortTermAuth); }));
+   asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSetUsernameAndPassword(new Data(username), new Data(password), shortTermAuth); }));
 }
 
 void 
@@ -114,7 +114,7 @@ TurnAsyncSocket::doSetUsernameAndPassword(Data* username, Data* password, bool s
 void 
 TurnAsyncSocket::setLocalPassword(const char* password)
 {
-   mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSetLocalPassword(new Data(password)); }));
+   asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSetLocalPassword(new Data(password)); }));
 }
 
 void 
@@ -127,7 +127,7 @@ TurnAsyncSocket::doSetLocalPassword(Data* password)
 void 
 TurnAsyncSocket::bindRequest()
 {
-   mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [this] { doBindRequest(); }));
+   asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [this] { doBindRequest(); }));
 }
 
 void 
@@ -151,7 +151,7 @@ void
 TurnAsyncSocket::connectivityCheck(const StunTuple& targetAddr, uint32_t peerRflxPriority, bool setIceControlling, bool setIceControlled, unsigned int numRetransmits, unsigned int retrans_iterval_ms)
 {
    resip_assert(setIceControlling || setIceControlled);
-   mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doConnectivityCheck(new StunTuple(targetAddr.getTransportType(), targetAddr.getAddress(), targetAddr.getPort()), peerRflxPriority, setIceControlling, setIceControlled, numRetransmits, retrans_iterval_ms); }));
+   asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doConnectivityCheck(new StunTuple(targetAddr.getTransportType(), targetAddr.getAddress(), targetAddr.getPort()), peerRflxPriority, setIceControlling, setIceControlled, numRetransmits, retrans_iterval_ms); }));
 }
 
 void
@@ -182,7 +182,7 @@ TurnAsyncSocket::createAllocation(unsigned int lifetimeSecs,
                                   uint64_t reservationToken,
                                   StunTuple::TransportType requestedTransportType)
 {
-    mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doCreateAllocation(lifetimeSecs, bandwidth, requestedProps, reservationToken, requestedTransportType); }));
+    asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doCreateAllocation(lifetimeSecs, bandwidth, requestedProps, reservationToken, requestedTransportType); }));
 }
 
 void
@@ -273,7 +273,7 @@ TurnAsyncSocket::doCreateAllocation(unsigned int lifetimeSecs,
 void 
 TurnAsyncSocket::refreshAllocation(unsigned int lifetimeSecs)
 {
-   mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doRefreshAllocation(lifetimeSecs); }));
+   asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doRefreshAllocation(lifetimeSecs); }));
 }
 
 void 
@@ -311,7 +311,7 @@ TurnAsyncSocket::doRefreshAllocation(unsigned int lifetimeSecs)
 void 
 TurnAsyncSocket::destroyAllocation()
 {
-   mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [this] { doDestroyAllocation(); }));
+   asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [this] { doDestroyAllocation(); }));
 }
 
 void 
@@ -323,7 +323,7 @@ TurnAsyncSocket::doDestroyAllocation()
 void
 TurnAsyncSocket::setActiveDestination(const asio::ip::address& address, unsigned short port)
 {
-   mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSetActiveDestination(address, port); }));
+   asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSetActiveDestination(address, port); }));
 }
 
 void
@@ -375,7 +375,7 @@ void TurnAsyncSocket::doChannelBinding(RemotePeer& remotePeer)
 void
 TurnAsyncSocket::clearActiveDestination()
 {
-   mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [this] { doClearActiveDestination(); }));
+   asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [this] { doClearActiveDestination(); }));
 }
 
 void
@@ -1085,13 +1085,13 @@ TurnAsyncSocket::sendTo(const asio::ip::address& address, unsigned short port, c
 void 
 TurnAsyncSocket::sendFramed(const std::shared_ptr<DataBuffer>& data)
 {
-   mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSendFramed(data); }));
+   asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSendFramed(data); }));
 }
 
 void 
 TurnAsyncSocket::sendToFramed(const asio::ip::address& address, unsigned short port, const std::shared_ptr<DataBuffer>& data)
 {
-   mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSendToFramed(address, port, data); }));
+   asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSendToFramed(address, port, data); }));
 }
 
 void 
@@ -1171,7 +1171,7 @@ TurnAsyncSocket::sendToRemotePeer(RemotePeer& remotePeer, const std::shared_ptr<
 void
 TurnAsyncSocket::setSoftware(const char* software)
 {
-   mIOService.dispatch(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSetSoftware(new Data(software)); }));
+   asio::dispatch(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [=] { doSetSoftware(new Data(software)); }));
 }
 
 void
@@ -1201,7 +1201,7 @@ TurnAsyncSocket::connect(const std::string& address, unsigned short port)
 void
 TurnAsyncSocket::close()
 {
-   mIOService.post(weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [this] { doClose(); }));
+   asio::post(mIOService, weak_bind<AsyncSocketBase, void()>(mAsyncSocketBase.shared_from_this(), [this] { doClose(); }));
 }
 
 void
@@ -1251,7 +1251,7 @@ TurnAsyncSocket::sendOverChannel(unsigned short channel, const std::shared_ptr<D
    mAsyncSocketBase.send(destination, channel, data);
 }
 
-TurnAsyncSocket::RequestEntry::RequestEntry(asio::io_service& ioService, 
+TurnAsyncSocket::RequestEntry::RequestEntry(asio::io_context& ioService, 
                                             TurnAsyncSocket* turnAsyncSocket, 
                                             StunMessage* requestMessage,
                                             unsigned int rc,
@@ -1277,7 +1277,7 @@ TurnAsyncSocket::RequestEntry::startTimer()
 {
    //std::cout << "RequestEntry::startTimer() " << mTimeout << " " << mRequestMessage->mHeader.magicCookieAndTid << std::endl;
    // start the request timer
-   mRequestTimer.expires_from_now(milliseconds(mTimeout));  
+   mRequestTimer.expires_after(milliseconds(mTimeout));
    mRequestTimer.async_wait(weak_bind<RequestEntry, void(const asio::error_code&)>(shared_from_this(), std::bind(&TurnAsyncSocket::RequestEntry::requestTimerExpired, this, std::placeholders::_1)));
 }
 
@@ -1403,7 +1403,7 @@ TurnAsyncSocket::clearActiveRequestMap()
 void
 TurnAsyncSocket::startAllocationTimer()
 {
-   mAllocationTimer.expires_from_now(seconds((mLifetime*5)/8));  // Allocation refresh should sent before 3/4 lifetime - use 5/8 lifetime 
+   mAllocationTimer.expires_after(seconds((mLifetime*5)/8));  // Allocation refresh should sent before 3/4 lifetime - use 5/8 lifetime 
    mAllocationTimer.async_wait(weak_bind<AsyncSocketBase, void(const asio::error_code&)>(mAsyncSocketBase.shared_from_this(), std::bind(&TurnAsyncSocket::allocationTimerExpired, this, std::placeholders::_1)));
 }
 
@@ -1431,7 +1431,7 @@ TurnAsyncSocket::startChannelBindingTimer(unsigned short channel)
       resip_assert(ret.second);
       it = ret.first;
    }
-   it->second->expires_from_now(seconds(TURN_CHANNEL_BINDING_REFRESH_SECONDS));  
+   it->second->expires_after(seconds(TURN_CHANNEL_BINDING_REFRESH_SECONDS));
    it->second->async_wait(weak_bind<AsyncSocketBase, void(const asio::error_code&)>( mAsyncSocketBase.shared_from_this(), std::bind(&TurnAsyncSocket::channelBindingTimerExpired, this, std::placeholders::_1, channel)));
 }
 

--- a/reTurn/client/TurnAsyncSocket.hxx
+++ b/reTurn/client/TurnAsyncSocket.hxx
@@ -46,7 +46,7 @@ public:
    static unsigned short UnspecifiedToken;
    static asio::ip::address UnspecifiedIpAddress;
 
-   explicit TurnAsyncSocket(asio::io_service& ioService,
+   explicit TurnAsyncSocket(asio::io_context& ioService,
                             AsyncSocketBase& asyncSocketBase,
                             TurnAsyncSocketHandler* turnAsyncSocketHandler,
                             const asio::ip::address& address = UnspecifiedIpAddress, 
@@ -115,7 +115,7 @@ protected:
 
    void handleReceivedData(const asio::ip::address& address, unsigned short port, const std::shared_ptr<DataBuffer>& data);
 
-   asio::io_service& mIOService;
+   asio::io_context& mIOService;
    TurnAsyncSocketHandler* mTurnAsyncSocketHandler;
    resip::RecursiveMutex mHandlerMutex;
 
@@ -154,14 +154,14 @@ private:
    class RequestEntry : public std::enable_shared_from_this<RequestEntry>
    {
    public:
-      RequestEntry(asio::io_service& ioService, TurnAsyncSocket* turnAsyncSocket, StunMessage* requestMessage, unsigned int rc, unsigned int retrans_iterval_ms, const StunTuple* dest=NULL);
+      RequestEntry(asio::io_context& ioService, TurnAsyncSocket* turnAsyncSocket, StunMessage* requestMessage, unsigned int rc, unsigned int retrans_iterval_ms, const StunTuple* dest=NULL);
       ~RequestEntry();
 
       void startTimer();
       void stopTimer();
       void requestTimerExpired(const asio::error_code& e);
 
-      asio::io_service& mIOService;
+      asio::io_context& mIOService;
       TurnAsyncSocket* mTurnAsyncSocket;
       StunMessage* mRequestMessage;
       asio::steady_timer mRequestTimer;

--- a/reTurn/client/TurnAsyncTcpSocket.cxx
+++ b/reTurn/client/TurnAsyncTcpSocket.cxx
@@ -15,7 +15,7 @@ using namespace resip;
 
 namespace reTurn {
 
-TurnAsyncTcpSocket::TurnAsyncTcpSocket(asio::io_service& ioService,
+TurnAsyncTcpSocket::TurnAsyncTcpSocket(asio::io_context& ioService,
                                        TurnAsyncSocketHandler* turnAsyncSocketHandler,
                                        const asio::ip::address& address, 
                                        unsigned short port) : 

--- a/reTurn/client/TurnAsyncTcpSocket.hxx
+++ b/reTurn/client/TurnAsyncTcpSocket.hxx
@@ -14,7 +14,7 @@ namespace reTurn {
 class TurnAsyncTcpSocket : public TurnAsyncSocket, public AsyncTcpSocketBase
 {
 public:
-   explicit TurnAsyncTcpSocket(asio::io_service& ioService, 
+   explicit TurnAsyncTcpSocket(asio::io_context& ioService, 
                                TurnAsyncSocketHandler* turnAsyncSocketHandler,
                                const asio::ip::address& address = UnspecifiedIpAddress, 
                                unsigned short port = 0);

--- a/reTurn/client/TurnAsyncTlsSocket.cxx
+++ b/reTurn/client/TurnAsyncTlsSocket.cxx
@@ -16,7 +16,7 @@ using namespace resip;
 
 namespace reTurn {
 
-TurnAsyncTlsSocket::TurnAsyncTlsSocket(asio::io_service& ioService,
+TurnAsyncTlsSocket::TurnAsyncTlsSocket(asio::io_context& ioService,
                                        asio::ssl::context& sslContext,
                                        bool validateServerCertificateHostname,
                                        TurnAsyncSocketHandler* turnAsyncSocketHandler,

--- a/reTurn/client/TurnAsyncTlsSocket.hxx
+++ b/reTurn/client/TurnAsyncTlsSocket.hxx
@@ -18,7 +18,7 @@ namespace reTurn {
 class TurnAsyncTlsSocket : public TurnAsyncSocket, public AsyncTlsSocketBase
 {
 public:
-   explicit TurnAsyncTlsSocket(asio::io_service& ioService, 
+   explicit TurnAsyncTlsSocket(asio::io_context& ioService, 
                                asio::ssl::context& sslContext,
                                bool validateServerCertificateHostname,
                                TurnAsyncSocketHandler* turnAsyncSocketHandler,

--- a/reTurn/client/TurnAsyncUdpSocket.cxx
+++ b/reTurn/client/TurnAsyncUdpSocket.cxx
@@ -15,7 +15,7 @@ using namespace resip;
 
 namespace reTurn {
 
-TurnAsyncUdpSocket::TurnAsyncUdpSocket(asio::io_service& ioService,
+TurnAsyncUdpSocket::TurnAsyncUdpSocket(asio::io_context& ioService,
                                        TurnAsyncSocketHandler* turnAsyncSocketHandler,
                                        const asio::ip::address& address, 
                                        unsigned short port) : 

--- a/reTurn/client/TurnAsyncUdpSocket.hxx
+++ b/reTurn/client/TurnAsyncUdpSocket.hxx
@@ -14,7 +14,7 @@ namespace reTurn {
    class TurnAsyncUdpSocket : public TurnAsyncSocket, public AsyncUdpSocketBase
 {
 public:
-   explicit TurnAsyncUdpSocket(asio::io_service& ioService,
+   explicit TurnAsyncUdpSocket(asio::io_context& ioService,
                                TurnAsyncSocketHandler* turnAsyncSocketHandler,
                                const asio::ip::address& address, 
                                unsigned short port); 

--- a/reTurn/client/TurnLoadGenClient/TurnLoadGenAsyncSocketHandler.hxx
+++ b/reTurn/client/TurnLoadGenClient/TurnLoadGenAsyncSocketHandler.hxx
@@ -18,7 +18,7 @@ class TurnLoadGenAsyncSocketHandler : public TurnAsyncSocketHandler
 public:
    TurnLoadGenAsyncSocketHandler(
       int clientNum, 
-      asio::io_service& ioService, 
+      asio::io_context& ioService, 
       const Data& localAddress, 
       const Data& turnServerAddress, 
       unsigned short turnServerPort, 

--- a/reTurn/client/TurnLoadGenClient/TurnLoadGenClient.cxx
+++ b/reTurn/client/TurnLoadGenClient/TurnLoadGenClient.cxx
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
       UdpEchoServer udpEchoServer(localAddress, echoServerPort);
       udpEchoServer.run();
 
-      asio::io_service ioService;
+      asio::io_context ioService;
 
       int numClientsToSimulate = config.getConfigInt("NumClientsToSimulate", 1);
       std::list<TurnLoadGenAsyncSocketHandler*> mClients;
@@ -135,17 +135,17 @@ int main(int argc, char* argv[])
 
          if (isEqualNoCase(turnProtocol, "TLS"))
          {
-            turnSocket = std::make_shared<TurnAsyncTlsSocket>(ioService, sslContext, false, client, asio::ip::address::from_string(localAddress.c_str()), 0);
+            turnSocket = std::make_shared<TurnAsyncTlsSocket>(ioService, sslContext, false, client, asio::ip::make_address(localAddress.c_str()), 0);
          }
          else
 #endif
          if (isEqualNoCase(turnProtocol, "TCP"))
          {
-           turnSocket = std::make_shared<TurnAsyncTcpSocket>(ioService, client, asio::ip::address::from_string(localAddress.c_str()), 0);
+           turnSocket = std::make_shared<TurnAsyncTcpSocket>(ioService, client, asio::ip::make_address(localAddress.c_str()), 0);
          }
          else
          {
-           turnSocket = std::make_shared<TurnAsyncUdpSocket>(ioService, client, asio::ip::address::from_string(localAddress.c_str()), 0);
+           turnSocket = std::make_shared<TurnAsyncUdpSocket>(ioService, client, asio::ip::make_address(localAddress.c_str()), 0);
          }
 
          // Set the username and password

--- a/reTurn/client/TurnSocket.cxx
+++ b/reTurn/client/TurnSocket.cxx
@@ -35,7 +35,7 @@ namespace reTurn {
 unsigned int TurnSocket::UnspecifiedLifetime = 0xFFFFFFFF;
 unsigned int TurnSocket::UnspecifiedBandwidth = 0xFFFFFFFF; 
 unsigned short TurnSocket::UnspecifiedToken = 0;
-asio::ip::address TurnSocket::UnspecifiedIpAddress = asio::ip::address::from_string("0.0.0.0");
+asio::ip::address TurnSocket::UnspecifiedIpAddress = asio::ip::make_address("0.0.0.0");
 
 TurnSocket::TurnSocket(const asio::ip::address& address, unsigned short port) : 
    mLocalBinding(StunTuple::None /* Set properly by sub class */, address, port),
@@ -595,7 +595,7 @@ TurnSocket::sendTo(RemotePeer& remotePeer, const char* buffer, unsigned int size
       else
       {
          ind.mTurnXorPeerAddress[0].family = StunMessage::IPv4Family;
-         ind.mTurnXorPeerAddress[0].addr.ipv4 = remotePeer.getPeerTuple().getAddress().to_v4().to_ulong();
+         ind.mTurnXorPeerAddress[0].addr.ipv4 = remotePeer.getPeerTuple().getAddress().to_v4().to_uint();
       }
       if(size > 0)
       {
@@ -868,7 +868,7 @@ TurnSocket::startReadTimer(unsigned int timeout)
 {
    if(timeout != 0)
    {
-      mReadTimer.expires_from_now(milliseconds(timeout));
+      mReadTimer.expires_after(milliseconds(timeout));
       mReadTimer.async_wait(std::bind(&TurnSocket::handleRawReadTimeout, this, std::placeholders::_1));
    }
 }

--- a/reTurn/client/TurnSocket.hxx
+++ b/reTurn/client/TurnSocket.hxx
@@ -120,7 +120,7 @@ protected:
    ChannelBindingRefreshTimeMap mChannelBindingRefreshTimes;
    RemotePeer* mActiveDestination;
 
-   asio::io_service mIOService;
+   asio::io_context mIOService;
 
    // handlers and timers required to do a timed out read
    asio::steady_timer mReadTimer;

--- a/reTurn/client/TurnTcpSocket.cxx
+++ b/reTurn/client/TurnTcpSocket.cxx
@@ -34,9 +34,9 @@ TurnTcpSocket::connect(const std::string& address, unsigned short port)
    // Get a list of endpoints corresponding to the server name.
    asio::ip::tcp::resolver resolver(mIOService);
    resip::Data service(port);
-   asio::ip::tcp::resolver::query query(mSocket.local_endpoint().protocol(), address, service.c_str());
-   asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
-   const asio::ip::tcp::resolver::iterator end;
+   asio::ip::tcp::resolver::results_type results = resolver.resolve(mSocket.local_endpoint().protocol(), address, service.c_str());
+   asio::ip::tcp::resolver::results_type::const_iterator endpoint_iterator = results.begin();
+   asio::ip::tcp::resolver::results_type::const_iterator end = results.end();
 
    // Try each endpoint until we successfully establish a connection.
    asio::error_code errorCode = asio::error::host_not_found;
@@ -52,7 +52,7 @@ TurnTcpSocket::connect(const std::string& address, unsigned short port)
          mConnectedTuple.setAddress(endpoint_iterator->endpoint().address());
          mConnectedTuple.setPort(endpoint_iterator->endpoint().port());
       }
-      endpoint_iterator++;
+      ++endpoint_iterator;
    }
 
    return errorCode;
@@ -82,7 +82,7 @@ TurnTcpSocket::rawRead(unsigned int timeout, unsigned int* bytesRead, asio::ip::
 
    // Wait for timer and read to end
    mIOService.run();
-   mIOService.reset();
+   mIOService.restart();
 
    *bytesRead = (unsigned int)mBytesRead+4;
    if(!mReadErrorCode)

--- a/reTurn/client/TurnTlsSocket.cxx
+++ b/reTurn/client/TurnTlsSocket.cxx
@@ -54,9 +54,9 @@ TurnTlsSocket::connect(const std::string& address, unsigned short port)
    // Get a list of endpoints corresponding to the server name.
    asio::ip::tcp::resolver resolver(mIOService);
    resip::Data service(port);
-   asio::ip::tcp::resolver::query query(mSocket.lowest_layer().local_endpoint().protocol(), address, service.c_str());
-   asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
-   const asio::ip::tcp::resolver::iterator end;
+   asio::ip::tcp::resolver::results_type results = resolver.resolve(mSocket.lowest_layer().local_endpoint().protocol(), address, service.c_str());
+   asio::ip::tcp::resolver::results_type::const_iterator endpoint_iterator = results.begin();
+   asio::ip::tcp::resolver::results_type::const_iterator end = results.end();
 
    // Try each endpoint until we successfully establish a connection.
    asio::error_code errorCode = asio::error::host_not_found;
@@ -88,7 +88,7 @@ TurnTlsSocket::connect(const std::string& address, unsigned short port)
             }
          }
       }
-      endpoint_iterator++;
+      ++endpoint_iterator;
    }
 
    return errorCode;

--- a/reTurn/client/TurnUdpSocket.cxx
+++ b/reTurn/client/TurnUdpSocket.cxx
@@ -31,9 +31,9 @@ TurnUdpSocket::connect(const std::string& address, unsigned short port)
    // Get a list of endpoints corresponding to the server name.
    asio::ip::udp::resolver resolver(mIOService);
    resip::Data service(port);
-   asio::ip::udp::resolver::query query(mSocket.local_endpoint().protocol(), address, service.c_str());
-   asio::ip::udp::resolver::iterator endpoint_iterator = resolver.resolve(query);
-   const asio::ip::udp::resolver::iterator end;
+   asio::ip::udp::resolver::results_type results = resolver.resolve(mSocket.local_endpoint().protocol(), address, service.c_str());
+   asio::ip::udp::resolver::results_type::const_iterator endpoint_iterator = results.begin();
+   asio::ip::udp::resolver::results_type::const_iterator end = results.end();
 
    // Use first endpoint in list
    if(endpoint_iterator == end)
@@ -77,7 +77,7 @@ TurnUdpSocket::rawRead(unsigned int timeout, unsigned int* bytesRead, asio::ip::
 
    // Wait for timer and read to end
    mIOService.run();
-   mIOService.reset();
+   mIOService.restart();
 
    *bytesRead = (unsigned int)mBytesRead;
 

--- a/reTurn/client/UdpEchoServer.cxx
+++ b/reTurn/client/UdpEchoServer.cxx
@@ -29,7 +29,7 @@ UdpEchoServer::UdpEchoServer(const Data& localAddress, unsigned int port) :
    mSocket(mIOContext),
    mIntervalReadCount(0)
 {
-   asio::ip::address address = asio::ip::address::from_string(localAddress.c_str());
+   asio::ip::address address = asio::ip::make_address(localAddress.c_str());
    asio::error_code errorCode;
    mSocket.open(address.is_v6() ? asio::ip::udp::v6() : asio::ip::udp::v4(), errorCode);
    if (!errorCode)

--- a/reTurn/client/test/TestAsyncClient.cxx
+++ b/reTurn/client/test/TestAsyncClient.cxx
@@ -53,7 +53,7 @@ public:
    virtual void thread()
    {
       asio::error_code rc;
-      TurnUdpSocket turnSocket(asio::ip::address::from_string(address.c_str()), 2000);
+      TurnUdpSocket turnSocket(asio::ip::make_address(address.c_str()), 2000);
 
       char buffer[1024];
       unsigned int size = sizeof(buffer);
@@ -142,11 +142,11 @@ public:
        // Test Data sending and receiving over allocation
        resip::Data turnData("This test is for wrapped Turn Data!");
        InfoLog( << "CLIENT: Sending: " << turnData);
-       mTurnAsyncSocket->sendTo(asio::ip::address::from_string(address.c_str()), 2000, turnData.c_str(), turnData.size()+1);
+       mTurnAsyncSocket->sendTo(asio::ip::make_address(address.c_str()), 2000, turnData.c_str(), turnData.size()+1);
 
        turnData = "This test should be in ChannelData message in TCP/TLS but not in UDP - since ChannelBindResponse is not yet received.";
        InfoLog( << "CLIENT: Sending: " << turnData);
-       mTurnAsyncSocket->setActiveDestination(asio::ip::address::from_string(address.c_str()), 2000);
+       mTurnAsyncSocket->setActiveDestination(asio::ip::make_address(address.c_str()), 2000);
        mTurnAsyncSocket->send(turnData.c_str(), turnData.size()+1);       
    }
    virtual void onAllocationFailure(unsigned int socketDesc, const asio::error_code& e)
@@ -281,7 +281,7 @@ int main(int argc, char* argv[])
     char password[256] = "1234";
     TurnPeer turnPeer;
     turnPeer.run();
-    asio::io_service ioService;
+    asio::io_context ioService;
     MyTurnAsyncSocketHandler handler;
 
 #ifdef USE_SSL
@@ -293,10 +293,10 @@ int main(int argc, char* argv[])
     sslContext.load_verify_file("ca.pem");
 #endif
 
-    const std::shared_ptr<TurnAsyncSocket> turnSocket = std::make_shared<TurnAsyncUdpSocket>(ioService, &handler, asio::ip::address::from_string(address.c_str()), 0);
-    //const std::shared_ptr<TurnAsyncSocket> turnSocket = std::make_shared<TurnAsyncTcpSocket>(ioService, &handler, asio::ip::address::from_string(address.c_str()), 0);
+    const std::shared_ptr<TurnAsyncSocket> turnSocket = std::make_shared<TurnAsyncUdpSocket>(ioService, &handler, asio::ip::make_address(address.c_str()), 0);
+    //const std::shared_ptr<TurnAsyncSocket> turnSocket = std::make_shared<TurnAsyncTcpSocket>(ioService, &handler, asio::ip::make_address(address.c_str()), 0);
 #ifdef USE_SSL
-    //const std::shared_ptr<TurnAsyncSocket> turnSocket = std::make_shared<TurnAsyncTlsSocket>(ioService, sslContext, false /* validateServerCertificateHostname */, &handler, asio::ip::address::from_string(address.c_str()), 0);
+    //const std::shared_ptr<TurnAsyncSocket> turnSocket = std::make_shared<TurnAsyncTlsSocket>(ioService, sslContext, false /* validateServerCertificateHostname */, &handler, asio::ip::make_address(address.c_str()), 0);
 #endif
     //port=5349;
 

--- a/reTurn/client/test/TestClient.cxx
+++ b/reTurn/client/test/TestClient.cxx
@@ -49,7 +49,7 @@ public:
    virtual void thread()
    {
       asio::error_code rc;
-      TurnUdpSocket turnSocket(asio::ip::address::from_string("127.0.0.1"), 2000);
+      TurnUdpSocket turnSocket(asio::ip::make_address("127.0.0.1"), 2000);
 
       char buffer[1024];
       unsigned int size = sizeof(buffer);
@@ -107,8 +107,8 @@ int main(int argc, char* argv[])
 #ifndef NO_AUTHENTICATION
 #ifdef USE_SSL
       {  // Connect via TLS, get SharedSecret, and disconnect
-         TurnTlsSocket tlsSocket(asio::ip::address::from_string("127.0.0.1"), 40001);
-         rc = tlsSocket.requestSharedSecret(asio::ip::address::from_string(argv[1]), 
+         TurnTlsSocket tlsSocket(asio::ip::make_address("127.0.0.1"), 40001);
+         rc = tlsSocket.requestSharedSecret(asio::ip::make_address(argv[1]), 
             port.convertUnsignedLong()+1,
             username, sizeof(username),
             password, sizeof(password));
@@ -184,11 +184,11 @@ int main(int argc, char* argv[])
          // Test Data sending and receiving over allocation
          resip::Data turnData("This test is for wrapped Turn Data!");
          InfoLog(<< "CLIENT: Sending: " << turnData);
-         turnSocket.sendTo(asio::ip::address::from_string("127.0.0.1"), 2000, turnData.c_str(), turnData.size());
+         turnSocket.sendTo(asio::ip::make_address("127.0.0.1"), 2000, turnData.c_str(), turnData.size());
 
          turnData = "This test should be a Channel Data message in TCP/TLS but not in UDP - since ChannelBindResponse is not yet received.";
          InfoLog( << "CLIENT: Sending: " << turnData);
-         turnSocket.setActiveDestination(asio::ip::address::from_string("127.0.0.1"), 2000);
+         turnSocket.setActiveDestination(asio::ip::make_address("127.0.0.1"), 2000);
          turnSocket.send(turnData.c_str(), turnData.size());
 
          // Receive Data

--- a/reTurn/reTurnServer.cxx
+++ b/reTurn/reTurnServer.cxx
@@ -93,7 +93,7 @@ reTurn::ReTurnServerProcess::main(int argc, char* argv[])
       resip::Log::initialize(reTurnConfig, argv[0]);
 
       // Initialize server.
-      asio::io_service ioService;                                // The one and only ioService for the stunServer
+      asio::io_context ioService;                                // The one and only ioService for the stunServer
       reTurn::TurnManager turnManager(ioService, reTurnConfig);  // The one and only Turn Manager
 
       std::shared_ptr<reTurn::UdpServer> udpTurnServer;  // also a1p1StunUdpServer
@@ -193,7 +193,7 @@ reTurn::ReTurnServerProcess::main(int argc, char* argv[])
 #endif
 
       // Run the ioService until stopped.
-      // Create a pool of threads to run all of the io_services.
+      // Create a pool of threads to run all of the io_contexts.
       asio::thread thread([&ioService] { ioService.run(); });
 
 #ifndef _WIN32

--- a/reTurn/test/stunTestVectors.cxx
+++ b/reTurn/test/stunTestVectors.cxx
@@ -18,8 +18,8 @@ using namespace std;
 
 int main(int argc, char* argv[])
 {
-   StunTuple local(StunTuple::UDP, asio::ip::address::from_string("10.0.0.1"), 5000);
-   StunTuple remote(StunTuple::UDP, asio::ip::address::from_string("10.0.0.2"), 5001);
+   StunTuple local(StunTuple::UDP, asio::ip::make_address("10.0.0.1"), 5000);
+   StunTuple remote(StunTuple::UDP, asio::ip::make_address("10.0.0.2"), 5001);
 
    resip::Log::initialize(resip::Log::Cout, resip::Log::Info, "");
 
@@ -81,7 +81,7 @@ int main(int argc, char* argv[])
    assert(respv4Message.mHasXorMappedAddress);
    assert(respv4Message.mXorMappedAddress.family == StunMessage::IPv4Family);
    assert(respv4Message.mXorMappedAddress.port == 32853);
-   assert(respv4Message.mXorMappedAddress.addr.ipv4 == asio::ip::address::from_string("192.0.2.1").to_v4().to_ulong());
+   assert(respv4Message.mXorMappedAddress.addr.ipv4 == asio::ip::make_address("192.0.2.1").to_v4().to_uint());
    assert(respv4Message.mHasMessageIntegrity);
    assert(respv4Message.checkMessageIntegrity("VOkJxbRl1RmTxUk/WvJxBt"));
    assert(respv4Message.mHasFingerprint);
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
    assert(respv6Message.mHasXorMappedAddress);
    assert(respv6Message.mXorMappedAddress.family == StunMessage::IPv6Family);
    assert(respv6Message.mXorMappedAddress.port == 32853);
-   asio::ip::address_v6::bytes_type v6addr = asio::ip::address::from_string("2001:db8:1234:5678:11:2233:4455:6677").to_v6().to_bytes();
+   asio::ip::address_v6::bytes_type v6addr = asio::ip::make_address("2001:db8:1234:5678:11:2233:4455:6677").to_v6().to_bytes();
    assert(memcmp(&respv6Message.mXorMappedAddress.addr.ipv6, v6addr.data(), sizeof(respv6Message.mXorMappedAddress.addr.ipv6)) == 0);
    assert(respv6Message.mHasMessageIntegrity);
    assert(respv6Message.checkMessageIntegrity("VOkJxbRl1RmTxUk/WvJxBt"));

--- a/reflow/Flow.cxx
+++ b/reflow/Flow.cxx
@@ -120,7 +120,7 @@ const char* srtp_error_string(srtp_err_status_t error)
    }
 }
 
-Flow::Flow(asio::io_service& ioService,
+Flow::Flow(asio::io_context& ioService,
 #ifdef USE_SSL
            asio::ssl::context& sslContext,
 #endif
@@ -506,7 +506,7 @@ Flow::setActiveDestination(const char* address, unsigned short port)
 {
    if (mTurnSocket)
    {
-      asio::ip::address peerAddress = asio::ip::address::from_string(address);
+      asio::ip::address peerAddress = asio::ip::make_address(address);
 
       {
          Lock lock(mMutex);
@@ -552,7 +552,7 @@ void
 Flow::startDtlsClient(const char* address, unsigned short port)
 {
    Lock lock(mMutex);
-   createDtlsSocketClient(StunTuple(mLocalBinding.getTransportType(), asio::ip::address::from_string(address), port));
+   createDtlsSocketClient(StunTuple(mLocalBinding.getTransportType(), asio::ip::make_address(address), port));
 }
 #endif 
 

--- a/reflow/Flow.hxx
+++ b/reflow/Flow.hxx
@@ -59,7 +59,7 @@ public:
       Ready
    };
 
-   Flow(asio::io_service& ioService,
+   Flow(asio::io_context& ioService,
         asio::ssl::context& sslContext,
         unsigned int componentId,
         const StunTuple& localBinding, 
@@ -119,7 +119,7 @@ public:
    unsigned int getComponentId() { return mComponentId; }
 
 private:
-   asio::io_service& mIOService;
+   asio::io_context& mIOService;
    asio::ssl::context& mSslContext;
 
    // Note: these member variables are set at creation time and never changed, thus

--- a/reflow/FlowDtlsTimerContext.cxx
+++ b/reflow/FlowDtlsTimerContext.cxx
@@ -21,7 +21,7 @@ using namespace std;
 
 using namespace std::chrono;
 
-FlowDtlsTimerContext::FlowDtlsTimerContext(asio::io_service& ioService) :
+FlowDtlsTimerContext::FlowDtlsTimerContext(asio::io_context& ioService) :
   mIOService(ioService) 
 {
 }
@@ -30,7 +30,7 @@ void
 FlowDtlsTimerContext::addTimer(dtls::DtlsTimer *timer, unsigned int durationMs) 
 {
    auto deadlineTimer = std::make_shared<asio::steady_timer>(mIOService);
-   deadlineTimer->expires_from_now(milliseconds(durationMs));
+   deadlineTimer->expires_after(milliseconds(durationMs));
    deadlineTimer->async_wait(std::bind(&FlowDtlsTimerContext::handleTimeout, this, timer, std::placeholders::_1));
    mDeadlineTimers[timer] = deadlineTimer;
    //InfoLog(<< "FlowDtlsTimerContext: starting timer for " << durationMs << "ms.");

--- a/reflow/FlowDtlsTimerContext.hxx
+++ b/reflow/FlowDtlsTimerContext.hxx
@@ -24,12 +24,12 @@ namespace flowmanager
 class FlowDtlsTimerContext: public dtls::DtlsTimerContext
 {
   public:
-     FlowDtlsTimerContext(asio::io_service& ioService);
+     FlowDtlsTimerContext(asio::io_context& ioService);
      void addTimer(dtls::DtlsTimer *timer, unsigned int durationMs);
      void handleTimeout(dtls::DtlsTimer *timer, const asio::error_code& errorCode);
 
    private:
-     asio::io_service& mIOService;
+     asio::io_context& mIOService;
      std::map<dtls::DtlsTimer*, std::shared_ptr<asio::steady_timer> > mDeadlineTimers;  
 };
 

--- a/reflow/FlowManager.cxx
+++ b/reflow/FlowManager.cxx
@@ -48,7 +48,7 @@ namespace flowmanager
 class IOServiceThread : public ThreadIf
 {
 public:
-   IOServiceThread(asio::io_service& ioService) : mIOService(ioService) {}
+   IOServiceThread(asio::io_context& ioService) : mIOService(ioService) {}
 
    virtual ~IOServiceThread() {}
 
@@ -57,7 +57,7 @@ public:
       mIOService.run();
    }
 private:
-   asio::io_service& mIOService;
+   asio::io_context& mIOService;
 };
 }
 
@@ -70,7 +70,7 @@ FlowManager::FlowManager()
    mDtlsFactory(0)
 #endif  
 {
-   mIOServiceWork = new asio::io_service::work(mIOService);
+   mIOServiceWork = new asio::executor_work_guard<asio::io_context::executor_type>(mIOService.get_executor());
    mIOServiceThread = new IOServiceThread(mIOService);
    mIOServiceThread->run();
 

--- a/reflow/FlowManager.hxx
+++ b/reflow/FlowManager.hxx
@@ -14,6 +14,9 @@
 #include <openssl/crypto.h>
 #include <openssl/ssl.h>
 
+#include <asio.hpp>
+#include <asio/ssl.hpp>
+
 #include <map>
 #include <memory>
 #include <utility>
@@ -68,9 +71,9 @@ private:
    std::shared_ptr<RTCPEventLoggingHandler> mRtcpEventLoggingHandler;
 
    // Member variables used to manager asio io service thread
-   asio::io_service mIOService;
+   asio::io_context mIOService;
    IOServiceThread* mIOServiceThread;
-   asio::io_service::work* mIOServiceWork;
+   asio::executor_work_guard<asio::io_context::executor_type>* mIOServiceWork;
    static int createCert (const resip::Data& pAor, int expireDays, int keyLen, X509*& outCert, EVP_PKEY*& outKey );
    asio::ssl::context mSslContext;
    

--- a/reflow/MediaStream.cxx
+++ b/reflow/MediaStream.cxx
@@ -20,7 +20,7 @@ using namespace std;
 
 #define RESIPROCATE_SUBSYSTEM FlowManagerSubsystem::FLOWMANAGER
 
-MediaStream::MediaStream(asio::io_service& ioService,
+MediaStream::MediaStream(asio::io_context& ioService,
 #ifdef USE_SSL
                          asio::ssl::context& sslContext,
 #endif

--- a/reflow/MediaStream.hxx
+++ b/reflow/MediaStream.hxx
@@ -64,7 +64,7 @@ public:
       TurnAllocation
    };
 
-   MediaStream(asio::io_service& ioService,
+   MediaStream(asio::io_context& ioService,
                asio::ssl::context& sslContext,
                MediaStreamHandler& mediaStreamHandler,
                const StunTuple& localRtpBinding, 


### PR DESCRIPTION
This updates usage of Asio for compatibility with version 1.34 and newer, where a number of previously deprecated APIs were removed.