### PR TITLE
Fix deprecated implicit this captures and dangling pointer captures

### DIFF
--- a/reTurn/client/TurnAsyncSocket.hxx
+++ b/reTurn/client/TurnAsyncSocket.hxx
@@ -227,9 +227,9 @@ private:
    void channelBindingTimerExpired(const asio::error_code& e, unsigned short channel);
 
    void doRequestSharedSecret();
-   void doSetUsernameAndPassword(resip::Data* username, resip::Data* password, bool shortTermAuth);
-   void doSetLocalPassword(resip::Data* password);
-   void doSetSoftware(resip::Data* software);
+   void doSetUsernameAndPassword(resip::Data&& username, resip::Data&& password, bool shortTermAuth);
+   void doSetLocalPassword(resip::Data&& password);
+   void doSetSoftware(resip::Data&& software);
    void doBindRequest();
    void doConnectivityCheck(StunTuple* targetAddr, uint32_t peerRflxPriority, bool setIceControlling, bool setIceControlled, unsigned int numRetransmits, unsigned int retrans_iterval_ms);
    void doCreateAllocation(unsigned int lifetime = UnspecifiedLifetime,


### PR DESCRIPTION
C++20 deprecates implicit capture of `this` pointer by the `[=]` capture clause. Compilers generate warnings about this. Explicitly specify `this`, where needed.

Furthermore, in a few methods of `TurnAsyncSocket`, raw pointers were captured in the callbacks passed to `asio::dispatch`. Since `asio::dispatch` may post the callback to the IO thread, the captured pointer could become dangling when the callback was invoked. Avoid this by capturing `Data` instead. To avoid an extra copy, move the captured `Data` object into the `TurnAsyncSocket` class members when the callback is invoked.