### PR TITLE
Fix `weak_bind` constructor definition

### DIFF
--- a/reTurn/client/TurnAsyncSocket.hxx
+++ b/reTurn/client/TurnAsyncSocket.hxx
@@ -187,7 +187,7 @@ private:
       // argument for this constructor BE CAREFUL that you are passing 'this' and
       // not 'shared_from_this()' to the bind(..) -- otherwise you will defeat the
       // purpose of this class holding a weak_ptr
-      weak_bind<P,F>(std::weak_ptr<P> parent, std::function<F> func)
+      weak_bind(std::weak_ptr<P> parent, std::function<F> func)
          : mParent(std::move(parent)), mFunction(std::move(func))
       {
       }


### PR DESCRIPTION
The constructor name should not include template parameters. Otherwise, it causes compilation errors with gcc 13.3 in C++20 mode.