### PR TITLE
Fix potential ambiguity of the comparison operator for `BranchParameter`

### DIFF
--- a/resip/stack/BranchParameter.cxx
+++ b/resip/stack/BranchParameter.cxx
@@ -159,7 +159,7 @@ BranchParameter::operator=(const BranchParameter& other)
 }
 
 bool
-BranchParameter::operator==(const BranchParameter& other)
+BranchParameter::operator==(const BranchParameter& other) const
 {
    if (mIsMyBranch != other.mIsMyBranch ||
        mHasMagicCookie != other.mHasMagicCookie ||

--- a/resip/stack/BranchParameter.hxx
+++ b/resip/stack/BranchParameter.hxx
@@ -67,7 +67,7 @@ class BranchParameter : public Parameter
 
       BranchParameter(const BranchParameter& other);
       BranchParameter& operator=(const BranchParameter& other);
-      bool operator==(const BranchParameter& other);
+      bool operator==(const BranchParameter& other) const;
 
       Type& value() {return *this;}
 


### PR DESCRIPTION
C++20 introduces support for comparison operator rewriting. In particular, the compiler is now able to synthesize comparison operators with swapped arguments, so e.g. for `operator==(A, B)` it would synthesize `operator==(B, A)`.

This poses a problem for `BranchParameter::operator==`, which is declared non-const and accepts a `const BranchParameter&` argument. The above rewriting would synthesize a different `operator==` that is marked as const but accepts a non-const `BranchParameter&` argument. Invoking comparison between two non-const `BranchParameter` objects would therefore be ambiguous as the original and the synthesized overloads would both equally match. Gcc 14 gratiously accepts such code, albeit with a warning, but other compilers may reject it.

Fix this by marking the `operator==` as `const`.