### PR TITLE
Fix ACK correlation for retransmitted INVITE 2xx responses

### DIFF
--- a/resip/dum/InviteSession.cxx
+++ b/resip/dum/InviteSession.cxx
@@ -1385,7 +1385,9 @@ InviteSession::dispatch(const DumTimeout& timeout)
 {
    if (timeout.type() == DumTimeout::Retransmit200)
    {
-      if (mCurrentRetransmit200)
+      if (mCurrentRetransmit200 &&
+          mInvite200 &&
+          timeout.seq() == mInvite200->header(h_CSeq).sequence())
       {
          InfoLog(<< "Retransmitting: " << endl << mInvite200->brief());
          //DumHelper::setOutgoingEncryptionLevel(*mInvite200, mCurrentEncryptionLevel);
@@ -1393,12 +1395,18 @@ InviteSession::dispatch(const DumTimeout& timeout)
          mCurrentRetransmit200 *= 2;
          mDum.addTimerMs(DumTimeout::Retransmit200, resipMin(Timer::T2, mCurrentRetransmit200), getBaseHandle(), timeout.seq());
       }
+      else if (mCurrentRetransmit200)   // we ARE retransmitting, but this timer is for a superseded 2xx
+      {
+         InfoLog(<< "Ignoring stale Retransmit200 timer: seq=" << timeout.seq()
+                 << " current=" << (mInvite200 ? mInvite200->header(h_CSeq).sequence() : 0u));
+      }
+      // else: mCurrentRetransmit200 == 0 -> ACK already received; nothing to do (matches prior silent behaviour)
    }
    else if (timeout.type() == DumTimeout::WaitForAck)
    {
       if (mCurrentRetransmit200)  // If retransmit200 timer is active then ACK is not received yet
       {
-         if (timeout.seq() == mLastRemoteSessionModification->header(h_CSeq).sequence())
+         if (mInvite200 && timeout.seq() == mInvite200->header(h_CSeq).sequence())
          {
             mCurrentRetransmit200 = 0; // stop the 200 retransmit timer
 
@@ -1608,10 +1616,10 @@ InviteSession::dispatchConnected(const SipMessage& msg)
 
       case OnAck:
       case OnAckAnswer:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -1835,10 +1843,10 @@ InviteSession::dispatchSentReinvite(const SipMessage& msg)
 
       case OnAck:
       case OnAckAnswer:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -2012,10 +2020,10 @@ InviteSession::dispatchReceivedReinviteSentOffer(const SipMessage& msg)
          break;
       }
       case OnAckAnswer:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -2034,10 +2042,10 @@ InviteSession::dispatchReceivedReinviteSentOffer(const SipMessage& msg)
          }
          break;
       case OnAck:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -2242,10 +2250,10 @@ InviteSession::dispatchWaitingToHangup(const SipMessage& msg)
    {
       case OnAck:
       case OnAckAnswer:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -2325,10 +2333,10 @@ InviteSession::dispatchOthers(const SipMessage& msg)
          dispatchMessage(msg);
          break;
       case ACK:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -2654,11 +2662,35 @@ InviteSession::dispatchMessage(const SipMessage& msg)
    }
 }
 
+// RFC 3261 13.2.2.4: the ACK for a 2xx INVITE response carries the same CSeq
+// sequence number as the INVITE/2xx it acknowledges.  mInvite200 holds the 2xx
+// we are currently retransmitting, so its CSeq sequence number is the correct
+// (and only reliable) key for deciding whether an inbound ACK terminates that
+// retransmission.  Keying off this - rather than mLastRemoteSessionModification -
+// is robust under re-INVITE glare (where the session has already moved on to
+// SentReinvite/Glare for a crossing re-INVITE) and under a peer that re-uses or
+// does not strictly increase the in-dialog CSeq.
+bool
+InviteSession::isAckForCurrent200(const SipMessage& ack) const
+{
+   if (!ack.isRequest() || ack.header(h_RequestLine).method() != ACK)
+   {
+      return false;
+   }
+
+   if (mCurrentRetransmit200 == 0 || !mInvite200)
+   {
+      return false;
+   }
+
+   return ack.header(h_CSeq).sequence() == mInvite200->header(h_CSeq).sequence();
+}
+
 void
 InviteSession::startRetransmit200Timer()
 {
    mCurrentRetransmit200 = Timer::T1;
-   unsigned int seq = mLastRemoteSessionModification->header(h_CSeq).sequence();
+   unsigned int seq = mInvite200->header(h_CSeq).sequence();
    mDum.addTimerMs(DumTimeout::Retransmit200, mCurrentRetransmit200, getBaseHandle(), seq);
    mDum.addTimerMs(DumTimeout::WaitForAck, Timer::TH, getBaseHandle(), seq);
 }

--- a/resip/dum/InviteSession.hxx
+++ b/resip/dum/InviteSession.hxx
@@ -333,6 +333,13 @@ class InviteSession : public DialogUsage
       void dispatchMessage(const SipMessage& msg);
       void dispatchOptions(const SipMessage& msg);
 
+      // True iff the supplied message is an ACK, a 2xx (INVITE) retransmission
+      // is currently outstanding (mInvite200 / mCurrentRetransmit200), and the
+      // ACK acknowledges that 2xx.  Correlates on the CSeq sequence number
+      // (RFC 3261 13.2.2.4); robust under re-INVITE glare and a peer that
+      // re-uses the in-dialog CSeq.
+      [[nodiscard]] bool isAckForCurrent200(const SipMessage& ack) const;
+
       void startRetransmit200Timer();
       void start491Timer();
       void startStaleReInviteTimer();


### PR DESCRIPTION
Summary:

InviteSession previously decided whether an inbound ACK should stop retransmission of an outstanding 200 OK to an INVITE or re-INVITE by comparing mLastRemoteSessionModification's CSeq against the ACK's CSeq.

The previous logic was effectively:

lastRemote.CSeq > ack.CSeq means drop the ACK as stale.

That is the wrong correlator. The response currently being retransmitted is held in mInvite200, and the ACK for a 2xx INVITE response carries the same CSeq sequence number as the INVITE and 2xx response it acknowledges.

This change correlates the ACK against mInvite200 instead of mLastRemoteSessionModification, applies the same key to the Retransmit200 and WaitForAck timers, and adds two defensive checks.

Symptoms:

A UAS-sent 200 OK to a re-INVITE may continue retransmitting even though the peer's ACK is received and routed to the dialog.

The log may show dropped stale ACK, or there may be no effective clear of the retransmission state.

onAckReceived is not called for the valid ACK.

After the ACK wait timer expires, the call may be torn down.

This was observed in production during session-timer re-INVITE glare and overlapping session-modification traffic.

Root cause:

The clear-on-ACK logic in several ACK handling paths was keyed on mLastRemoteSessionModification.

That value represents the most recently received remote session-modification request. It is not necessarily the INVITE whose 200 OK is currently being retransmitted.

During re-INVITE glare or overlapping session-modification traffic, the dialog state and mLastRemoteSessionModification can advance while a previous 200 OK is still waiting for its ACK. In that case, a valid ACK for the outstanding 200 OK can be misclassified as stale, leaving mCurrentRetransmit200 active until the ACK wait timer expires.

The correct correlator is the CSeq sequence number in mInvite200, because mInvite200 is the actual 2xx response currently being retransmitted.

Fix:

Add InviteSession::isAckForCurrent200(const SipMessage&) const.

The helper returns true only when all of the following are true:

1. The supplied message is a SIP request.
2. The request method is ACK.
3. A 2xx INVITE retransmission is currently outstanding.
4. The ACK's CSeq sequence number matches mInvite200's CSeq sequence number.

Replace the old mLastRemoteSessionModification-based stale ACK guard with !isAckForCurrent200(msg) in the relevant ACK handling paths.

Key startRetransmit200Timer() and the WaitForAck timer off mInvite200's CSeq instead of mLastRemoteSessionModification's CSeq.

Harden the Retransmit200 timer path so it retransmits only when all of the following are true:

mCurrentRetransmit200 is active.
mInvite200 is available.
timeout.seq() matches mInvite200->header(h_CSeq).sequence().

This prevents a stale timer event from retransmitting a replaced mInvite200.

Update the stale ACK log message to:

dropped stale or duplicate ACK