### PR TITLE
resip/stack: downgrade duplicate parameter-name log to INFO level

### DIFF
--- a/resip/stack/ParserCategory.cxx
+++ b/resip/stack/ParserCategory.cxx
@@ -274,7 +274,7 @@ ParserCategory::addParameter(Parameter* param)
    {
       // RFC 3261 7.3.1 & 19.1.1
       // any given parameter-name MUST NOT appear more than once
-      WarningLog(<< "Duplicate parameter-name \"" << param->getName() << "\", skip it.");
+      InfoLog(<< "Duplicate parameter-name \"" << param->getName() << "\", skip it.");
       return false;
    }
 }
@@ -295,7 +295,7 @@ ParserCategory::addParameter(UnknownParameter* unknownParam)
    {
       // RFC 3261 7.3.1 & 19.1.1
       // any given parameter-name MUST NOT appear more than once
-      WarningLog(<< "Duplicate parameter-name \"" << unknownParamName << "\", skip it.");
+      InfoLog(<< "Duplicate parameter-name \"" << unknownParamName << "\", skip it.");
       return false;
    }
 }


### PR DESCRIPTION
Duplicate parameters are a protocol violation per RFC 3261 §7.3.1 and §19.1.1, but the stack already handles them gracefully by silently skipping the duplicate. Using WarningLog implies operator attention is needed, which is not the case here.

Downgrade to InfoLog to avoid noise in production environments where non-compliant peers may frequently send duplicate parameters.