### PR TITLE
rutil: downgrade c-ares deprecation errors to warnings

### DIFF
--- a/rutil/dns/AresDns.cxx
+++ b/rutil/dns/AresDns.cxx
@@ -27,6 +27,14 @@
 #endif
 #endif
 
+#ifndef WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
+#else
+#pragma warning(push)
+#pragma warning(3 : 4996)
+#endif
+
 using namespace resip;
 
 #define RESIPROCATE_SUBSYSTEM resip::Subsystem::DNS


### PR DESCRIPTION
Due to `/sdl` those deprecation warnings are now errors:

```
FAILED: rutil/CMakeFiles/rutil.dir/dns/AresDns.cxx.obj 
C:\PROGRA~1\MICROS~2\2022\COMMUN~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\cl.exe  /nologo /TP -DHAVE_CONFIG_H -DHAVE_VERSION_H -DNOMINMAX -DOPENSSL_API_COMPAT=0x10101000L -DUSE_CARES -DUSE_DTLS -DUSE_IPV6 -DUSE_SSL -D_RESIP_MONOTONIC_CLOCK -D_WIN32_WINNT=0x0601 -IC:\j\30509-2\b\resip1518c1e8eae95\b\build\Release -IC:\j\30509-2\b\resip1518c1e8eae95\b\src -external:IC:\j\30509-2\opens162a9367fb2bf\p\include -external:IC:\j\30509-2\c-are771b7af4ed8c9\p\include -external:W0 /DWIN32 /D_WINDOWS /EHsc /O2 /Ob2 /DNDEBUG -std:c++14 -MD /W3 /sdl -DCARES_STATICLIB /showIncludes /Forutil\CMakeFiles\rutil.dir\dns\AresDns.cxx.obj /Fdrutil\CMakeFiles\rutil.dir\rutil.pdb /FS -c C:\j\30509-2\b\resip1518c1e8eae95\b\src\rutil\dns\AresDns.cxx
C:\j\30509-2\b\resip1518c1e8eae95\b\src\rutil\dns\AresDns.cxx(657): error C4996: 'ares_fds': Use ARES_OPT_EVENT_THREAD or ARES_OPT_SOCK_STATE_CB instead
C:\j\30509-2\b\resip1518c1e8eae95\b\src\rutil\dns\AresDns.cxx(668): error C4996: 'ares_process': Use ares_process_fds instead
C:\j\30509-2\b\resip1518c1e8eae95\b\src\rutil\dns\AresDns.cxx(692): error C4996: 'ares_process': Use ares_process_fds instead
C:\j\30509-2\b\resip1518c1e8eae95\b\src\rutil\dns\AresDns.cxx(711): error C4996: 'ares_query': Use ares_query_dnsrec instead
```

I'm also working on a PR to use the newer c-ares APIs.