### PR TITLE
Fix C++20 warnings about operations on enums of different types

### DIFF
--- a/resip/dum/DialogUsageManager.cxx
+++ b/resip/dum/DialogUsageManager.cxx
@@ -1067,13 +1067,13 @@ void DialogUsageManager::outgoingProcess(std::unique_ptr<Message> message)
       
       DumFeatureChain::ProcessingResult res = it->second->process(message.get());
       
-      if (res & DumFeatureChain::ChainDoneBit)
+      if (static_cast<unsigned int>(res) & DumFeatureChain::ChainDoneBit)
       {
          delete it->second;
          mOutgoingFeatureChainMap.erase(it);
       }
 
-      if (res & DumFeatureChain::EventTakenBit)
+      if (static_cast<unsigned int>(res) & DumFeatureChain::EventTakenBit)
       {
          message.release();
          return;
@@ -1608,14 +1608,14 @@ DialogUsageManager::incomingProcess(std::unique_ptr<Message> msg)
       
       DumFeatureChain::ProcessingResult res = it->second->process(msg.get());
       
-      if (res & DumFeatureChain::ChainDoneBit)
+      if (static_cast<unsigned int>(res) & DumFeatureChain::ChainDoneBit)
       {
          delete it->second;
          mIncomingFeatureChainMap.erase(it);
          //DebugLog(<< "feature chain deleted" << endl);
       }
  
-      if (res & DumFeatureChain::EventTakenBit)
+      if (static_cast<unsigned int>(res) & DumFeatureChain::EventTakenBit)
       {
          msg.release();
          //DebugLog(<< "event taken");

--- a/resip/dum/DumFeatureChain.cxx
+++ b/resip/dum/DumFeatureChain.cxx
@@ -64,10 +64,10 @@ DumFeatureChain::ProcessingResult DumFeatureChain::process(Message* msg)
                break;
          }
 
-         if (pres & DumFeature::EventDoneBit)
+         if (static_cast<unsigned int>(pres) & DumFeature::EventDoneBit)
          {
             delete msg;
-            int bits = pres;
+            unsigned int bits = pres;
             bits ^= DumFeature::EventDoneBit;
             bits |= DumFeature::EventTaken;
             pres = static_cast<DumFeature::ProcessingResult>(bits);
@@ -80,13 +80,13 @@ DumFeatureChain::ProcessingResult DumFeatureChain::process(Message* msg)
    while(!stop && feat != mFeatures.end());
 
 
-   int chainBits = 0;
-   if (pres & DumFeature::ChainDoneBit || feat == mFeatures.end())
+   unsigned int chainBits = 0;
+   if (static_cast<unsigned int>(pres) & DumFeature::ChainDoneBit || feat == mFeatures.end())
    {
       chainBits |= ChainDoneBit;
    }
 
-   if (pres & DumFeature::EventTakenBit)
+   if (static_cast<unsigned int>(pres) & DumFeature::EventTakenBit)
    {
       chainBits |= EventTakenBit;
    }

--- a/resip/stack/Auth.hxx
+++ b/resip/stack/Auth.hxx
@@ -17,7 +17,7 @@ namespace resip
 class Auth : public ParserCategory
 {
    public:
-      enum {commaHandling = NoCommaTokenizing};
+      static constexpr CommaHandlingMode commaHandling = NoCommaTokenizing;
 
       Auth();
       Auth(const HeaderFieldValue& hfv, Headers::Type type, PoolBase* pool=0);

--- a/resip/stack/CSeqCategory.hxx
+++ b/resip/stack/CSeqCategory.hxx
@@ -18,7 +18,7 @@ namespace resip
 class CSeqCategory : public ParserCategory
 {
    public:
-      enum {commaHandling = NoCommaTokenizing};
+      static constexpr CommaHandlingMode commaHandling = NoCommaTokenizing;
       
       CSeqCategory();
       CSeqCategory(const HeaderFieldValue& hfv, 

--- a/resip/stack/CallId.hxx
+++ b/resip/stack/CallId.hxx
@@ -17,7 +17,7 @@ namespace resip
 class CallID : public ParserCategory
 {
    public:
-      enum {commaHandling = NoCommaTokenizing};
+      static constexpr CommaHandlingMode commaHandling = NoCommaTokenizing;
 
       CallID();
       CallID(const HeaderFieldValue& hfv, 

--- a/resip/stack/DateCategory.hxx
+++ b/resip/stack/DateCategory.hxx
@@ -48,7 +48,7 @@ enum Month {
 class DateCategory : public ParserCategory
 {
    public:
-      enum {commaHandling = NoCommaTokenizing};
+      static constexpr CommaHandlingMode commaHandling = NoCommaTokenizing;
 
       DateCategory();
       DateCategory(time_t datetime);

--- a/resip/stack/ExpiresCategory.hxx
+++ b/resip/stack/ExpiresCategory.hxx
@@ -19,7 +19,7 @@ namespace resip
 class ExpiresCategory : public ParserCategory
 {
    public:
-      enum {commaHandling = NoCommaTokenizing};
+      static constexpr CommaHandlingMode commaHandling = NoCommaTokenizing;
 
       ExpiresCategory();
       ExpiresCategory(const HeaderFieldValue& hfv, 

--- a/resip/stack/GenericUri.hxx
+++ b/resip/stack/GenericUri.hxx
@@ -16,7 +16,7 @@ namespace resip
 class GenericUri : public ParserCategory
 {
    public:
-      enum {commaHandling = CommasAllowedOutputMulti};
+      static constexpr CommaHandlingMode commaHandling = CommasAllowedOutputMulti;
 
       GenericUri() : ParserCategory() {}
       GenericUri(const HeaderFieldValue& hfv, 

--- a/resip/stack/IntegerCategory.hxx
+++ b/resip/stack/IntegerCategory.hxx
@@ -15,7 +15,7 @@ namespace resip
 class IntegerCategory : public ParserCategory
 {
    public:
-      enum {commaHandling = NoCommaTokenizing};
+      static constexpr CommaHandlingMode commaHandling = NoCommaTokenizing;
 
       IntegerCategory();
       IntegerCategory(const HeaderFieldValue& hfv, 

--- a/resip/stack/Mime.hxx
+++ b/resip/stack/Mime.hxx
@@ -19,7 +19,7 @@ class HeaderFieldValue;
 class Mime : public ParserCategory
 {
    public:
-      enum {commaHandling = CommasAllowedOutputCommas};
+      static constexpr CommaHandlingMode commaHandling = CommasAllowedOutputCommas;
 
       Mime();
       Mime(const Data& type, const Data& subType);

--- a/resip/stack/NameAddr.hxx
+++ b/resip/stack/NameAddr.hxx
@@ -18,7 +18,7 @@ namespace resip
 class NameAddr : public ParserCategory
 {
    public:
-      enum {commaHandling = CommasAllowedOutputMulti};
+      static constexpr CommaHandlingMode commaHandling = CommasAllowedOutputMulti;
 
       NameAddr();
       NameAddr(const HeaderFieldValue& hfv, 

--- a/resip/stack/ParserCategory.hxx
+++ b/resip/stack/ParserCategory.hxx
@@ -92,7 +92,7 @@ class ParserCategory : public LazyParser
       // CommasAllowedOutputCommas: multi headers can be received with commas
       //                            and will always output with commas when
       //                            parsed.  
-      enum {NoCommaTokenizing = 0, CommasAllowedOutputMulti = 1, CommasAllowedOutputCommas = 3};
+      enum CommaHandlingMode {NoCommaTokenizing = 0, CommasAllowedOutputMulti = 1, CommasAllowedOutputCommas = 3};
 
       /**
          @internal

--- a/resip/stack/PrivacyCategory.hxx
+++ b/resip/stack/PrivacyCategory.hxx
@@ -17,7 +17,7 @@ namespace resip
 class PrivacyCategory : public ParserCategory
 {
    public:
-      enum {commaHandling = CommasAllowedOutputCommas};
+      static constexpr CommaHandlingMode commaHandling = CommasAllowedOutputCommas;
 
       PrivacyCategory();
       explicit PrivacyCategory(const Data& d);

--- a/resip/stack/RAckCategory.hxx
+++ b/resip/stack/RAckCategory.hxx
@@ -17,7 +17,7 @@ namespace resip
 class RAckCategory : public ParserCategory
 {
    public:
-      enum {commaHandling = NoCommaTokenizing};
+      static constexpr CommaHandlingMode commaHandling = NoCommaTokenizing;
       
       RAckCategory();
       RAckCategory(const HeaderFieldValue& hfv, 

--- a/resip/stack/StringCategory.hxx
+++ b/resip/stack/StringCategory.hxx
@@ -17,7 +17,7 @@ namespace resip
 class StringCategory : public ParserCategory
 {
    public:
-      enum {commaHandling = NoCommaTokenizing};
+      static constexpr CommaHandlingMode commaHandling = NoCommaTokenizing;
 
       StringCategory();
       explicit StringCategory(const Data& value);

--- a/resip/stack/Token.hxx
+++ b/resip/stack/Token.hxx
@@ -17,7 +17,7 @@ namespace resip
 class Token : public ParserCategory
 {
    public:
-      enum {commaHandling = CommasAllowedOutputCommas};
+      static constexpr CommaHandlingMode commaHandling = CommasAllowedOutputCommas;
 
       Token();
       explicit Token(const Data& d);

--- a/resip/stack/TokenOrQuotedStringCategory.hxx
+++ b/resip/stack/TokenOrQuotedStringCategory.hxx
@@ -18,7 +18,7 @@ namespace resip
 class TokenOrQuotedStringCategory : public ParserCategory
 {
    public:
-      enum {commaHandling = CommasAllowedOutputCommas};
+      static constexpr CommaHandlingMode commaHandling = CommasAllowedOutputCommas;
 
       TokenOrQuotedStringCategory();
       explicit TokenOrQuotedStringCategory(const Data& value, bool quoted);

--- a/resip/stack/UInt32Category.hxx
+++ b/resip/stack/UInt32Category.hxx
@@ -17,7 +17,7 @@ namespace resip
 class UInt32Category : public ParserCategory
 {
    public:
-      enum {commaHandling = NoCommaTokenizing};
+      static constexpr CommaHandlingMode commaHandling = NoCommaTokenizing;
 
       UInt32Category();
       UInt32Category(const HeaderFieldValue& hfv, 

--- a/resip/stack/Via.hxx
+++ b/resip/stack/Via.hxx
@@ -17,7 +17,7 @@ class PoolBase;
 class Via : public ParserCategory
 {
    public:
-      enum {commaHandling = CommasAllowedOutputMulti};
+      static constexpr CommaHandlingMode commaHandling = CommasAllowedOutputMulti;
 
       Via();
       Via(const HeaderFieldValue& hfv, 

--- a/resip/stack/WarningCategory.hxx
+++ b/resip/stack/WarningCategory.hxx
@@ -17,7 +17,7 @@ namespace resip
 class WarningCategory : public ParserCategory
 {
    public:
-      enum {commaHandling = CommasAllowedOutputCommas};
+      static constexpr CommaHandlingMode commaHandling = CommasAllowedOutputCommas;
 
       WarningCategory();
       WarningCategory(const HeaderFieldValue& hfv, 


### PR DESCRIPTION
C++20 deprecates support for bitwise operations where the two arguments have different enum types. Compilers generate warnings about this.

In Headers.cxx, `commaHandling` is used in bitwise operations with `ParserCategory::CommasAllowedOutputMulti`. Since `commaHandling` is defined as an unnamed enum in each class derived from `ParserCategory`, each constant constitutes a distinct enum type. To avoid the warnings, name the enum in `ParserCategory` and use that name to define `commaHandling` constants.

In DumFeatureChain.cxx and DialogUsageManager.cxx, `DumFeature::ProcessingResult` bit masks are tested using `DumFeature::ProcessingResultMask` bits, which are two different enums. To avoid the warnings, cast the enums to `unsigned int` (since these are bit masks).