### PR TITLE
Fix the NameAddr parse issue

### DIFF
--- a/resip/stack/NameAddr.cxx
+++ b/resip/stack/NameAddr.cxx
@@ -40,8 +40,8 @@ NameAddr::NameAddr(const NameAddr& rhs,
                    PoolBase* pool)
    : ParserCategory(rhs, pool),
      mAllContacts(rhs.mAllContacts),
-     mUri(rhs.mUri, pool),
-     mDisplayName(rhs.mDisplayName),
+     mUri(rhs.uri(), pool),
+     mDisplayName(rhs.displayName()),
      mUnknownUriParametersBuffer(0)
 {}
 


### PR DESCRIPTION
Fixes an issue where accessing a name-addr header could incorrectly produce an empty result when the display name is unquoted.

Example:
`Referred-By: Name <sip:1002@portsip.com>`

Then code such as:
`auto referredBy = msg.header(h_ReferredBy);`

The returned referredBy with an empty mUri and mDisplayName, even though the header was present and valid. This change ensures Referred-By (and other name-addr style headers) are parsed and accessible correctly whether the display name is unquoted.