### PR TITLE
Reduce log level of stats messages

### DIFF
--- a/resip/stack/StatisticsMessage.cxx
+++ b/resip/stack/StatisticsMessage.cxx
@@ -93,7 +93,7 @@ void
 StatisticsMessage::logStats(const resip::Subsystem& subsystem, 
                             const StatisticsMessage::Payload& stats)
 {
-   WarningLog(<< subsystem
+   InfoLog(<< subsystem
               << std::endl
               << stats);
 }


### PR DESCRIPTION
Stats messages do not indicate a problem and therefore should not be logged at warning level.