### PR TITLE
Remove operations on volatile variables

### DIFF
--- a/rutil/Log.hxx
+++ b/rutil/Log.hxx
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #endif
 
+#include <atomic>
 #include <set>
 
 #include "rutil/ConfigParse.hxx"
@@ -286,7 +287,7 @@ class Log
 
    protected:
       static Mutex _mutex;
-      static volatile short touchCount;
+      static std::atomic<unsigned int> touchCount;
       static const Data delim;
 
       static unsigned int MaxLineCount;

--- a/rutil/test/testRandomThread.cxx
+++ b/rutil/test/testRandomThread.cxx
@@ -29,17 +29,17 @@ class Barrier {
    protected:
       Condition mCond;
       Mutex mMutex;
-      volatile int mCurId;
-      volatile int mHaveCnt;
+      int mCurId;
+      int mHaveCnt;
       int mWantCnt;
 
    public:
-      static volatile int sPreWaitCnt;
-      static volatile int sPostWaitCnt;
+      static int sPreWaitCnt;
+      static int sPostWaitCnt;
 };
 
-volatile int Barrier::sPreWaitCnt = 0;
-volatile int Barrier::sPostWaitCnt = 0;
+int Barrier::sPreWaitCnt = 0;
+int Barrier::sPostWaitCnt = 0;
 
 void
 Barrier::sync(int id, bool isMaster)


### PR DESCRIPTION
C++20 deprecates operations other than reads and writes  performed on volatile variables. Compilers generate warnings about this.

In the `Log` class, `touchCount` was marked as volatile in attempt to emulate atomics in C++03 (which was incorrect; atomicity was not guaranteed). Replace it with `std::atomic`. Also change it to `unsigned int` to increase chances of native support for atomic operations rather than emulation.

In testRandomThread, the volatile variables need not be marked as such as the compiler is required to reload these variables across `wait()` calls since a wait call unlocks and locks the mutex, which implies release and acquire fences.