### PR TITLE
resip/dum: correlate the 2xx ACK to mInvite200 (fix endless 200 OK re…

### DIFF
--- a/resip/dum/InviteSession.cxx
+++ b/resip/dum/InviteSession.cxx
@@ -1385,7 +1385,9 @@ InviteSession::dispatch(const DumTimeout& timeout)
 {
    if (timeout.type() == DumTimeout::Retransmit200)
    {
-      if (mCurrentRetransmit200)
+      if (mCurrentRetransmit200 &&
+          mInvite200 &&
+          timeout.seq() == mInvite200->header(h_CSeq).sequence())
       {
          InfoLog(<< "Retransmitting: " << endl << mInvite200->brief());
          //DumHelper::setOutgoingEncryptionLevel(*mInvite200, mCurrentEncryptionLevel);
@@ -1393,12 +1395,18 @@ InviteSession::dispatch(const DumTimeout& timeout)
          mCurrentRetransmit200 *= 2;
          mDum.addTimerMs(DumTimeout::Retransmit200, resipMin(Timer::T2, mCurrentRetransmit200), getBaseHandle(), timeout.seq());
       }
+      else if (mCurrentRetransmit200)   // we ARE retransmitting, but this timer is for a superseded 2xx
+      {
+         InfoLog(<< "Ignoring stale Retransmit200 timer: seq=" << timeout.seq()
+                 << " current=" << (mInvite200 ? mInvite200->header(h_CSeq).sequence() : 0u));
+      }
+      // else: mCurrentRetransmit200 == 0 -> ACK already received; nothing to do (matches prior silent behaviour)
    }
    else if (timeout.type() == DumTimeout::WaitForAck)
    {
       if (mCurrentRetransmit200)  // If retransmit200 timer is active then ACK is not received yet
       {
-         if (timeout.seq() == mLastRemoteSessionModification->header(h_CSeq).sequence())
+         if (mInvite200 && timeout.seq() == mInvite200->header(h_CSeq).sequence())
          {
             mCurrentRetransmit200 = 0; // stop the 200 retransmit timer
 
@@ -1608,10 +1616,10 @@ InviteSession::dispatchConnected(const SipMessage& msg)
 
       case OnAck:
       case OnAckAnswer:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -1835,10 +1843,10 @@ InviteSession::dispatchSentReinvite(const SipMessage& msg)
 
       case OnAck:
       case OnAckAnswer:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -2012,10 +2020,10 @@ InviteSession::dispatchReceivedReinviteSentOffer(const SipMessage& msg)
          break;
       }
       case OnAckAnswer:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -2034,10 +2042,10 @@ InviteSession::dispatchReceivedReinviteSentOffer(const SipMessage& msg)
          }
          break;
       case OnAck:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -2242,10 +2250,10 @@ InviteSession::dispatchWaitingToHangup(const SipMessage& msg)
    {
       case OnAck:
       case OnAckAnswer:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -2325,10 +2333,10 @@ InviteSession::dispatchOthers(const SipMessage& msg)
          dispatchMessage(msg);
          break;
       case ACK:
-         // Not checking for strict equality, since request may have been digest challenged
-         if (mLastRemoteSessionModification->header(h_CSeq).sequence() > msg.header(h_CSeq).sequence())
+         // Stop retransmitting our 2xx once its ACK arrives; correlate by CSeq sequence (RFC 3261 13.2.2.4) - see isAckForCurrent200()
+         if (!isAckForCurrent200(msg))
          {
-            InfoLog(<< "dropped stale ACK");
+            InfoLog(<< "dropped stale or duplicate ACK");
          }
          else
          {
@@ -2654,11 +2662,35 @@ InviteSession::dispatchMessage(const SipMessage& msg)
    }
 }
 
+// RFC 3261 13.2.2.4: the ACK for a 2xx INVITE response carries the same CSeq
+// sequence number as the INVITE/2xx it acknowledges.  mInvite200 holds the 2xx
+// we are currently retransmitting, so its CSeq sequence number is the correct
+// (and only reliable) key for deciding whether an inbound ACK terminates that
+// retransmission.  Keying off this - rather than mLastRemoteSessionModification -
+// is robust under re-INVITE glare (where the session has already moved on to
+// SentReinvite/Glare for a crossing re-INVITE) and under a peer that re-uses or
+// does not strictly increase the in-dialog CSeq.
+bool
+InviteSession::isAckForCurrent200(const SipMessage& ack) const
+{
+   if (!ack.isRequest() || ack.header(h_RequestLine).method() != ACK)
+   {
+      return false;
+   }
+
+   if (mCurrentRetransmit200 == 0 || !mInvite200)
+   {
+      return false;
+   }
+
+   return ack.header(h_CSeq).sequence() == mInvite200->header(h_CSeq).sequence();
+}
+
 void
 InviteSession::startRetransmit200Timer()
 {
    mCurrentRetransmit200 = Timer::T1;
-   unsigned int seq = mLastRemoteSessionModification->header(h_CSeq).sequence();
+   unsigned int seq = mInvite200->header(h_CSeq).sequence();
    mDum.addTimerMs(DumTimeout::Retransmit200, mCurrentRetransmit200, getBaseHandle(), seq);
    mDum.addTimerMs(DumTimeout::WaitForAck, Timer::TH, getBaseHandle(), seq);
 }

--- a/resip/dum/InviteSession.hxx
+++ b/resip/dum/InviteSession.hxx
@@ -338,7 +338,7 @@ class InviteSession : public DialogUsage
       // ACK acknowledges that 2xx.  Correlates on the CSeq sequence number
       // (RFC 3261 13.2.2.4); robust under re-INVITE glare and a peer that
       // re-uses the in-dialog CSeq.
-      [[nodiscard]] bool isAckForCurrent200(const SipMessage& ack) const;
+      bool isAckForCurrent200(const SipMessage& ack) const;
 
       void startRetransmit200Timer();
       void start491Timer();

--- a/resip/dum/InviteSession.hxx
+++ b/resip/dum/InviteSession.hxx
@@ -333,6 +333,13 @@ class InviteSession : public DialogUsage
       void dispatchMessage(const SipMessage& msg);
       void dispatchOptions(const SipMessage& msg);
 
+      // True iff the supplied message is an ACK, a 2xx (INVITE) retransmission
+      // is currently outstanding (mInvite200 / mCurrentRetransmit200), and the
+      // ACK acknowledges that 2xx.  Correlates on the CSeq sequence number
+      // (RFC 3261 13.2.2.4); robust under re-INVITE glare and a peer that
+      // re-uses the in-dialog CSeq.
+      [[nodiscard]] bool isAckForCurrent200(const SipMessage& ack) const;
+
       void startRetransmit200Timer();
       void start491Timer();
       void startStaleReInviteTimer();


### PR DESCRIPTION
## Summary

`InviteSession` previously decided whether an inbound ACK should stop retransmission of an outstanding `200 OK` to an INVITE/re-INVITE by comparing `mLastRemoteSessionModification`'s CSeq against the ACK's CSeq:

```text
lastRemote.CSeq > ack.CSeq => drop as stale
```

That is the wrong correlator. The response being retransmitted is held in `mInvite200`, and RFC 3261 §13.2.2.4 / §17.1.1.3 require the ACK for a 2xx INVITE response to carry the same CSeq sequence number as the INVITE/2xx response it acknowledges.

This PR correlates the ACK against `mInvite200`, applies the same key to the `Retransmit200` / `WaitForAck` timers, and adds two defensive checks.

## Symptoms

* A UAS-sent `200 OK` to a re-INVITE keeps retransmitting, using T1, 2*T1, and then capped at T2, even though the peer's ACK is received and routed to the dialog.
* `onAckReceived` is not called for the valid ACK.
* The log may show either no effective clear of the retransmission state or `dropped stale ACK`.
* After about 32 seconds, the ACK wait timer expires and the call is torn down.
* This was observed in production against an SBC that hairpins a B2BUA call and emits bidirectional session-timer refresh re-INVITEs, causing re-INVITE glare / overlapping session-modification traffic.

## Root cause

The clear-on-ACK logic in `dispatchConnected`, `dispatchSentReinvite`, `dispatchReceivedReinviteSentOffer`, `dispatchWaitingToHangup`, `dispatchOthers`, and the `WaitForAck` timer was keyed on `mLastRemoteSessionModification`.

That value represents the most recently received remote session-modification request. It is not necessarily the INVITE whose `200 OK` is currently being retransmitted.

`mLastRemoteSessionModification` can diverge from `mInvite200` in cases such as:

1. **Re-INVITE glare**

   We send our own re-INVITE, so the state advances to `SentReinvite` or a glare-related state, while we are still waiting for the ACK to a 2xx response we sent for the remote's re-INVITE.

2. **Overlapping remote session-modification traffic**

   For example, the remote sends re-INVITE B with CSeq N+1 before the ACK for our `200 OK` to re-INVITE A with CSeq N arrives.

   `dispatchConnected` overwrites `*mLastRemoteSessionModification` with B. When A's ACK with CSeq N arrives, the old guard evaluates `N+1 > N` as true, treats the ACK as stale, logs `dropped stale ACK`, and the retransmission never stops. The `WaitForAck` failsafe is armed with seq N but is compared against CSeq N+1, so it also fails to fire.

3. **Non-monotonic in-dialog CSeq behavior**

   A peer may reuse, or may not strictly increase, the in-dialog CSeq.

Minimal reproducible sequence:

```text
<-- INVITE (CSeq N)      re-INVITE A
--> 200 OK (CSeq N)      start Retransmit200/WaitForAck(seq=N), mInvite200=200(A)
<-- INVITE (CSeq N+1)    re-INVITE B; *mLastRemoteSessionModification = B
--> 200 OK (CSeq N+1)
<-- ACK (CSeq N)         ACK for A -> dispatchOthers -> (N+1 > N) -> "dropped stale ACK"
                         => 200(A) retransmits until the ACK wait timer expires
```

## Fix

* Add a new helper:

  ```cpp
  InviteSession::isAckForCurrent200(const SipMessage&) const
  ```

  The helper returns true only when all of the following are true:

  1. The message is a SIP request.
  2. The request method is ACK.
  3. A 2xx INVITE retransmission is currently outstanding.
  4. `mCurrentRetransmit200 != 0`.
  5. `mInvite200` is valid.
  6. The ACK's CSeq sequence number equals `mInvite200`'s CSeq sequence number.

* Replace the old `mLastRemoteSessionModification`-based stale-ACK guard with `!isAckForCurrent200(msg)` in the relevant ACK handling paths.

  Each branch keeps its existing side effects, including clearing the retransmission state, calling `onAckReceived`, delivering answer-in-ACK, or sending BYE.

  `dispatchOthers` is the universal fallback for re-INVITE and glare states, so this also covers states that do not special-case `OnAck`.

* Key the timers off `mInvite200`.

  `WaitForAck` and `startRetransmit200Timer()` now use `mInvite200`'s CSeq instead of `mLastRemoteSessionModification`'s CSeq. This ensures the timers identify the specific 2xx response and continue to work even if `mLastRemoteSessionModification` is overwritten by later remote session-modification traffic.

* Suppress stale `Retransmit200` timer events.

  The `Retransmit200` branch now retransmits only when `timeout.seq()` still matches the current `mInvite200`'s CSeq. This prevents a leftover timer for a superseded `mInvite200` from retransmitting a replaced response.

  The benign post-ACK case, where `mCurrentRetransmit200 == 0`, stays silent as before. Only genuine stale-chain suppression is logged.

* Update the stale ACK log message to:

  ```text
  dropped stale or duplicate ACK
  ```
