### PR TITLE
build: expose `config.h` to library users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -914,6 +914,8 @@ endif()
 add_definitions(-DHAVE_CONFIG_H)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/)
 
 # Used to group targets together when CMake generates projects for IDEs
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
`config.h` defines macros required for correct compilation of Resiprocate-related classes.
For example, it controls `std::string_view` support, but the header was not previously installed, preventing users from including it. This change installs the file so that client projects can use the same configuration as the library.