### PR TITLE
Fix usage of `<cctype>` functions

### DIFF
--- a/p2p/s2c/s2c/gen.c
+++ b/p2p/s2c/s2c/gen.c
@@ -11,6 +11,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include "parser.h"
 
 
@@ -31,7 +32,7 @@ static char *camelback(char *name)
 
     for(j=0;j<strlen(name);j++){
       if(leading){
-        buf[i++]=toupper(name[j]);
+        buf[i++]=toupper((unsigned char)name[j]);
         leading=0;
       }
       else{
@@ -53,7 +54,7 @@ char *name2namespace(char *name)
 
     p=tmp;
     while(*p){
-      if(!isalnum(*p))
+      if(!isalnum((unsigned char)*p))
         *p='_';
       p++;
     }

--- a/reTurn/RequestHandler.cxx
+++ b/reTurn/RequestHandler.cxx
@@ -1,4 +1,5 @@
 #include "RequestHandler.hxx"
+#include <ctype.h>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -190,7 +191,7 @@ RequestHandler::CheckNonceResult
 RequestHandler::checkNonce(const Data& nonce)
 {
    ParseBuffer pb(nonce.data(), nonce.size());
-   if (!pb.eof() && !isdigit(*pb.position()))
+   if (!pb.eof() && !isdigit(static_cast< unsigned char >(*pb.position())))
    {
       DebugLog(<< "Invalid nonce.  Expected timestamp.");
       return NotValid;

--- a/resip/stack/BasicNonceHelper.cxx
+++ b/resip/stack/BasicNonceHelper.cxx
@@ -1,4 +1,4 @@
-
+#include <ctype.h>
 
 #include "resip/stack/BasicNonceHelper.hxx"
 #include "rutil/Logger.hxx"
@@ -59,7 +59,7 @@ NonceHelper::Nonce
 BasicNonceHelper::parseNonce(const Data& nonce) 
 {
    ParseBuffer pb(nonce.data(), nonce.size());
-   if (!pb.eof() && !isdigit(*pb.position()))
+   if (!pb.eof() && !isdigit(static_cast< unsigned char >(*pb.position())))
    {
       DebugLog(<< "Invalid nonce; expected timestamp.");
       return BasicNonceHelper::Nonce(0);

--- a/resip/stack/DtmfPayloadContents.cxx
+++ b/resip/stack/DtmfPayloadContents.cxx
@@ -100,8 +100,8 @@ DtmfPayloadContents::DtmfPayload::operator=(const DtmfPayload& rhs)
 bool
 DtmfPayloadContents::DtmfPayload::isValidButton(const char c)
 {
-   static const char* permittedChars = "ABCD*#";
-   if(isdigit(c))
+   static const char permittedChars[] = "ABCD*#";
+   if(c >= '0' && c <= '9')
    {
       return true;
    }
@@ -169,17 +169,17 @@ unsigned short
 DtmfPayloadContents::DtmfPayload::getEventCode() const
 {
    resip_assert(mButton);
-   unsigned short eventCode;
-   if(isdigit(mButton))
+   unsigned short eventCode = 0;
+   if(mButton >= '0' && mButton <= '9')
    {
       eventCode = mButton - '0';
    }
    else if(mButton == '*')
-   {      
+   {
       eventCode = 10;
-   }      
+   }
    else if(mButton == '#')
-   {      
+   {
       eventCode = 11;
    }
    else if(mButton >= 'A' && mButton <= 'D')

--- a/resip/stack/Embedded.cxx
+++ b/resip/stack/Embedded.cxx
@@ -2,6 +2,7 @@
 #include "config.h"
 #endif
 
+#include <ctype.h>
 
 #include "rutil/ResipAssert.h"
 
@@ -14,13 +15,13 @@ using namespace resip;
 
 char fromHex(char h1, char h2)
 {
-   h1 = toupper(h1);
-   h2 = toupper(h2);
+   h1 = toupper(static_cast< unsigned char >(h1));
+   h2 = toupper(static_cast< unsigned char >(h2));
 
    int i1;
    int i2;
 
-   if (isdigit(h1))
+   if (isdigit(static_cast< unsigned char >(h1)))
    {
       i1 = h1 - '0';
    }
@@ -29,7 +30,7 @@ char fromHex(char h1, char h2)
       i1 = h1 - 'A' + 10;
    }
 
-   if (isdigit(h2))
+   if (isdigit(static_cast< unsigned char >(h2)))
    {
       i2 = h2 - '0';
    }

--- a/resip/stack/ExpiresCategory.cxx
+++ b/resip/stack/ExpiresCategory.cxx
@@ -2,6 +2,8 @@
 #include "config.h"
 #endif
 
+#include <ctype.h>
+
 #include "resip/stack/ExpiresCategory.hxx"
 #include "rutil/Logger.hxx"
 #include "rutil/ParseBuffer.hxx"
@@ -78,7 +80,7 @@ ExpiresCategory::parse(ParseBuffer& pb)
 {
    pb.skipWhitespace();
    const char *p = pb.position();
-   if (!pb.eof() && isdigit(*p))
+   if (!pb.eof() && isdigit(static_cast< unsigned char >(*p)))
    {
      mValue = pb.uInt32();
    }

--- a/resip/stack/Helper.cxx
+++ b/resip/stack/Helper.cxx
@@ -2,6 +2,7 @@
 #include "config.h"
 #endif
 
+//#include <ctype.h>
 #include <cstring>
 #include <iomanip>
 #include <algorithm>
@@ -839,7 +840,7 @@ Helper::advancedAuthenticateRequest(const SipMessage& request,
                continue;
             }
             /* ParseBuffer pb(i->param(p_nonce).data(), i->param(p_nonce).size());
-            if (!pb.eof() && !isdigit(*pb.position()))
+            if (!pb.eof() && !isdigit(static_cast< unsigned char >(*pb.position())))
             {
                DebugLog(<< "Invalid nonce; expected timestamp.");
                return make_pair(BadlyFormed,username);
@@ -1000,7 +1001,7 @@ Helper::authenticateRequest(const SipMessage& request,
          }
          /*
          ParseBuffer pb(i->param(p_nonce).data(), i->param(p_nonce).size());
-         if (!pb.eof() && !isdigit(*pb.position()))
+         if (!pb.eof() && !isdigit(static_cast< unsigned char >(*pb.position())))
          {
             DebugLog(<< "Invalid nonce; expected timestamp.");
             return BadlyFormed;
@@ -1156,7 +1157,7 @@ Helper::authenticateRequestWithA1(const SipMessage& request,
          }
          /*
          ParseBuffer pb(i->param(p_nonce).data(), i->param(p_nonce).size());
-         if (!pb.eof() && !isdigit(*pb.position()))
+         if (!pb.eof() && !isdigit(static_cast< unsigned char >(*pb.position())))
          {
             DebugLog(<< "Invalid nonce; expected timestamp.");
             return BadlyFormed;

--- a/resip/stack/MessageWaitingContents.cxx
+++ b/resip/stack/MessageWaitingContents.cxx
@@ -2,6 +2,8 @@
 #include "config.h"
 #endif
 
+#include <ctype.h>
+
 #include "resip/stack/MessageWaitingContents.hxx"
 #include "rutil/Logger.hxx"
 #include "rutil/ParseBuffer.hxx"
@@ -336,7 +338,7 @@ MessageWaitingContents::parse(ParseBuffer& pb)
    while (!pb.eof() && *pb.position() != Symbols::CR[0])
    {
       int ht = -1;
-      switch (tolower(*pb.position()))
+      switch (tolower(static_cast< unsigned char >(*pb.position())))
       {
          case 'v' :
             ht = mw_voice;

--- a/resip/stack/MsgHeaderScanner.cxx
+++ b/resip/stack/MsgHeaderScanner.cxx
@@ -501,7 +501,7 @@ cleanName(const char * name)
       unsigned int l = strlen(leaders[i]);
       if (strstr(name,leaders[i]) == name &&
           strlen(name) > l && 
-          isupper(name[l]))
+          isupper(static_cast< unsigned char >(name[l])))
       {
          offset = l;
          break;

--- a/resip/stack/Uri.cxx
+++ b/resip/stack/Uri.cxx
@@ -2,11 +2,12 @@
 #include "config.h"
 #endif
 
+#include <ctype.h>
 #include <set>
 
 #include "resip/stack/Embedded.hxx"
 #include "resip/stack/Helper.hxx"
-#include "resip/stack/NameAddr.hxx" 
+#include "resip/stack/NameAddr.hxx"
 #include "resip/stack/SipMessage.hxx"
 #include "resip/stack/Symbols.hxx"
 #include "resip/stack/UnknownParameter.hxx"
@@ -282,7 +283,7 @@ Uri::isEnumSearchable() const
    // count the digits (skip the leading `+')
    for(const char* i=user().begin() + 1; i!= user().end(); i++)
    {
-      if (isdigit(*i))
+      if (isdigit(static_cast< unsigned char >(*i)))
       {
          digits++;
       }
@@ -316,7 +317,7 @@ Uri::getEnumLookups(const std::vector<Data>& suffixes) const
       // skip the leading +
       for (const char* i=user().end()-1 ; i!= user().begin(); --i)
       {
-         if (isdigit(*i))
+         if (isdigit(static_cast< unsigned char >(*i)))
          {
             prefix += *i;
             prefix += Symbols::DOT;

--- a/resip/stack/test/TestSupport.cxx
+++ b/resip/stack/test/TestSupport.cxx
@@ -67,7 +67,7 @@ namespace resip
             if (o >= len) break;
             char ch = p[o];
 
-            if (isalnum(ch) || ispunct(ch) || ch == ' ')
+            if (isalnum(static_cast< unsigned char >(ch)) || ispunct(static_cast< unsigned char >(ch)) || ch == ' ')
             {
                cout << ' ' << (char)ch;
                fb(3);

--- a/resip/stack/test/dumpasn1.c
+++ b/resip/stack/test/dumpasn1.c
@@ -543,7 +543,7 @@ static int readLine( FILE *file, char *buffer )
 		/* Check for an illegal char in the data.  Note that we don't just
 		   check for chars with high bits set because these are legal in
 		   non-ASCII strings */
-		if( !isprint( ch ) )
+		if( !isprint( (unsigned char)ch ) )
 			{
 			printf( "Bad character '%c' in config file line %d.\n",
 					ch, lineNo );
@@ -1274,12 +1274,12 @@ static void displayString( FILE *inFile, long length, int level,
 					warnIA5 = TRUE;
 				if( strOption == STR_LATIN1 )
 					{
-					if( !isprint( ch & 0x7F ) )
+					if( !isprint( (unsigned char)ch & 0x7F ) )
 						ch = '.';	/* Convert non-ASCII to placeholders */
 					}
 				else
 					{
-					if( !isprint( ch ) )
+					if( !isprint( (unsigned char)ch ) )
 						ch = '.';	/* Convert non-ASCII to placeholders */
 					}
 #ifdef __OS390__
@@ -1289,10 +1289,10 @@ static void displayString( FILE *inFile, long length, int level,
 
 			case STR_UTCTIME:
 			case STR_GENERALIZED:
-				if( !isdigit( ch ) && ch != 'Z' )
+				if( !isdigit( (unsigned char)ch ) && ch != 'Z' )
 					{
 					warnTime = TRUE;
-					if( !isprint( ch ) )
+					if( !isprint( (unsigned char)ch ) )
 						ch = '.';	/* Convert non-ASCII to placeholders */
 					}
 #ifdef __OS390__
@@ -1320,7 +1320,7 @@ static void displayString( FILE *inFile, long length, int level,
 				/* Drop through */
 
 			default:
-				if( !isprint( ch ) )
+				if( !isprint( (unsigned char)ch ) )
 					ch = '.';	/* Convert control chars to placeholders */
 #ifdef __OS390__
 				ch = asciiToEbcdic( ch );
@@ -1581,8 +1581,8 @@ static STR_OPTION checkForText( FILE *inFile, const int length )
 		fseek( inFile, -sampleLength, SEEK_CUR );
 		for( i = 0; i < sampleLength; i++ )
 			{
-			if( !( isalpha( buffer[ i ] ) || isdigit( buffer[ i ] ) || \
-				   isspace( buffer[ i ] ) ) )
+			if( !( isalpha( (unsigned char)buffer[ i ] ) || isdigit( (unsigned char)buffer[ i ] ) || \
+				   isspace( (unsigned char)buffer[ i ] ) ) )
 				return( STR_NONE );
 			}
 		return( STR_IA5 );
@@ -1591,13 +1591,13 @@ static STR_OPTION checkForText( FILE *inFile, const int length )
 	/* Check for ASCII-looking text */
 	sampleLength = fread( buffer, 1, sampleLength, inFile );
 	fseek( inFile, -sampleLength, SEEK_CUR );
-	if( isdigit( buffer[ 0 ] ) && ( length == 13 || length == 15 ) && \
+	if( isdigit( (unsigned char)buffer[ 0 ] ) && ( length == 13 || length == 15 ) && \
 		buffer[ length - 1 ] == 'Z' )
 		{
 		/* It looks like a time string, make sure that it really is one */
 		for( i = 0; i < length - 1; i++ )
 			{
-			if( !isdigit( buffer[ i ] ) )
+			if( !isdigit( (unsigned char)buffer[ i ] ) )
 				break;
 			}
 		if( i == length - 1 )
@@ -2247,12 +2247,12 @@ int main( int argc, char *argv[] )
 			useStdin = TRUE;
 		while( *argPtr )
 			{
-			if( isdigit( *argPtr ) )
+			if( isdigit( (unsigned char)*argPtr ) )
 				{
 				offset = atol( argPtr );
 				break;
 				}
-			switch( toupper( *argPtr ) )
+			switch( toupper( (unsigned char)*argPtr ) )
 				{
 				case '-':
 					moreArgs = FALSE;	/* GNU-style end-of-args flag */

--- a/rutil/ConfigParse.cxx
+++ b/rutil/ConfigParse.cxx
@@ -1,3 +1,4 @@
+#include <ctype.h>
 #include <iostream>
 #include <fstream>
 #include <iterator>
@@ -213,10 +214,10 @@ ConfigParse::getConfigIndexKeys(const resip::Data& indexName, std::set<Data>& ke
    {
       const Data& keyName = it->first;
       if(keyName.prefix(indexNameLower) && keyName.size() > numPos
-         && isdigit(keyName[numPos]))
+         && isdigit(static_cast< unsigned char >(keyName[numPos])))
       {
          Data::size_type i = numPos + 1;
-         while(i < keyName.size() && isdigit(keyName[i]))
+         while(i < keyName.size() && isdigit(static_cast< unsigned char >(keyName[i])))
          {
             i++;
          }
@@ -445,10 +446,10 @@ ConfigParse::getConfigNested(const resip::Data& mapsPrefix) const
    {
       const Data& keyName = it->first;
       if(keyName.prefix(mapsPrefixLower) && keyName.size() > numPos
-         && isdigit(keyName[numPos]))
+         && isdigit(static_cast< unsigned char >(keyName[numPos])))
       {
          Data::size_type i = numPos + 1;
-         while(i < keyName.size() && isdigit(keyName[i]))
+         while(i < keyName.size() && isdigit(static_cast< unsigned char >(keyName[i])))
          {
             i++;
          }

--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -1313,8 +1313,8 @@ Data::charUnencoded() const
       {
          if ( i+2 < size())
          {
-            const char* high = strchr(hexmap, tolower(*p++));
-            const char* low = strchr(hexmap, tolower(*p++));
+            const char* high = strchr(hexmap, tolower(static_cast< unsigned char >(*p++)));
+            const char* low = strchr(hexmap, tolower(static_cast< unsigned char >(*p++)));
 
             // !rwm! changed from high==0 || low==0
             if (high == 0 && low == 0)
@@ -1323,7 +1323,7 @@ Data::charUnencoded() const
                // ugh
                return ret;
             }
-            
+
             int highInt = int(high - hexmap);
             int lowInt = int(low - hexmap);
             ret += char(highInt<<4 | lowInt);
@@ -1653,7 +1653,7 @@ Data::lowercase()
    char* p = mBuf;
    for (size_type i=0; i < mSize; ++i)
    {
-      *p = tolower(*p);
+      *p = tolower(static_cast< unsigned char >(*p));
       ++p;
    }
    return *this;
@@ -1666,7 +1666,7 @@ Data::uppercase()
    char* p = mBuf;
    for (size_type i=0; i < mSize; ++i)
    {
-      *p = toupper(*p);
+      *p = toupper(static_cast< unsigned char >(*p));
       ++p;
    }
    return *this;
@@ -1705,7 +1705,7 @@ Data::convertInt() const
 
    for (; p != end; ++p)
    {
-      if (!isspace(*p))
+      if (!isspace(static_cast< unsigned char >(*p)))
       {
          goto sign_char;
       }
@@ -1725,7 +1725,7 @@ sign_char:
 
    for(; p != end; ++p)
    {
-      if (!isdigit(*p))
+      if (!isdigit(static_cast< unsigned char >(*p)))
       {
          break;
       }
@@ -1744,7 +1744,7 @@ Data::convertUnsignedLong() const
 
    for (; p != end; ++p)
    {
-      if (!isspace(*p))
+      if (!isspace(static_cast< unsigned char >(*p)))
       {
          goto sign_char;
       }
@@ -1759,7 +1759,7 @@ sign_char:
 
    for(; p != end; ++p)
    {
-      if (!isdigit(*p))
+      if (!isdigit(static_cast< unsigned char >(*p)))
       {
          break;
       }
@@ -1778,7 +1778,7 @@ Data::convertUInt64() const
 
    for (; p != end; ++p)
    {
-      if (!isspace(*p))
+      if (!isspace(static_cast< unsigned char >(*p)))
       {
          goto sign_char;
       }
@@ -1793,7 +1793,7 @@ sign_char:
 
    for(; p != end; ++p)
    {
-      if (!isdigit(*p))
+      if (!isdigit(static_cast< unsigned char >(*p)))
       {
          break;
       }
@@ -1812,7 +1812,7 @@ Data::convertSize() const
 
    for (; p != end; ++p)
    {
-      if (!isspace(*p))
+      if (!isspace(static_cast< unsigned char >(*p)))
       {
          goto sign_char;
       }
@@ -1827,7 +1827,7 @@ sign_char:
 
    for(; p != end; ++p)
    {
-      if (!isdigit(*p))
+      if (!isdigit(static_cast< unsigned char >(*p)))
       {
          break;
       }
@@ -1848,7 +1848,7 @@ Data::convertDouble() const
 
    for (; p != end; ++p)
    {
-      if (!isspace(*p))
+      if (!isspace(static_cast< unsigned char >(*p)))
       {
          goto sign_char;
       }
@@ -1872,7 +1872,7 @@ sign_char:
       {
          goto decimals;
       }
-      if (!isdigit(*p))
+      if (!isdigit(static_cast< unsigned char >(*p)))
       {
          return s*val;
       }
@@ -1887,7 +1887,7 @@ decimals:
    double div = 1.0;
    for(; p != end; ++p)
    {
-      if (!isdigit(*p)) 
+      if (!isdigit(static_cast< unsigned char >(*p)))
       {
          break;
       }

--- a/rutil/DnsUtil.cxx
+++ b/rutil/DnsUtil.cxx
@@ -17,6 +17,7 @@
 #endif
 
 #include <stdio.h>
+#include <ctype.h>
 #include <memory>
 
 #include "rutil/compat.hxx"
@@ -390,7 +391,7 @@ DnsUtil::isIpV6Address(const Data& ipAddress)
    }
 
    // first character must be a hex digit or colon
-   if (!isxdigit(*ipAddress.data()) &&
+   if (!isxdigit(static_cast< unsigned char >(*ipAddress.data())) &&
        *ipAddress.data() != ':')
    {
       return false;

--- a/rutil/ParseBuffer.cxx
+++ b/rutil/ParseBuffer.cxx
@@ -1,3 +1,5 @@
+#include <ctype.h>
+
 #include "rutil/ResipAssert.h"
 
 #include "rutil/Logger.hxx"
@@ -676,7 +678,7 @@ ParseBuffer::integer()
       assertNotEof();
    }
 
-   if (!isdigit(*mPosition))
+   if (!isdigit(static_cast< unsigned char >(*mPosition)))
    {
       Data msg("Expected a digit, got: ");
       msg += Data(mPosition, (Data::size_type)(mEnd - mPosition));
@@ -695,7 +697,7 @@ ParseBuffer::integer()
    const unsigned int digitLimit = absoluteLimit % 10;
 
    unsigned int num = 0;
-   while (!eof() && isdigit(*mPosition))
+   while (!eof() && isdigit(static_cast< unsigned char >(*mPosition)))
    {
       const unsigned int c = *mPosition++ - '0';
       if (num > border || (num == border && c > digitLimit)) {
@@ -720,7 +722,7 @@ ParseBuffer::uInt8()
    const char* begin=mPosition;
    uint8_t num = 0;
    uint8_t last = 0;
-   while (!eof() && isdigit(*mPosition))
+   while (!eof() && isdigit(static_cast< unsigned char >(*mPosition)))
    {
       last = num;
       num = num*10 + (*mPosition-'0');
@@ -745,7 +747,7 @@ ParseBuffer::uInt32()
 {
    const char* begin=mPosition;
    uint32_t num = 0;
-   while (!eof() && isdigit(*mPosition))
+   while (!eof() && isdigit(static_cast< unsigned char >(*mPosition)))
    {
       num = num*10 + (*mPosition-'0');
       ++mPosition;
@@ -786,7 +788,7 @@ ParseBuffer::uInt64()
 {
    const char* begin=mPosition;
    uint64_t num = 0;
-   while (!eof() && isdigit(*mPosition))
+   while (!eof() && isdigit(static_cast< unsigned char >(*mPosition)))
    {
       num = num*10 + (*mPosition-'0');
       ++mPosition;
@@ -884,7 +886,7 @@ ParseBuffer::qVal()
          skipChar();
          
          int i = 100;
-         while(!eof() && isdigit(*mPosition) && i)
+         while(!eof() && isdigit(static_cast< unsigned char >(*mPosition)) && i)
          {
             num += (*mPosition-'0') * i;
             i /= 10;
@@ -954,8 +956,8 @@ escapeAndAnnotate(const char* buffer,
             continue;
          }
       }
-      
-      if (iscntrl(c) || (c >= 0x7F))
+
+      if (iscntrl(static_cast< unsigned char >(c)) || (c >= 0x7F))
       {
          ret +='*'; // indicates unprintable character
          continue;

--- a/rutil/dns/ares/adig.c
+++ b/rutil/dns/ares/adig.c
@@ -169,7 +169,7 @@ int getopt(int argc,
  p = argv[carg];
    //register int al = strlen(argv[carg]);
 
-   if (*p  == '-' && isalnum(*(p+1)))
+   if (*p  == '-' && isalnum((unsigned char)*(p+1)))
    {
       char o = *(p+1);
 	 int i,l;

--- a/rutil/stun/Stun.cxx
+++ b/rutil/stun/Stun.cxx
@@ -5,8 +5,9 @@
 #include "rutil/ResipAssert.h"
 #include <cstring>
 #include <iostream>
-#include <cstdlib>   
+#include <cstdlib>
 #include <errno.h>
+#include <ctype.h>
 
 #ifdef WIN32
 #include <winsock2.h>
@@ -21,7 +22,7 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/time.h>
-#include <sys/types.h> 
+#include <sys/types.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -1235,7 +1236,7 @@ stunParseHostName(char* peerName,
 
 #ifdef WIN32
    resip_assert(strlen(host) >= 1);
-   if (isdigit(host[0]))
+   if (isdigit(static_cast< unsigned char >(host[0])))
    {
       // assume it is a ip address 
 #if defined(_MSC_VER) && _MSC_VER >= 1800  /* removing compilation warning in VS2013+ */

--- a/tfm/CppTestSelector.cxx
+++ b/tfm/CppTestSelector.cxx
@@ -1,4 +1,5 @@
 #include "CppTestSelector.hxx"
+#include <ctype.h>
 #include <cstring>
 #include <iostream>
 #include <regex>
@@ -15,7 +16,7 @@ CommandLineSelector::CommandLineSelector(int argc, char** argv) : mArgNumTimes(0
 	{
 		std::string userInput = argv[i];
 
-		if(isdigit(*userInput.c_str()))
+		if(isdigit(static_cast< unsigned char >(*userInput.c_str())))
 		{
 		   int res = atoi(userInput.c_str());
 
@@ -110,7 +111,7 @@ void CommandLineSelector::ReadLineInput(std::vector<int> &result, int maxSelecti
       std::cout << "Enter a test number (or pattern) followed by number of repetitions: ";
       std::cin >> userInput;
       std::cin >> repeatStr;
-      if(isdigit(*userInput.c_str()))
+      if(isdigit(static_cast< unsigned char >(*userInput.c_str())))
       {
          res = atoi(userInput.c_str());
          if(res == maxSelection)  

--- a/tfm/repro/sanityTests.cxx
+++ b/tfm/repro/sanityTests.cxx
@@ -2,6 +2,8 @@
 #include "config.h"
 #endif
 
+#include <ctype.h>
+
 #include <cppunit/TextTestRunner.h>
 #include <cppunit/TextTestResult.h>
 #include <cppunit/TextOutputter.h>
@@ -347,13 +349,13 @@ class TestHolder : public ReproFixture
          Data& branch = *const_cast<Data*>(&(msg->header(h_Vias).front().param(p_branch).getTransactionId()));
          for(Data::size_type i=0;i<branch.size();++i)
          {
-            if(isupper(branch[i]))
+            if(isupper(static_cast< unsigned char >(branch[i])))
             {
-               branch[i] = tolower(branch[i]);
+               branch[i] = tolower(static_cast< unsigned char >(branch[i]));
             }
-            else if(islower(branch[i]))
+            else if(islower(static_cast< unsigned char >(branch[i])))
             {
-               branch[i] = toupper(branch[i]);
+               branch[i] = toupper(static_cast< unsigned char >(branch[i]));
             }
          }
          return msg;
@@ -367,7 +369,7 @@ class TestHolder : public ReproFixture
          Data& branch = *const_cast<Data*>(&(msg->header(h_Vias).front().param(p_branch).getTransactionId()));
          for(Data::size_type i=0;i<branch.size();++i)
          {
-            branch[i] = toupper(branch[i]);
+            branch[i] = toupper(static_cast< unsigned char >(branch[i]));
          }
          return msg;
       }


### PR DESCRIPTION
Functions defined in `<cctype>` have undefined behavior if a negative value is passed on input. Input values must always be converted to unsigned integers.

Also, added missing includes.