### PR TITLE
Mark `Data` move constructor/assignment/takeBuf as `noexcept`

### DIFF
--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -368,7 +368,7 @@ Data::Data(const Data& data)
 }
 
 #ifdef RESIP_HAS_RVALUE_REFS
-Data::Data(Data &&data)
+Data::Data(Data &&data) noexcept
    : mBuf(mPreBuffer),mSize(0),mCapacity(LocalAlloc),mShareEnum(Borrow)
 {
    *this = std::move(data);
@@ -638,7 +638,7 @@ Data::setBuf(ShareEnum se, const char* buffer, size_type length)
 }
 
 Data&
-Data::takeBuf(Data& other)
+Data::takeBuf(Data& other) noexcept
 {
    if ( &other == this )
       return *this;
@@ -916,7 +916,7 @@ Data::operator=(const Data& data)
 #endif
 
 #ifdef RESIP_HAS_RVALUE_REFS
-Data& Data::operator=(Data &&data)
+Data& Data::operator=(Data &&data) noexcept
 {
    if (&data != this)
    {

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -177,7 +177,7 @@ class Data
       Data(const Data& data);
 
 #ifdef RESIP_HAS_RVALUE_REFS
-      Data(Data &&data);
+      Data(Data &&data) noexcept;
 #endif
       /**
         Creates a data with the contents of the string.
@@ -353,7 +353,7 @@ class Data
         are legal. When done, {other} will be empty (it will ref its
         internal buffer).
       **/
-      Data& takeBuf(Data& other);
+      Data& takeBuf(Data& other) noexcept;
 
       /**
         Functional equivalent of: *this = Data(buf, length)
@@ -432,7 +432,7 @@ class Data
       }
 
 #ifdef RESIP_HAS_RVALUE_REFS
-      Data& operator=(Data &&data);
+      Data& operator=(Data &&data) noexcept;
 #endif
 
       operator std::string() const 


### PR DESCRIPTION
Noexcept markup improves efficiency when `Data` objects are stored in containers, such as `std::vector`.