### PR TITLE
Remove custom definition of `strncasecmp`

### DIFF
--- a/resip/stack/Headers.cxx
+++ b/resip/stack/Headers.cxx
@@ -11,11 +11,8 @@
 #include "resip/stack/HeaderHash.hxx"
 
 #include <iostream>
+
 using namespace std;
-
-//int strcasecmp(const char*, const char*);
-//int strncasecmp(const char*, const char*, int len);
-
 using namespace resip;
 
 Data Headers::HeaderNames[MAX_HEADERS+1];

--- a/resip/stack/MethodTypes.cxx
+++ b/resip/stack/MethodTypes.cxx
@@ -63,20 +63,6 @@ resip::getMethodType(const char* name, int len)
    return m ? m->type : UNKNOWN;
 }
 
-// ?dlb? why aren't we using the lib strncasecmp?
-int strncasecmp(const char* a, const char* b, int len)
-{
-    //!ah! whoever implemented this should be shot.
-    //!ah! should use library based strncasecmp() !
-    //!ah! have fixed it up a bit.
-   for (int i = 0; i < len; i++)
-   {
-      int c = tolower(a[i]) - tolower(b[i]);
-      if (c) return c;
-   }
-   return 0;
-}
-
 /* ====================================================================
  * The Vovida Software License, Version 1.0 
  * 

--- a/resip/stack/ParameterTypes.cxx
+++ b/resip/stack/ParameterTypes.cxx
@@ -41,8 +41,6 @@ _enum##_Param::_enum##_Param()                                                  
 }                                                                               \
 _enum##_Param resip::p_##_enum
 
-int strncasecmp(char*,char*,int);
-
 using namespace std;
 
 using namespace resip;


### PR DESCRIPTION
The custom definition had non-standard signature and could conflict with the same-named function in libc. It also incorrectly used `tolower()`.