### PR TITLE
Preserve percent-escaping in the URI user part

### DIFF
--- a/resip/stack/Uri.cxx
+++ b/resip/stack/Uri.cxx
@@ -81,7 +81,8 @@ Uri::Uri(const Uri& rhs,
      mCanonicalHost(rhs.mCanonicalHost),
      mIsBetweenAngleQuotes(rhs.mIsBetweenAngleQuotes),
      mEmbeddedHeadersText(rhs.mEmbeddedHeadersText.get() ? new Data(*rhs.mEmbeddedHeadersText) : 0),
-     mEmbeddedHeaders(rhs.mEmbeddedHeaders.get() ? new SipMessage(*rhs.mEmbeddedHeaders) : 0)
+     mEmbeddedHeaders(rhs.mEmbeddedHeaders.get() ? new SipMessage(*rhs.mEmbeddedHeaders) : 0),
+     mUserRaw(rhs.mUserRaw ? new Data(*rhs.mUserRaw) : nullptr)
 {}
 
 
@@ -359,6 +360,14 @@ Uri::operator=(const Uri& rhs)
       mHostCanonicalized = rhs.mHostCanonicalized;
       mCanonicalHost = rhs.mCanonicalHost;
       mUser = rhs.mUser;
+      if (rhs.mUserRaw)
+      {
+         mUserRaw.reset(new Data(*rhs.mUserRaw));
+      }
+      else
+      {
+         mUserRaw.reset();
+      }
       mUserParameters = rhs.mUserParameters;
       mPort = rhs.mPort;
       mPassword = rhs.mPassword;
@@ -866,6 +875,14 @@ Uri::aorEqual(const resip::Uri& rhs) const
 void 
 Uri::getAorInternal(bool dropScheme, bool addPort, Data& aor) const
 {
+   // The AOR is an identity/lookup key, so the user part is intentionally
+   // emitted in canonical (table-escaped) form and is NOT preserved verbatim
+   // the way encodeParsed()/getAorAsUri() preserve the sender's mUserRaw.
+   // Canonicalizing here keeps the key stable regardless of how a sender
+   // escaped it (e.g. "%23" vs a literal '#'), which matters because
+   // getAorNoPort() feeds auth key comparisons (DigestAuthenticator, etc.)
+   // and the registration DB is keyed on this form. Do not change this to
+   // preserve mUserRaw without auditing those key/identity paths.
    checkParsed();
    // canonicalize host
 
@@ -1017,6 +1034,7 @@ Uri::setUserAsTelephoneSubscriber(const Token& telephoneSubscriber)
    mUser.clear();
    oDataStream str(mUser);
    str << telephoneSubscriber;
+   mUserRaw.reset();
 }
 
 Data
@@ -1041,8 +1059,14 @@ Uri::getAorAsUri(TransportType transportTypeToRemoveDefaultPort) const
    //.dcm. -- tel conversion?
    checkParsed();
    Uri ret;
-   ret.scheme() = mScheme;   
+   ret.scheme() = mScheme;
    ret.user() = mUser;
+   // Carry the as-received user bytes so a derived URI that reaches the wire
+   // (e.g. a Route built from the AOR) preserves the sender's escaping too.
+   if (mUserRaw)
+   {
+      ret.mUserRaw.reset(new Data(*mUserRaw));
+   }
    ret.host() = mHost;
 
    // Remove any default ports (if required)
@@ -1075,6 +1099,9 @@ Uri::parse(ParseBuffer& pb)
 {
    pb.skipWhitespace();
    const char* start = pb.position();
+
+   // Cleared up front so a path that sets no user part leaves no stale raw.
+   mUserRaw.reset();
 
    // Relative URLs (typically HTTP) start with a slash.  These
    // are seen when parsing the WebSocket handshake.
@@ -1155,7 +1182,28 @@ Uri::parse(ParseBuffer& pb)
       if(atSign)
       {
 #ifdef HANDLE_CHARACTER_ESCAPING
+         // Scan the user part -- exactly the range dataUnescaped decodes below
+         // (':' before a password, else '@') -- for an escape before decoding.
+         // (This '%' scan repeats one dataUnescaped does internally.)
+         const char* userEnd = pb.position();
+         bool userHasEscape = false;
+         for (const char* p = start; p < userEnd; ++p)
+         {
+            if (*p == Symbols::PERCENT[0])
+            {
+               userHasEscape = true;
+               break;
+            }
+         }
          pb.dataUnescaped(mUser, start);
+         // Capture the as-received bytes only after the decode succeeds -- it can
+         // throw on a malformed escape, and mUserRaw must never hold bytes that
+         // fail to decode, so the encode-path re-decode cannot throw. mUserRaw
+         // then always decodes back to the mUser just produced.
+         if (userHasEscape)
+         {
+            mUserRaw.reset(new Data(start, (Data::size_type)(userEnd - start)));
+         }
 #else
          pb.data(mUser, start);
 #endif
@@ -1277,7 +1325,33 @@ Uri::encodeParsed(EncodeStream& str) const
    if (!mUser.empty())
    {
 #ifdef HANDLE_CHARACTER_ESCAPING
-      mUser.escapeToStream(str, getUserEncodingTable()); 
+      if (mUserRaw)
+      {
+         // Emit the as-received bytes verbatim while they still decode (via the
+         // same dataUnescaped as parse) to the current mUser, so the sender's
+         // escaping (e.g. %23) survives regardless of the encoding table; a
+         // post-parse edit breaks the match and falls back to table escaping.
+         // Cost: re-decodes and compares on the encode path for every
+         // %-containing user part (inline Data buffer avoids a heap alloc for
+         // short values; unescaped users skip this branch).
+         Data decodedUserRaw;
+         ParseBuffer pb(mUserRaw->data(), mUserRaw->size());
+         const char* anchor = pb.position();
+         pb.skipToEnd();
+         pb.dataUnescaped(decodedUserRaw, anchor);
+         if (decodedUserRaw == mUser)
+         {
+            str << *mUserRaw;
+         }
+         else
+         {
+            mUser.escapeToStream(str, getUserEncodingTable());
+         }
+      }
+      else
+      {
+         mUser.escapeToStream(str, getUserEncodingTable());
+      }
 #else
       str << mUser;
 #endif

--- a/resip/stack/Uri.hxx
+++ b/resip/stack/Uri.hxx
@@ -306,6 +306,9 @@ class Uri : public ParserCategory
    private:
       std::unique_ptr<Data> mEmbeddedHeadersText;
       std::unique_ptr<SipMessage> mEmbeddedHeaders;
+      // As-received user-part bytes, kept only when the user part contains a
+      // percent-escape, so that escaping is preserved verbatim on re-encode.
+      std::unique_ptr<Data> mUserRaw;
 
       static ParameterTypes::Factory ParameterFactories[ParameterTypes::MAX_PARAMETER];
 

--- a/resip/stack/test/testUri.cxx
+++ b/resip/stack/test/testUri.cxx
@@ -1070,6 +1070,59 @@ main(int argc, char* argv[])
       Uri::setUriUserEncoding('#', true);
    }
 
+   // An already-escaped '#' (%23) in the user part must be preserved on the
+   // wire even when '#' encoding is disabled; it must not be unquoted to a bare
+   // '#' (which is invalid in the RFC 3261 user part and rejected by strict
+   // parsers downstream).
+   {
+      Uri::setUriUserEncoding('#', false);
+
+      // user() still exposes the decoded value
+      Uri uri = Uri("sip:1234%2300442031111111@lvdx.com");
+      assert(uri.user() == "1234#00442031111111");
+      assert(Data::from(uri) == "sip:1234%2300442031111111@lvdx.com");
+
+      // ... and it survives a host retarget (which re-serializes the URI)
+      uri.host() = "pn.internal";
+      assert(Data::from(uri) == "sip:1234%2300442031111111@pn.internal");
+
+      // a literal '#' input still passes through as a literal '#'
+      Uri literalUri = Uri("sip:1234#00442031111111@lvdx.com");
+      literalUri.host() = "pn.internal";
+      assert(Data::from(literalUri) == "sip:1234#00442031111111@pn.internal");
+
+      // modifying the user part after parse abandons the as-received bytes and
+      // falls back to table-based escaping ('#' disabled -> bare '#')
+      Uri modified = Uri("sip:1234%2300442031111111@lvdx.com");
+      modified.user() = "5678#99";
+      assert(Data::from(modified) == "sip:5678#99@lvdx.com");
+
+      // the preserved bytes survive a copy and an assignment
+      Uri copied = uri;
+      assert(Data::from(copied) == "sip:1234%2300442031111111@pn.internal");
+      Uri assigned;
+      assigned = uri;
+      assert(Data::from(assigned) == "sip:1234%2300442031111111@pn.internal");
+
+      // a URI derived via getAorAsUri (e.g. used to build an on-wire Route)
+      // also preserves the escaping
+      Uri aorUri = Uri("sip:1234%2300442031111111@lvdx.com").getAorAsUri();
+      assert(Data::from(aorUri) == "sip:1234%2300442031111111@lvdx.com");
+
+      // an escaped user part followed by a password: the raw capture must cover
+      // only the user part (up to the colon), not the password
+      Uri withPassword = Uri("sip:1234%2300:secret@lvdx.com");
+      withPassword.host() = "pn.internal";
+      assert(Data::from(withPassword) == "sip:1234%2300:secret@pn.internal");
+
+      Uri::setUriUserEncoding('#', true);
+
+      // the raw form is emitted byte-for-byte: a lowercase escape stays
+      // lowercase, and an escaped otherwise-safe character stays escaped
+      // rather than being canonicalised by the encoding table
+      assert(Data::from(Uri("sip:12%2a34@lvdx.com")) == "sip:12%2a34@lvdx.com");
+   }
+
    {
       Uri uri = Uri("sip:1234#00442031111111;phone-context=+89@lvdx.com");
       assert(uri.userIsTelephoneSubscriber());


### PR DESCRIPTION
### Problem

`Uri` decodes percent-escapes in the user part at parse time
(`dataUnescaped` into `mUser`) and re-encodes them on serialization via the
process-global user-encoding table. When that table is configured **not** to
escape a character through `setUriUserEncoding()` — e.g. to let a literal `#`
pass through unescaped — an inbound percent-escaped form of that character is
silently unquoted on output: `sip:1234%2300@h` parses `mUser` to `1234#00` and
then serializes as `sip:1234#00@h`. The user part no longer round-trips, and a
strict RFC 3261 parser rejects the result because `#` is not allowed unescaped
in the user part.

### Fix

Keep the as-received user-part bytes (`mUserRaw`) whenever the user part
contains a percent-escape, and emit them verbatim on encode as long as they
still decode (via the same `dataUnescaped`) to the current `mUser`. A
post-parse modification of the user part breaks that equality and falls back to
the existing table-based escaping. The raw bytes are propagated across the copy
constructor, `operator=`, and `getAorAsUri`, and cleared in
`setUserAsTelephoneSubscriber`.

An escaped character now round-trips unchanged regardless of the
encoding-table configuration, while an unescaped character is still encoded per
the table exactly as before. The common path is unaffected — `mUserRaw` is only
populated when the user part contains a `%`.

### Compatibility

This also changes serialization under the **default** encoding table: a user
part containing any percent-escape is now emitted with its escaping preserved
rather than canonicalized (e.g. `sip:12%2a34@h` stays `12%2a34` instead of
becoming `12*34`). This is RFC 3261-equivalent — user parts compare after
unescaping and `operator==`/`aorEqual` compare the decoded value — but it is a
visible on-wire change for every caller, not only those that customize the table
via `setUriUserEncoding()`.

### Tests

`testUri` extended: an escaped `#` survives a host retarget, a copy, an
assignment, and `getAorAsUri`; a post-parse modification falls back to
table-based escaping; a password-bearing user part and a lowercase escape are
preserved byte-for-byte.