### PR TITLE
Add support for session refresh using OPTIONS

### DIFF
--- a/resip/dum/Dialog.cxx
+++ b/resip/dum/Dialog.cxx
@@ -538,6 +538,17 @@ Dialog::dispatch(const SipMessage& msg)
                mInviteSession->dispatch(request);
             }
             break;
+         case OPTIONS:
+            if (mInviteSession == 0)
+            {
+               InfoLog ( << "Spurious OPTIONS" );
+               return;
+            }
+            else
+            {
+               mInviteSession->dispatch(request);
+            }
+            break;
          case PRACK:
             if (mInviteSession == 0)
             {
@@ -777,6 +788,7 @@ Dialog::dispatch(const SipMessage& msg)
          case MESSAGE:
          case UPDATE:
          case PRACK:
+         case OPTIONS:
             if (mInviteSession)
             {
                mInviteSession->dispatch(response);

--- a/resip/dum/DialogSet.cxx
+++ b/resip/dum/DialogSet.cxx
@@ -635,6 +635,14 @@ DialogSet::dispatch(const SipMessage& msg)
             }
             break;
 
+         case OPTIONS:
+            if (dialog)
+            {
+               DebugLog(<< "in dialog options request");
+               break;
+            }
+            // fallthrough
+
          default:
             // !jf! move this to DialogUsageManager
             DebugLog ( << "In DialogSet::dispatch, default(ServerOutOfDialogRequest), msg: " << msg );
@@ -788,6 +796,7 @@ DialogSet::dispatch(const SipMessage& msg)
                break;
             }
          case NOTIFY:
+         case OPTIONS:
             if (dialog)
             {
                break;

--- a/resip/dum/InviteSession.hxx
+++ b/resip/dum/InviteSession.hxx
@@ -197,6 +197,8 @@ class InviteSession : public DialogUsage
          SentReinviteNoOffer,       // Sent a reINVITE with no offer (requestOffer)
          SentReinviteAnswered,      // Sent a reINVITE no offer and received a 200-offer
          SentReinviteNoOfferGlare,  // Got a 491
+         SentOptions,               // Sent an OPTIONS
+         SentOptionsGlare,          // Got a 491
          ReceivedUpdate,            // Received an UPDATE
          ReceivedReinvite,          // Received a reINVITE
          ReceivedReinviteNoOffer,   // Received a reINVITE with no offer
@@ -288,6 +290,9 @@ class InviteSession : public DialogUsage
          On200Update,
          OnPrack, // UAS
          On200Prack, // UAC
+         OnOptions,
+         On200Options,
+         On491Options,
          Unknown
       } Event;
 
@@ -312,6 +317,7 @@ class InviteSession : public DialogUsage
       void dispatchSentReinviteNoOffer(const SipMessage& msg);
       void dispatchSentReinviteAnswered(const SipMessage& msg);
       void dispatchGlare(const SipMessage& msg);
+      void dispatchSentOptions(const SipMessage& msg);
       void dispatchReinviteNoOfferGlare(const SipMessage& msg);
       void dispatchReceivedUpdateOrReinvite(const SipMessage& msg);
       void dispatchReceivedReinviteSentOffer(const SipMessage& msg);
@@ -324,6 +330,7 @@ class InviteSession : public DialogUsage
       void dispatchBye(const SipMessage& msg);
       void dispatchInfo(const SipMessage& msg);
       void dispatchMessage(const SipMessage& msg);
+      void dispatchOptions(const SipMessage& msg);
 
       void startRetransmit200Timer();
       void start491Timer();
@@ -349,6 +356,7 @@ class InviteSession : public DialogUsage
 
       void storePeerCapabilities(const SipMessage& msg);
       bool updateMethodSupported() const;
+      bool timerOptionSupported() const;
 
       std::shared_ptr<SipMessage> sendAck(const Contents *answer=0);
       std::shared_ptr<SipMessage> sendBye();


### PR DESCRIPTION
When a SIP endpoint does not support timers extension (RFC4028) but supports OPTIONS request (which it should, as this is one of the basic requests defined in RFC3261), using OPTIONS instead of re-INVITE to perform session refresh can be beneficial. OPTIONS is much more lightweight as it doesn't update SDP, which in some cases may disrupt media exchange.

Note that OPTIONS can be sent in- or out-of-dialog. In this implementation we are sending in-dialog OPTIONS to verify that this dialog is still active.