### PR TITLE
fix deprecated compilation warnings on Windows + const char*

### DIFF
--- a/resip/stack/InterruptableStackThread.cxx
+++ b/resip/stack/InterruptableStackThread.cxx
@@ -28,6 +28,8 @@ InterruptableStackThread::~InterruptableStackThread()
 #ifndef WIN32
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else 
+#pragma warning(disable : 4996)
 #endif
 
 void

--- a/resip/stack/StackThread.cxx
+++ b/resip/stack/StackThread.cxx
@@ -26,6 +26,8 @@ StackThread::~StackThread()
 #ifndef WIN32
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#else 
+#pragma warning(disable : 4996)
 #endif
 
 void

--- a/rutil/WinCompat.cxx
+++ b/rutil/WinCompat.cxx
@@ -14,6 +14,7 @@
 #include "rutil/WinLeakCheck.hxx"
 
 #define RESIPROCATE_SUBSYSTEM Subsystem::TRANSPORT
+#pragma warning(disable : 4996)
 
 
 static char* ConvertLPWSTRToLPSTR(LPWSTR lpwszStrIn)

--- a/rutil/stun/Stun.cxx
+++ b/rutil/stun/Stun.cxx
@@ -1190,7 +1190,7 @@ namespace resip
 
    // returns true if it scucceeded
    bool
-      stunParseHostName(char* peerName,
+      stunParseHostName(const char* peerName,
          uint32_t& ip,
          uint16_t& portVal,
          uint16_t defaultPort)
@@ -1296,7 +1296,7 @@ namespace resip
 
 
    bool
-      stunParseServerName(char* name, StunAddress4& addr)
+      stunParseServerName(const char* name, StunAddress4& addr)
    {
       resip_assert(name);
 

--- a/rutil/stun/Stun.hxx
+++ b/rutil/stun/Stun.hxx
@@ -376,7 +376,7 @@ namespace resip
 
    /// find the IP address of a the specified stun server - return false is fails parse 
    bool
-      stunParseServerName(char* software, StunAddress4& stunServerAddr);
+      stunParseServerName(const char* software, StunAddress4& stunServerAddr);
 
    bool
       stunParseHostName(char* peerName,


### PR DESCRIPTION
Deprecation warnings on Windows should be also suppressed.

Note there's a GetVersionEx deprecation also - could you pls check? not sure if and how this should be handled