### PR TITLE
Use crypto RNG when generating certificates and nonce

### DIFF
--- a/resip/stack/BasicNonceHelper.cxx
+++ b/resip/stack/BasicNonceHelper.cxx
@@ -25,7 +25,7 @@ using namespace resip;
 BasicNonceHelper::BasicNonceHelper() 
 {
   //privateKey = Data("asdfklsadflkj");
-  privateKey = Random::getRandomHex(24);
+  privateKey = Random::getCryptoRandomHex(24);
 }
 
 BasicNonceHelper::~BasicNonceHelper() 

--- a/resip/stack/SERNonceHelper.cxx
+++ b/resip/stack/SERNonceHelper.cxx
@@ -24,7 +24,7 @@ using namespace resip;
 SERNonceHelper::SERNonceHelper(int serOffset) : serOffset(serOffset)
 {
    //privateKey = Data("asdfklsadflkj");
-   privateKey = Random::getRandomHex(24);
+   privateKey = Random::getCryptoRandomHex(24);
 }
 
 SERNonceHelper::~SERNonceHelper() 

--- a/resip/stack/makeCert.cxx
+++ b/resip/stack/makeCert.cxx
@@ -95,7 +95,7 @@ int makeSelfCert(X509 **cert, EVP_PKEY *privkey)   // should include a Uri type 
 
   //  RAND_bytes((char *) serial , 4);
   //serial = 1;
-  serial = Random::getRandom();  // get an int worth of randomness
+  serial = Random::getCryptoRandom();  // get an int worth of randomness
   ASN1_INTEGER_set(X509_get_serialNumber(selfcert),serial);
 
   X509_NAME_add_entry_by_txt( subject, "O",  MBSTRING_UTF8, (unsigned char *) domain.data(), domain.size(), -1, 0);

--- a/resip/stack/ssl/Security.cxx
+++ b/resip/stack/ssl/Security.cxx
@@ -1549,7 +1549,7 @@ BaseSecurity::generateUserCert (const Data& pAor, int expireDays, int keyLen )
    // set version to X509v3 (starts from 0)
    X509_set_version(cert, 2L);
    
-   int serial = Random::getRandom();  // get an int worth of randomness
+   int serial = Random::getCryptoRandom();  // get an int worth of randomness
    resip_assert(sizeof(int)==4);
    ASN1_INTEGER_set(X509_get_serialNumber(cert),serial);
    


### PR DESCRIPTION
This improves uniqueness of the generated certificates and nonce, which improves security.