### PR TITLE
Add urn: (RFC 8141) scheme support to resip::Uri

### DIFF
--- a/resip/dum/BaseCreator.cxx
+++ b/resip/dum/BaseCreator.cxx
@@ -105,7 +105,14 @@ BaseCreator::makeInitialRequest(const NameAddr& target, const NameAddr& from, Me
       {
          contact.uri() = mUserProfile->getOverrideHostAndPort();
       }
-      contact.uri().user() = from.uri().user();
+      // Contact header will always have a sip: scheme so it's safe to copy
+      // the user part from sip:, sips: and tel: but not from others like urn:
+      if (isEqualNoCase(from.uri().scheme(), Symbols::Sip) ||
+         isEqualNoCase(from.uri().scheme(), Symbols::Sips) ||
+         isEqualNoCase(from.uri().scheme(), Symbols::Tel))
+      {
+         contact.uri().user() = from.uri().user();
+      }
 
       // .jjg. there isn't anything in the outbound [11] draft that says we 
       // aren't allowed to include p_Instance in this case...  

--- a/resip/dum/BaseCreator.cxx
+++ b/resip/dum/BaseCreator.cxx
@@ -107,9 +107,14 @@ BaseCreator::makeInitialRequest(const NameAddr& target, const NameAddr& from, Me
       }
       // Contact header will always have a sip: scheme so it's safe to copy
       // the user part from sip:, sips: and tel: but not from others like urn:
-      if (isEqualNoCase(from.uri().scheme(), Symbols::Sip) ||
-         isEqualNoCase(from.uri().scheme(), Symbols::Sips) ||
-         isEqualNoCase(from.uri().scheme(), Symbols::Tel))
+      // (RFC 8141's NID:NSS has nothing to do with a sip: user's ABNF).
+      // When skipped, contact.uri().user() keeps whatever it already had:
+      // empty by default, or whatever getOverrideHostAndPort() set above --
+      // i.e. for a urn: "from" (e.g. an emergency-services From), an
+      // override profile's own user is now preserved instead of being
+      // clobbered by the (incompatible) urn: user. Legal either way; see
+      // the analogous comment in Dialog.cxx for the To/Request-URI case.
+      if (from.uri().isUserRelevant())
       {
          contact.uri().user() = from.uri().user();
       }

--- a/resip/dum/Dialog.cxx
+++ b/resip/dum/Dialog.cxx
@@ -125,20 +125,27 @@ Dialog::Dialog(DialogUsageManager& dum, const SipMessage& msg, DialogSet& ds)
                      {
                         // Contact header will always have a sip: scheme so it's safe to copy
                         // the user part from sip:, sips: and tel: but not from others like urn:
-                        if (isEqualNoCase(request.header(h_To).uri().scheme(), Symbols::Sip) ||
-                           isEqualNoCase(request.header(h_To).uri().scheme(), Symbols::Sips) ||
-                           isEqualNoCase(request.header(h_To).uri().scheme(), Symbols::Tel))
+                        // (RFC 8141's NID:NSS has nothing to do with a sip: user's ABNF).
+                        // When skipped, mLocalContact.uri().user() keeps whatever
+                        // getOverrideHostAndPort() set above (or stays empty) --
+                        // e.g. for a urn: To (an incoming request targeting an
+                        // emergency-services URN), the local Contact ends up with
+                        // no user part at all: "sip:host:port". Legal per RFC 3261
+                        // (Contact only needs a valid sip:/sips: URI), and arguably
+                        // the only sane choice here, since there is no sip:-shaped
+                        // user to carry over from a urn: To.
+                        if (request.header(h_To).uri().isUserRelevant())
                         {
                            mLocalContact.uri().user() = request.header(h_To).uri().user();
                         }
                      }
                      else
                      {
-                        // Contact header will always have a sip: scheme so it's safe to copy
-                        // the user part from sip:, sips: and tel: but not from others like urn:
-                        if (isEqualNoCase(request.header(h_RequestLine).uri().scheme(), Symbols::Sip) ||
-                           isEqualNoCase(request.header(h_RequestLine).uri().scheme(), Symbols::Sips) ||
-                           isEqualNoCase(request.header(h_RequestLine).uri().scheme(), Symbols::Tel))
+                        // Same reasoning as above, for the case where the
+                        // Request-URI (rather than To) carries the user to copy
+                        // -- e.g. a urn: Request-URI (RFC 5031 emergency call)
+                        // also leaves mLocalContact.uri().user() untouched.
+                        if (request.header(h_RequestLine).uri().isUserRelevant())
                         {
                            mLocalContact.uri().user() = request.header(h_RequestLine).uri().user();
                         }

--- a/resip/dum/Dialog.cxx
+++ b/resip/dum/Dialog.cxx
@@ -123,11 +123,25 @@ Dialog::Dialog(DialogUsageManager& dum, const SipMessage& msg, DialogSet& ds)
                      }
                      if(request.header(h_RequestLine).uri().user().empty())
                      {
-                        mLocalContact.uri().user() = request.header(h_To).uri().user(); 
+                        // Contact header will always have a sip: scheme so it's safe to copy
+                        // the user part from sip:, sips: and tel: but not from others like urn:
+                        if (isEqualNoCase(request.header(h_To).uri().scheme(), Symbols::Sip) ||
+                           isEqualNoCase(request.header(h_To).uri().scheme(), Symbols::Sips) ||
+                           isEqualNoCase(request.header(h_To).uri().scheme(), Symbols::Tel))
+                        {
+                           mLocalContact.uri().user() = request.header(h_To).uri().user();
+                        }
                      }
                      else
                      {
-                        mLocalContact.uri().user() = request.header(h_RequestLine).uri().user(); 
+                        // Contact header will always have a sip: scheme so it's safe to copy
+                        // the user part from sip:, sips: and tel: but not from others like urn:
+                        if (isEqualNoCase(request.header(h_RequestLine).uri().scheme(), Symbols::Sip) ||
+                           isEqualNoCase(request.header(h_RequestLine).uri().scheme(), Symbols::Sips) ||
+                           isEqualNoCase(request.header(h_RequestLine).uri().scheme(), Symbols::Tel))
+                        {
+                           mLocalContact.uri().user() = request.header(h_RequestLine).uri().user();
+                        }
                      }
                      const Data& instanceId = mDialogSet.mUserProfile->getInstanceId();
                      if (!contact.uri().exists(p_gr) && !instanceId.empty())

--- a/resip/dum/MasterProfile.cxx
+++ b/resip/dum/MasterProfile.cxx
@@ -38,6 +38,7 @@ MasterProfile::MasterProfile() :
    addSupportedMethod(BYE);
    addSupportedMethod(UPDATE);
    addSupportedScheme(Symbols::Sip);  
+   addSupportedScheme(Symbols::Urn);
 }
 
 void 

--- a/resip/dum/MasterProfile.cxx
+++ b/resip/dum/MasterProfile.cxx
@@ -37,8 +37,10 @@ MasterProfile::MasterProfile() :
    addSupportedMethod(OPTIONS);
    addSupportedMethod(BYE);
    addSupportedMethod(UPDATE);
-   addSupportedScheme(Symbols::Sip);  
-   addSupportedScheme(Symbols::Urn);
+   addSupportedScheme(Symbols::Sip);
+   // urn: (e.g. RFC 5031 emergency service URNs) is intentionally not
+   // added to the default supported schemes. An application that wants 
+   // it should call addSupportedScheme(Symbols::Urn) itself.
 }
 
 void 

--- a/resip/dum/MasterProfile.hxx
+++ b/resip/dum/MasterProfile.hxx
@@ -19,8 +19,16 @@ class MasterProfile : public UserProfile
       /// Creates an Identity/Profile with no BaseProfile - this is the root of all profiles
       MasterProfile();  
       
-      /// Default is "sip"
-      virtual void addSupportedScheme(const Data& scheme);          
+      /// Default is "sip". Note: "urn" (RFC 8141, e.g. the RFC 5031
+      /// emergency service URNs like "urn:service:sos") is intentionally
+      /// NOT included by default -- accepting urn: Request-URIs is
+      /// deployment policy, not something the library should impose on
+      /// every application. An application that wants to accept them
+      /// (e.g. an emergency-services UAS) should call this explicitly:
+      /// @code
+      ///    masterProfile->addSupportedScheme(Symbols::Urn);
+      /// @endcode
+      virtual void addSupportedScheme(const Data& scheme);
       virtual bool isSchemeSupported(const Data& scheme) const;
       virtual void clearSupportedSchemes() noexcept;
 

--- a/resip/dum/test/CMakeLists.txt
+++ b/resip/dum/test/CMakeLists.txt
@@ -50,6 +50,7 @@ test(testDialogSetId testDSI.cxx)
 #test(testIdentity testIdentity.cxx)    # deprecated
 test(testPubDocument testPubDocument.cxx)
 test(testRedirectManager testRedirectManager.cxx)
+test(testUrnContact testUrnContact.cxx)
 #test(testSMIMEInvite testSMIMEInvite.cxx)   #deprecated
 #test(testSMIMEMessage testSMIMEMessage.cxx) #deprecated
 

--- a/resip/dum/test/testUrnContact.cxx
+++ b/resip/dum/test/testUrnContact.cxx
@@ -1,0 +1,245 @@
+// Regression test for the behavior documented in Dialog.cxx and
+// BaseCreator.cxx: when a request's To/Request-URI is a urn: (e.g. an
+// RFC 5031 emergency-services URN), its user part is NOT copied into the
+// local Contact (urn:'s NID:NSS has nothing to do with a sip: user's
+// ABNF). This sends a real INVITE from a UAC to a urn: target and checks
+// that the UAS's resulting Contact (as seen by the UAC in the 180
+// response) ends up with a sip: URI and no user part.
+
+#include "resip/stack/SdpContents.hxx"
+#include "resip/stack/SipMessage.hxx"
+#include "resip/stack/SipStack.hxx"
+#include "resip/dum/ClientInviteSession.hxx"
+#include "resip/dum/DialogUsageManager.hxx"
+#include "resip/dum/InviteSessionHandler.hxx"
+#include "resip/dum/MasterProfile.hxx"
+#include "resip/dum/ServerInviteSession.hxx"
+#include "rutil/Log.hxx"
+#include "rutil/Logger.hxx"
+
+#define RESIPROCATE_SUBSYSTEM Subsystem::TEST
+
+using namespace resip;
+using namespace std;
+
+class TestInviteSessionHandler : public InviteSessionHandler
+{
+   public:
+      Data name;
+      bool sawProvisional;
+      NameAddr contactSeen;
+
+      TestInviteSessionHandler(const Data& n) : name(n), sawProvisional(false)
+      {
+      }
+
+      virtual ~TestInviteSessionHandler()
+      {
+      }
+
+      virtual void onNewSession(ClientInviteSessionHandle, InviteSession::OfferAnswerType, const SipMessage& msg)
+      {
+         cout << name << ": ClientInviteSession-onNewSession - " << msg.brief() << endl;
+      }
+
+      // UAS side: a new INVITE arrived (Request-URI/To == urn:service:sos).
+      // Immediately send a provisional response so the UAC can observe the
+      // Contact this Dialog builds for itself.
+      virtual void onNewSession(ServerInviteSessionHandle sis, InviteSession::OfferAnswerType, const SipMessage& msg)
+      {
+         cout << name << ": ServerInviteSession-onNewSession - " << msg.brief() << endl;
+         sis->provisional(180);
+      }
+
+      virtual void onFailure(ClientInviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": ClientInviteSession-onFailure - " << msg.brief() << endl;
+      }
+
+      // UAC side: capture the Contact from the 180 -- this is the UAS's
+      // mLocalContact, built while processing our urn: INVITE.
+      virtual void onProvisional(ClientInviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": ClientInviteSession-onProvisional - " << msg.brief() << endl;
+         if (msg.exists(h_Contacts) && msg.header(h_Contacts).size() == 1)
+         {
+            sawProvisional = true;
+            contactSeen = msg.header(h_Contacts).front();
+         }
+      }
+
+      virtual void onConnected(ClientInviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": ClientInviteSession-onConnected - " << msg.brief() << endl;
+      }
+
+      virtual void onStaleCallTimeout(ClientInviteSessionHandle)
+      {
+         cout << name << ": ClientInviteSession-onStaleCallTimeout" << endl;
+      }
+
+      virtual void onConnected(InviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onConnected - " << msg.brief() << endl;
+      }
+
+      virtual void onRedirected(ClientInviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": ClientInviteSession-onRedirected - " << msg.brief() << endl;
+      }
+
+      virtual void onTerminated(InviteSessionHandle, InviteSessionHandler::TerminatedReason, const SipMessage* msg)
+      {
+         cout << name << ": InviteSession-onTerminated" << endl;
+      }
+
+      virtual void onAnswer(InviteSessionHandle, const SipMessage&, const SdpContents&)
+      {
+         cout << name << ": InviteSession-onAnswer(SDP)" << endl;
+      }
+
+      virtual void onOffer(InviteSessionHandle is, const SipMessage&, const SdpContents&)
+      {
+         cout << name << ": InviteSession-onOffer(SDP)" << endl;
+      }
+
+      virtual void onEarlyMedia(ClientInviteSessionHandle, const SipMessage&, const SdpContents&)
+      {
+         cout << name << ": InviteSession-onEarlyMedia(SDP)" << endl;
+      }
+
+      virtual void onOfferRequired(InviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onOfferRequired - " << msg.brief() << endl;
+      }
+
+      virtual void onOfferRejected(InviteSessionHandle, const SipMessage*)
+      {
+         cout << name << ": InviteSession-onOfferRejected" << endl;
+      }
+
+      virtual void onRefer(InviteSessionHandle, ServerSubscriptionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onRefer - " << msg.brief() << endl;
+      }
+
+      virtual void onReferAccepted(InviteSessionHandle, ClientSubscriptionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onReferAccepted - " << msg.brief() << endl;
+      }
+
+      virtual void onReferRejected(InviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onReferRejected - " << msg.brief() << endl;
+      }
+
+      virtual void onReferNoSub(InviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onReferNoSub - " << msg.brief() << endl;
+      }
+
+      virtual void onInfo(InviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onInfo - " << msg.brief() << endl;
+      }
+
+      virtual void onInfoSuccess(InviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onInfoSuccess - " << msg.brief() << endl;
+      }
+
+      virtual void onInfoFailure(InviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onInfoFailure - " << msg.brief() << endl;
+      }
+
+      virtual void onMessage(InviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onMessage - " << msg.brief() << endl;
+      }
+
+      virtual void onMessageSuccess(InviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onMessageSuccess - " << msg.brief() << endl;
+      }
+
+      virtual void onMessageFailure(InviteSessionHandle, const SipMessage& msg)
+      {
+         cout << name << ": InviteSession-onMessageFailure - " << msg.brief() << endl;
+      }
+
+      virtual void onForkDestroyed(ClientInviteSessionHandle)
+      {
+         cout << name << ": ClientInviteSession-onForkDestroyed" << endl;
+      }
+};
+
+int
+main(int argc, char* argv[])
+{
+   Log::initialize(Log::Cout, resip::Log::Info, argv[0]);
+
+   SdpContents::Session::Medium medium("audio", 8000, 1, "RTP/AVP");
+   Data sdpTxt(
+      "v=0\r\n"
+      "o=1900 369696545 369696545 IN IP4 127.0.0.1\r\n"
+      "s=-\r\n"
+      "c=IN IP4 127.0.0.1\r\n"
+      "t=0 0\r\n"
+      "m=audio 8000 RTP/AVP 0\r\n"
+      "a=rtpmap:0 PCMU/8000\r\n");
+   HeaderFieldValue hfv(sdpTxt.data(), sdpTxt.size());
+   Mime sdpType("application", "sdp");
+   SdpContents offer(hfv, sdpType);
+
+   // Set up UAC.
+   SipStack stackUac;
+   DialogUsageManager dumUac(stackUac);
+   stackUac.addTransport(UDP, 27298);
+
+   auto uacMasterProfile = std::make_shared<MasterProfile>();
+   dumUac.setMasterProfile(uacMasterProfile);
+   dumUac.getMasterProfile()->setDefaultFrom(NameAddr("sip:uac@127.0.0.1:27298"));
+   // A urn: Request-URI has no host to resolve; a real UAC relies on an
+   // outbound/emergency proxy to route it (e.g. via LoST). Point directly
+   // at the UAS to exercise that without needing a real proxy.
+   dumUac.getMasterProfile()->setOutboundProxy(Uri("sip:127.0.0.1:27299"));
+
+   TestInviteSessionHandler uac("UAC");
+   dumUac.setInviteSessionHandler(&uac);
+
+   // Set up UAS. urn: support is opt-in per application (see the comment
+   // on MasterProfile::addSupportedScheme()) -- this is exactly the call
+   // an emergency-services UAS is expected to make.
+   SipStack stackUas;
+   DialogUsageManager dumUas(stackUas);
+   stackUas.addTransport(UDP, 27299);
+
+   auto uasMasterProfile = std::make_shared<MasterProfile>();
+   uasMasterProfile->addSupportedScheme(Symbols::Urn);
+   dumUas.setMasterProfile(uasMasterProfile);
+   dumUas.getMasterProfile()->setDefaultFrom(NameAddr("sip:uas@127.0.0.1:27299"));
+
+   TestInviteSessionHandler uas("UAS");
+   dumUas.setInviteSessionHandler(&uas);
+
+   // UAC sends an INVITE targeting a urn: (RFC 5031 emergency call). Per
+   // BaseCreator::makeInitialRequest(), this becomes both the Request-URI
+   // and the To header.
+   NameAddr target("urn:service:sos");
+   dumUac.send(dumUac.makeInviteSession(target, &offer));
+
+   for (int i = 0; i < 20 && !uac.sawProvisional; i++)
+   {
+      stackUac.process(50);
+      while (dumUac.process());
+      stackUas.process(50);
+      while (dumUas.process());
+   }
+
+   assert(uac.sawProvisional);
+   assert(isEqualNoCase(uac.contactSeen.uri().scheme(), Symbols::Sip));
+   assert(uac.contactSeen.uri().user().empty());
+
+   cout << "!!!!!!!!!!!!!!!!!! Successful !!!!!!!!!! " << endl;
+}

--- a/resip/stack/Aor.cxx
+++ b/resip/stack/Aor.cxx
@@ -26,6 +26,16 @@ Aor::Aor(const Data& value)
    pb.skipChar(Symbols::COLON[0]);
    mScheme.lowercase();
 
+   if (isEqualNoCase(mScheme, Symbols::Urn))
+   {
+      const char* anchor = pb.position();
+      // Unlike tel: (RFC 3966), the char ';' is a valid sub-delim inside 
+      // a urn: (RFC 8141) NSS and must not be treated as a delimiter.
+      pb.skipToOneOf(ParseBuffer::Whitespace, ">");
+      pb.data(mUser, anchor);
+      return;
+   }
+
    if (isEqualNoCase(mScheme, Symbols::Tel))
    {
       const char* anchor = pb.position();

--- a/resip/stack/Aor.cxx
+++ b/resip/stack/Aor.cxx
@@ -13,8 +13,9 @@ Aor::Aor()
 }
 
 Aor::Aor(const Data& value)
+   : mOwnedBuffer(value.data(), value.size())
 {
-   ParseBuffer pb(value);
+   ParseBuffer pb(mOwnedBuffer);
    
    pb.skipWhitespace();
    const char* start = pb.position();

--- a/resip/stack/Aor.hxx
+++ b/resip/stack/Aor.hxx
@@ -39,12 +39,21 @@ class Aor
       EncodeStream& operator<<(EncodeStream& str) const;
 
    private:
+      // Owns a copy of the string passed to Aor(const Data&): mScheme/
+      // mUser/mHost below are overlays (non-owning views, set via
+      // ParseBuffer::data()) into whatever buffer gets parsed, so it must
+      // be this member -- which lives as long as the Aor -- and not the
+      // constructor's `value` argument directly, which may be a temporary
+      // (e.g. Aor aor("sip:...")) destroyed right after the constructor
+      // returns, leaving those views dangling.
+      Data mOwnedBuffer;
+
       mutable Data mValue;
 
       mutable Data mOldScheme;
       mutable Data mOldUser;
       mutable Data mOldHost;
-      mutable int mOldPort;
+      mutable int mOldPort = 0;
 
       // cache for IPV6 host comparison
       mutable Data mCanonicalHost;
@@ -52,7 +61,7 @@ class Aor
       Data mScheme;
       Data mUser;
       Data mHost;
-      int mPort;
+      int mPort = 0;
 };
       
 }

--- a/resip/stack/MessageFilterRule.cxx
+++ b/resip/stack/MessageFilterRule.cxx
@@ -50,7 +50,8 @@ MessageFilterRule::matches(const SipMessage &msg) const
       return false;
    }
    
-   if (msg.header(h_RequestLine).uri().scheme() != Symbols::Tel)
+   if (msg.header(h_RequestLine).uri().scheme() != Symbols::Tel &&
+       msg.header(h_RequestLine).uri().scheme() != Symbols::Urn)
    {
       // !rwm! Should be hostport, not host
       if (!hostIsInList( msg.header(h_RequestLine).uri().host()))
@@ -93,7 +94,8 @@ MessageFilterRule::schemeIsInList(const Data& scheme) const
    // Emtpy list means "sip or sips"
    if (mSchemeList.empty())
    {
-      return (scheme == Symbols::Sip || scheme == Symbols::Sips || scheme == Symbols::Tel);
+      return (scheme == Symbols::Sip || scheme == Symbols::Sips ||
+              scheme == Symbols::Tel || scheme == Symbols::Urn);
    }
 
    // step through mSchemeList looking for supported schemes

--- a/resip/stack/NameAddr.cxx
+++ b/resip/stack/NameAddr.cxx
@@ -248,6 +248,10 @@ NameAddr::parse(ParseBuffer& pb)
       }
       pb.skipWhitespace();
       mUri.setIsBetweenAngleQuotes(laQuote); // Tell Uri parser if the Uri is between angle quotes/brackets or not, so that it can relax embedded header parsing rules if so
+      // Without brackets, header parameters (";tag=...") may follow the
+      // Uri directly with no separator; tell the parser so schemes like
+      // urn: know to stop at ';'/'?'/',' instead of swallowing them.
+      mUri.setIsBareAddrSpec(!laQuote);
       mUri.parse(pb);
       if (laQuote)
       {

--- a/resip/stack/Symbols.cxx
+++ b/resip/stack/Symbols.cxx
@@ -61,6 +61,7 @@ const char* Symbols::SRVSCTP = "_sctp.";
 const char* Symbols::Sip = "sip";
 const char* Symbols::Sips = "sips";
 const char* Symbols::Tel = "tel";
+const char* Symbols::Urn = "urn";
 const char* Symbols::Pres = "pres";
 
 const char* Symbols::Phone = "phone";

--- a/resip/stack/Symbols.hxx
+++ b/resip/stack/Symbols.hxx
@@ -62,6 +62,7 @@ class Symbols
       static const char* Sip;
       static const char* Sips;
       static const char* Tel;
+      static const char* Urn;
       static const char* Pres;
       
       static const char* Phone;

--- a/resip/stack/Uri.cxx
+++ b/resip/stack/Uri.cxx
@@ -29,6 +29,7 @@ static bool initAllTables()
    Uri::getPasswordEncodingTable();
    Uri::getLocalNumberTable();
    Uri::getGlobalNumberTable();
+   Uri::getUrnEncodingTable();
    return true;
 }
 
@@ -519,6 +520,26 @@ bool Uri::isSignificantUriParameter(const ParameterTypes::Type type) noexcept
           type == ParameterTypes::transport;
 }
 
+// urn: (RFC 8141): NID is case-insensitive, NSS is case-sensitive.
+// mUser stores "NID:NSS" (plus optional rq-components/fragment)
+// as one blob (see Uri::parse()), so split on the first ':' -- the NID
+// itself can't contain one (NID = alphanum *(alphanum/"-") alphanum) --
+// and compare each side with the right case rule. 
+// No ':' found (e.g. a malformed/hand-built value) falls back to a plain 
+// case-sensitive compare of the whole thing.
+static bool
+urnUserEqual(const Data& a, const Data& b)
+{
+   const Data::size_type sepA = a.find(Symbols::COLON);
+   const Data::size_type sepB = b.find(Symbols::COLON);
+   if (sepA == Data::npos || sepB == Data::npos)
+   {
+      return a == b;
+   }
+   return isEqualNoCase(a.substr(0, sepA), b.substr(0, sepB)) &&
+          a.substr(sepA) == b.substr(sepB);
+}
+
 bool 
 Uri::operator==(const Uri& other) const
 {
@@ -558,8 +579,25 @@ Uri::operator==(const Uri& other) const
       }
    }
    
+   // urn: needs its own NID/NSS-aware comparison in urnUserEqual()
+   // sip:/sips: user comparison is case-sensitive (RFC 3261 19.1.4);
+   // every other scheme defaults to case-insensitive.
+   bool userEqual;
+   if (isEqualNoCase(mScheme, Symbols::Urn))
+   {
+      userEqual = urnUserEqual(mUser, other.mUser);
+   }
+   else if (isEqualNoCase(mScheme, Symbols::Sip) || isEqualNoCase(mScheme, Symbols::Sips))
+   {
+      userEqual = (mUser == other.mUser);
+   }
+   else
+   {
+      userEqual = isEqualNoCase(mUser, other.mUser);
+   }
+
    if (isEqualNoCase(mScheme, other.mScheme) &&
-       ((isEqualNoCase(mScheme, Symbols::Sip) || isEqualNoCase(mScheme, Symbols::Sips)) ? mUser == other.mUser : isEqualNoCase(mUser, other.mUser)) &&
+       userEqual &&
        isEqualNoCase(mUserParameters,other.mUserParameters) &&
        mPassword == other.mPassword &&
        mPort == other.mPort &&
@@ -920,7 +958,14 @@ Uri::getAorInternal(bool dropScheme, bool addPort, Data& aor) const
 #ifdef HANDLE_CHARACTER_ESCAPING
       {
          oDataStream str(aor);
-         mUser.escapeToStream(str, getUserEncodingTable()); 
+         if (mScheme == Symbols::Urn)
+         {
+            mUser.escapeToStream(str, getUrnEncodingTable());
+         }
+         else
+         {
+            mUser.escapeToStream(str, getUserEncodingTable());
+         }
       }
 #else
       aor += mUser;
@@ -1125,6 +1170,54 @@ Uri::parse(ParseBuffer& pb)
    pb.skipChar(Symbols::COLON[0]);
    mScheme.schemeLowercase();
 
+   // NID:NSS plus any rq-components ("?+"/"?=") and fragment ("#") is
+   // captured as one opaque blob in mUser; no mUserParameters equivalent
+   // (RFC 8141 has none).
+   if (mScheme==Symbols::Urn)
+   {
+      const char* anchor = pb.position();
+      if (mIsBetweenAngleQuotes)
+      {
+         // Inside "<...>" the only terminator is '>' (SIP requires angle
+         // brackets exactly to avoid ';' clashing with NameAddr params).
+         static std::bitset<256> delimiter=Data::toBitset("\r\n\t >");
+         pb.skipToOneOf(delimiter);
+      }
+      else
+      {
+         // No angle brackets (e.g. Request-URI): terminator is whitespace.
+         pb.skipToOneOf(ParseBuffer::Whitespace);
+      }
+#ifdef HANDLE_CHARACTER_ESCAPING
+      // -- same mechanism used for sip:/sips: user.
+      // Decode %XX so user() returns the logical value, as for sip:/sips:.
+      // But '#'/'?' are structural when unescaped (fragment/rq-components),
+      // so a received "%23"/"%3F" (escaped data) and a literal "#"/"?"
+      // (real separator) must not collapse to the same mUser and then
+      // re-encode with the wrong form. Bytes containing '%' are kept
+      // verbatim (mUserRaw) and re-emitted as-is while still decoding to
+      // the same value 
+      const char* userEnd = pb.position();
+      bool userHasEscape = false;
+      for (const char* p = anchor; p < userEnd; ++p)
+      {
+         if (*p == Symbols::PERCENT[0])
+         {
+            userHasEscape = true;
+            break;
+         }
+      }
+      pb.dataUnescaped(mUser, anchor);
+      if (userHasEscape)
+      {
+         mUserRaw.reset(new Data(anchor, (Data::size_type)(userEnd - anchor)));
+      }
+#else
+      pb.data(mUser, anchor);
+#endif
+      return;
+   }
+
    if (mScheme==Symbols::Tel)
    {
       const char* anchor = pb.position();
@@ -1312,6 +1405,11 @@ void Uri::setUriPasswordEncoding(unsigned char c, bool encode)
    getPasswordEncodingTable()[c] = encode;
 }
 
+void Uri::setUriUrnEncoding(unsigned char c, bool encode)
+{
+   getUrnEncodingTable()[c] = encode;
+}
+
 // should not encode user parameters unless its a tel?
 EncodeStream& 
 Uri::encodeParsed(EncodeStream& str) const
@@ -1325,7 +1423,37 @@ Uri::encodeParsed(EncodeStream& str) const
    if (!mUser.empty())
    {
 #ifdef HANDLE_CHARACTER_ESCAPING
-      if (mUserRaw)
+      if (mScheme == Symbols::Urn)
+      {
+         // Same mUserRaw mechanism as sip:/sips: below: emit as-received
+         // bytes verbatim while they still decode to mUser, so '%23'
+         // (escaped data) and a literal '#' (real fragment separator)
+         // don't collapse and re-encode with the wrong character. Falls
+         // back to getUrnEncodingTable() (doesn't escape ':', '@', ';',
+         // '?', '#', sub-delims) if mUser was edited after parsing, or
+         // there's no mUserRaw (e.g. hand-built Uri).
+         if (mUserRaw)
+         {
+            Data decodedUserRaw;
+            ParseBuffer pbUrn(mUserRaw->data(), mUserRaw->size());
+            const char* anchorUrn = pbUrn.position();
+            pbUrn.skipToEnd();
+            pbUrn.dataUnescaped(decodedUserRaw, anchorUrn);
+            if (decodedUserRaw == mUser)
+            {
+               str << *mUserRaw;
+            }
+            else
+            {
+               mUser.escapeToStream(str, getUrnEncodingTable());
+            }
+         }
+         else
+         {
+            mUser.escapeToStream(str, getUrnEncodingTable());
+         }
+      }
+      else if (mUserRaw)
       {
          // Emit the as-received bytes verbatim while they still decode (via the
          // same dataUnescaped as parse) to the current mUser, so the sender's

--- a/resip/stack/Uri.cxx
+++ b/resip/stack/Uri.cxx
@@ -40,7 +40,8 @@ Uri::Uri(PoolBase* pool)
      mScheme(Data::Share, Symbols::DefaultSipScheme),
      mPort(0),
      mHostCanonicalized(false),
-     mIsBetweenAngleQuotes(false)
+     mIsBetweenAngleQuotes(false),
+     mIsBareAddrSpec(false)
 {
 }
 
@@ -48,17 +49,19 @@ Uri::Uri(const HeaderFieldValue& hfv, Headers::Type type, PoolBase* pool) :
    ParserCategory(hfv, type, pool),
    mPort(0),
    mHostCanonicalized(false),
-   mIsBetweenAngleQuotes(false)
+   mIsBetweenAngleQuotes(false),
+   mIsBareAddrSpec(false)
 {}
 
 
 static const Data parseContext("Uri constructor");
 Uri::Uri(const Data& data)
-   : ParserCategory(), 
+   : ParserCategory(),
      mScheme(Symbols::DefaultSipScheme),
      mPort(0),
      mHostCanonicalized(false),
-     mIsBetweenAngleQuotes(false)
+     mIsBetweenAngleQuotes(false),
+     mIsBareAddrSpec(false)
 {
    HeaderFieldValue hfv(data.data(), data.size());
    // must copy because parse creates overlays
@@ -81,6 +84,7 @@ Uri::Uri(const Uri& rhs,
      mHostCanonicalized(rhs.mHostCanonicalized),
      mCanonicalHost(rhs.mCanonicalHost),
      mIsBetweenAngleQuotes(rhs.mIsBetweenAngleQuotes),
+     mIsBareAddrSpec(rhs.mIsBareAddrSpec),
      mEmbeddedHeadersText(rhs.mEmbeddedHeadersText.get() ? new Data(*rhs.mEmbeddedHeadersText) : 0),
      mEmbeddedHeaders(rhs.mEmbeddedHeaders.get() ? new SipMessage(*rhs.mEmbeddedHeaders) : 0),
      mUserRaw(rhs.mUserRaw ? new Data(*rhs.mUserRaw) : nullptr)
@@ -520,27 +524,15 @@ bool Uri::isSignificantUriParameter(const ParameterTypes::Type type) noexcept
           type == ParameterTypes::transport;
 }
 
-// urn: (RFC 8141): NID is case-insensitive, NSS is case-sensitive.
-// mUser stores "NID:NSS" (plus optional rq-components/fragment)
-// as one blob (see Uri::parse()), so split on the first ':' -- the NID
-// itself can't contain one (NID = alphanum *(alphanum/"-") alphanum) --
-// and compare each side with the right case rule. 
-// No ':' found (e.g. a malformed/hand-built value) falls back to a plain 
-// case-sensitive compare of the whole thing.
-static bool
-urnUserEqual(const Data& a, const Data& b)
+bool Uri::isUserRelevant() const
 {
-   const Data::size_type sepA = a.find(Symbols::COLON);
-   const Data::size_type sepB = b.find(Symbols::COLON);
-   if (sepA == Data::npos || sepB == Data::npos)
-   {
-      return a == b;
-   }
-   return isEqualNoCase(a.substr(0, sepA), b.substr(0, sepB)) &&
-          a.substr(sepA) == b.substr(sepB);
+   checkParsed();
+   return isEqualNoCase(mScheme, Symbols::Sip) ||
+          isEqualNoCase(mScheme, Symbols::Sips) ||
+          isEqualNoCase(mScheme, Symbols::Tel);
 }
 
-bool 
+bool
 Uri::operator==(const Uri& other) const
 {
    checkParsed();
@@ -579,15 +571,23 @@ Uri::operator==(const Uri& other) const
       }
    }
    
-   // urn: needs its own NID/NSS-aware comparison in urnUserEqual()
-   // sip:/sips: user comparison is case-sensitive (RFC 3261 19.1.4);
-   // every other scheme defaults to case-insensitive.
+   // Case-sensitive user comparison for:
+   // - sip:/sips: per RFC 3261 sec 19.1.4.
+   // - urn: because the NID (case-insensitive per RFC 8141) is already
+   //   normalized to lowercase by Uri::parse() (see comment there), so a
+   //   plain compare here is correct: NID case differences have already
+   //   been folded away, and NSS case is preserved and compared as-is.
+   //   Known deviation: mUser also holds any rq-components/fragment
+   //   (see the comment in Uri::parse()'s urn branch), which RFC 8141
+   //   sec 3.1 explicitly excludes from URN equivalence -- so here
+   //   "urn:example:nss?+rcomponent" != "urn:example:nss", where the RFC
+   //   would consider them equivalent. Acceptable for SIP routing
+   //   purposes (this is the same granularity used to compare the
+   //   sip:/sips: user part above), but not a strict RFC 8141 comparison.
+   // Every other scheme defaults to case-insensitive.
    bool userEqual;
-   if (isEqualNoCase(mScheme, Symbols::Urn))
-   {
-      userEqual = urnUserEqual(mUser, other.mUser);
-   }
-   else if (isEqualNoCase(mScheme, Symbols::Sip) || isEqualNoCase(mScheme, Symbols::Sips))
+   if (isEqualNoCase(mScheme, Symbols::Sip) || isEqualNoCase(mScheme, Symbols::Sips) ||
+       isEqualNoCase(mScheme, Symbols::Urn))
    {
       userEqual = (mUser == other.mUser);
    }
@@ -958,7 +958,7 @@ Uri::getAorInternal(bool dropScheme, bool addPort, Data& aor) const
 #ifdef HANDLE_CHARACTER_ESCAPING
       {
          oDataStream str(aor);
-         if (mScheme == Symbols::Urn)
+         if (isEqualNoCase(mScheme, Symbols::Urn))
          {
             mUser.escapeToStream(str, getUrnEncodingTable());
          }
@@ -1139,6 +1139,38 @@ Uri::getAorAsUri(TransportType transportTypeToRemoveDefaultPort) const
    return ret;
 }
 
+#ifdef HANDLE_CHARACTER_ESCAPING
+// Decodes [start, pb.position()) into `user`, capturing the as-received
+// bytes into `userRaw` (only if a '%' escape is present) so encodeParsed()
+// can re-emit them verbatim instead of losing the sender's original
+// escaping. Shared by the sip:/sips: and urn: user-parsing below -- both
+// need the exact same "scan for '%', then dataUnescaped" dance.
+static void
+decodeUserPreservingEscapes(ParseBuffer& pb, const char* start,
+                             Data& user, std::unique_ptr<Data>& userRaw)
+{
+   const char* userEnd = pb.position();
+   bool userHasEscape = false;
+   for (const char* p = start; p < userEnd; ++p)
+   {
+      if (*p == Symbols::PERCENT[0])
+      {
+         userHasEscape = true;
+         break;
+      }
+   }
+   pb.dataUnescaped(user, start);
+   // Capture the as-received bytes only after the decode succeeds -- it can
+   // throw on a malformed escape, and userRaw must never hold bytes that
+   // fail to decode, so the encode-path re-decode cannot throw. userRaw
+   // then always decodes back to the user just produced.
+   if (userHasEscape)
+   {
+      userRaw.reset(new Data(start, (Data::size_type)(userEnd - start)));
+   }
+}
+#endif
+
 void
 Uri::parse(ParseBuffer& pb)
 {
@@ -1179,42 +1211,108 @@ Uri::parse(ParseBuffer& pb)
       if (mIsBetweenAngleQuotes)
       {
          // Inside "<...>" the only terminator is '>' (SIP requires angle
-         // brackets exactly to avoid ';' clashing with NameAddr params).
+         // brackets exactly to avoid ';'/'?'/',' clashing with NameAddr
+         // params -- RFC 3261 sec 20 -- so within brackets those chars are
+         // legal NSS content and must not be treated as delimiters).
          static std::bitset<256> delimiter=Data::toBitset("\r\n\t >");
+         pb.skipToOneOf(delimiter);
+      }
+      else if (mIsBareAddrSpec)
+      {
+         // Bare (unbracketed) URI inside a header value (e.g. To/From
+         // without "<...>"), flagged by NameAddr::parse(): stop at
+         // ';'/'?'/',' too, since NameAddr parameters (";tag=...") may
+         // follow directly and RFC 8141 gives no way to tell them apart
+         // from NSS content here. Per RFC 3261 sec 20, a producer whose
+         // NSS needs these characters must use "<...>" instead, where the
+         // permissive rule above still applies.
+         static std::bitset<256> delimiter=Data::toBitset("\r\n\t ;?,");
          pb.skipToOneOf(delimiter);
       }
       else
       {
-         // No angle brackets (e.g. Request-URI): terminator is whitespace.
+         // Every other context: a Request-URI (RequestLine, never
+         // bracketed but with nothing that can follow except whitespace
+         // then SIP-Version), a standalone Uri built directly from a
+         // string, or any other direct caller. ';'/'?'/',' here are legal
+         // NSS content, same as the bracketed case above.
          pb.skipToOneOf(ParseBuffer::Whitespace);
       }
 #ifdef HANDLE_CHARACTER_ESCAPING
-      // -- same mechanism used for sip:/sips: user.
       // Decode %XX so user() returns the logical value, as for sip:/sips:.
       // But '#'/'?' are structural when unescaped (fragment/rq-components),
       // so a received "%23"/"%3F" (escaped data) and a literal "#"/"?"
       // (real separator) must not collapse to the same mUser and then
-      // re-encode with the wrong form. Bytes containing '%' are kept
-      // verbatim (mUserRaw) and re-emitted as-is while still decoding to
-      // the same value 
-      const char* userEnd = pb.position();
-      bool userHasEscape = false;
-      for (const char* p = anchor; p < userEnd; ++p)
-      {
-         if (*p == Symbols::PERCENT[0])
-         {
-            userHasEscape = true;
-            break;
-         }
-      }
-      pb.dataUnescaped(mUser, anchor);
-      if (userHasEscape)
-      {
-         mUserRaw.reset(new Data(anchor, (Data::size_type)(userEnd - anchor)));
-      }
+      // re-encode with the wrong form -- decodeUserPreservingEscapes()
+      // keeps the as-received bytes in mUserRaw for that case.
+      decodeUserPreservingEscapes(pb, anchor, mUser, mUserRaw);
 #else
       pb.data(mUser, anchor);
 #endif
+      // RFC 8141 sec 2: NID = alphanum *(alphanum/"-") alphanum, 2-32
+      // chars, and the NSS must be non-empty; sec 5.1: the NID must not be
+      // "urn" itself (nonsensical/reserved). Reject anything else here so
+      // a malformed urn: fails to parse instead of silently reaching the
+      // application (e.g. DUM) looking like a well-formed one.
+      const Data::size_type sep = mUser.find(Symbols::COLON);
+      if (sep == Data::npos)
+      {
+         pb.fail(__FILE__, __LINE__, "urn: missing NID:NSS separator.");
+      }
+      if (sep < 2 || sep > 32)
+      {
+         pb.fail(__FILE__, __LINE__, "urn: NID must be 2-32 characters.");
+      }
+      for (Data::size_type i = 0; i < sep; ++i)
+      {
+         const unsigned char c = (unsigned char)mUser[i];
+         // Explicit ASCII range, not isalnum(): RFC 8141's NID ABNF is
+         // ASCII-only, but isalnum() follows the process-wide C locale,
+         // so a non-C locale (common in embedded/softswitch apps that
+         // call setlocale() for logging/i18n) would accept 8-bit
+         // characters here that RFC 8141 does not allow.
+         const bool isAsciiAlnum = (c >= '0' && c <= '9') ||
+                                   (c >= 'A' && c <= 'Z') ||
+                                   (c >= 'a' && c <= 'z');
+         if (!isAsciiAlnum && !(c == '-' && i > 0 && i < sep - 1))
+         {
+            pb.fail(__FILE__, __LINE__, "urn: NID has an invalid character.");
+         }
+      }
+      if (sep + 1 >= mUser.size())
+      {
+         pb.fail(__FILE__, __LINE__, "urn: NSS must not be empty.");
+      }
+      if (isEqualNoCase(mUser.substr(0, sep), Symbols::Urn))
+      {
+         pb.fail(__FILE__, __LINE__, "urn: NID must not be \"urn\".");
+      }
+
+      // RFC 8141 sec 2.2: the NID is case-insensitive. Normalize it to
+      // lowercase here, the same way schemeLowercase() already normalizes
+      // the scheme, so operator==, operator<, the hash function and
+      // getAorInternal() all agree on urn: equality without needing a
+      // urn-specific comparator.
+      // NB: this only runs at parse() time, so a hand-built Uri (user()
+      // set directly) is not validated/normalized -- same accepted
+      // limitation as the scheme case-sensitivity noted on
+      // getAorInternal()/encodeParsed().
+      {
+         Data nid(mUser.substr(0, sep));
+         nid.lowercase();
+         mUser = nid + mUser.substr(sep);
+      }
+      // mUserRaw is deliberately left untouched (still the exact bytes
+      // received): the validation above runs on the decoded mUser, so a
+      // NID could in principle hide a gratuitous, unnecessary %-escape
+      // (e.g. "urn:EX%41MPLE:nss") that isn't reflected at the same byte
+      // offset in mUserRaw -- rewriting mUserRaw's NID prefix in place,
+      // like above, would silently corrupt it in that case. Leaving it
+      // untouched is simpler and always correct: encodeParsed()'s
+      // decodedUserRaw==mUser check already re-decodes mUserRaw and falls
+      // back to escaping mUser fresh whenever they no longer match (e.g.
+      // because of this normalization step here), which is exactly the
+      // desired outcome whenever the NID's original casing has changed.
       return;
    }
 
@@ -1275,28 +1373,10 @@ Uri::parse(ParseBuffer& pb)
       if(atSign)
       {
 #ifdef HANDLE_CHARACTER_ESCAPING
-         // Scan the user part -- exactly the range dataUnescaped decodes below
-         // (':' before a password, else '@') -- for an escape before decoding.
-         // (This '%' scan repeats one dataUnescaped does internally.)
-         const char* userEnd = pb.position();
-         bool userHasEscape = false;
-         for (const char* p = start; p < userEnd; ++p)
-         {
-            if (*p == Symbols::PERCENT[0])
-            {
-               userHasEscape = true;
-               break;
-            }
-         }
-         pb.dataUnescaped(mUser, start);
-         // Capture the as-received bytes only after the decode succeeds -- it can
-         // throw on a malformed escape, and mUserRaw must never hold bytes that
-         // fail to decode, so the encode-path re-decode cannot throw. mUserRaw
-         // then always decodes back to the mUser just produced.
-         if (userHasEscape)
-         {
-            mUserRaw.reset(new Data(start, (Data::size_type)(userEnd - start)));
-         }
+         // The range dataUnescaped decodes here is exactly [start, position),
+         // i.e. up to ':' before a password, else '@' -- decodeUserPreservingEscapes()
+         // scans it for an escape and keeps the as-received bytes in mUserRaw.
+         decodeUserPreservingEscapes(pb, start, mUser, mUserRaw);
 #else
          pb.data(mUser, start);
 #endif
@@ -1423,37 +1503,12 @@ Uri::encodeParsed(EncodeStream& str) const
    if (!mUser.empty())
    {
 #ifdef HANDLE_CHARACTER_ESCAPING
-      if (mScheme == Symbols::Urn)
-      {
-         // Same mUserRaw mechanism as sip:/sips: below: emit as-received
-         // bytes verbatim while they still decode to mUser, so '%23'
-         // (escaped data) and a literal '#' (real fragment separator)
-         // don't collapse and re-encode with the wrong character. Falls
-         // back to getUrnEncodingTable() (doesn't escape ':', '@', ';',
-         // '?', '#', sub-delims) if mUser was edited after parsing, or
-         // there's no mUserRaw (e.g. hand-built Uri).
-         if (mUserRaw)
-         {
-            Data decodedUserRaw;
-            ParseBuffer pbUrn(mUserRaw->data(), mUserRaw->size());
-            const char* anchorUrn = pbUrn.position();
-            pbUrn.skipToEnd();
-            pbUrn.dataUnescaped(decodedUserRaw, anchorUrn);
-            if (decodedUserRaw == mUser)
-            {
-               str << *mUserRaw;
-            }
-            else
-            {
-               mUser.escapeToStream(str, getUrnEncodingTable());
-            }
-         }
-         else
-         {
-            mUser.escapeToStream(str, getUrnEncodingTable());
-         }
-      }
-      else if (mUserRaw)
+      // urn: uses its own table (doesn't escape ':', '@', ';', '?', '#',
+      // sub-delims -- RFC 8141); every other scheme uses the sip:/sips:
+      // user table.
+      const EncodingTable& table = isEqualNoCase(mScheme, Symbols::Urn)
+         ? getUrnEncodingTable() : getUserEncodingTable();
+      if (mUserRaw)
       {
          // Emit the as-received bytes verbatim while they still decode (via the
          // same dataUnescaped as parse) to the current mUser, so the sender's
@@ -1473,12 +1528,12 @@ Uri::encodeParsed(EncodeStream& str) const
          }
          else
          {
-            mUser.escapeToStream(str, getUserEncodingTable());
+            mUser.escapeToStream(str, table);
          }
       }
       else
       {
-         mUser.escapeToStream(str, getUserEncodingTable());
+         mUser.escapeToStream(str, table);
       }
 #else
       str << mUser;

--- a/resip/stack/Uri.hxx
+++ b/resip/stack/Uri.hxx
@@ -189,6 +189,22 @@ class Uri : public ParserCategory
       void setIsBetweenAngleQuotes(bool value) { mIsBetweenAngleQuotes = value; }
 
       /**
+         @brief Tells the parser this URI is being parsed as a bare
+                (unbracketed) addr-spec inside a header value (e.g. a
+                To/From without "<...>"), where NameAddr-style header
+                parameters (";tag=...", etc.) may follow directly with no
+                separator of their own. Needed so schemes like urn: (whose
+                NSS may legitimately contain ';'/'?'/',', RFC 8141) know to
+                stop at those characters here -- unlike every other
+                context (Request-URI, a standalone Uri built directly from
+                a string, or between angle brackets), where the same
+                characters are legal NSS content and nothing ambiguous can
+                follow. Set by NameAddr::parse() only; false everywhere
+                else by default.
+      */
+      void setIsBareAddrSpec(bool value) { mIsBareAddrSpec = value; }
+
+      /**
          @brief Compares two known URI parameters for equality.
          @param param1 The first parameter to compare.
          @param param2 The second parameter to compare.
@@ -215,6 +231,16 @@ class Uri : public ParserCategory
          @note Follows RFC 3261 section 19.1.4.
       */
       static bool isSignificantUriParameter(const ParameterTypes::Type type) noexcept;
+
+      /**
+         @brief Checks if this URI's scheme has sip:/sips:/tel: user-part
+                semantics, i.e. whether its user() can be safely copied into
+                another URI (e.g. a Contact, which is always sip:/sips:)
+                that assumes that syntax.
+         @return `true` for sip:, sips: and tel:; `false` for any other
+                 scheme (e.g. urn:, whose user-part ABNF is incompatible).
+      */
+      bool isUserRelevant() const;
 
       typedef std::bitset<Uri::uriEncodingTableSize> EncodingTable;
 
@@ -323,6 +349,7 @@ class Uri : public ParserCategory
       mutable Data mCanonicalHost;  ///< cache for IPv6 host comparison
 
       bool mIsBetweenAngleQuotes;
+      bool mIsBareAddrSpec;
 
    private:
       std::unique_ptr<Data> mEmbeddedHeadersText;

--- a/resip/stack/Uri.hxx
+++ b/resip/stack/Uri.hxx
@@ -162,6 +162,7 @@ class Uri : public ParserCategory
       /** Modifies the default URI encoding character sets */
       static void setUriUserEncoding(unsigned char c, bool encode);
       static void setUriPasswordEncoding(unsigned char c, bool encode);
+      static void setUriUrnEncoding(unsigned char c, bool encode);
       
       bool hasEmbedded() const;
       SipMessage& embedded();
@@ -235,6 +236,26 @@ class Uri : public ParserCategory
                               "0123456789"
                               "-_.!~*\\()&=+$").flip());
          return passwordEncodingTable;
+      }
+
+      /**
+         @brief Encoding table for the NID:NSS (plus optional
+                rq-components/fragment) of a urn: URI (RFC 8141:
+                namestring = "urn" ":" NID ":" NSS).
+                https://tools.ietf.org/html/rfc8141#section-2
+      */
+      static EncodingTable& getUrnEncodingTable()
+      {
+         static EncodingTable urnEncodingTable(
+               Data::toBitset("abcdefghijklmnopqrstuvwxyz"
+                              "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                              "0123456789"
+                              "-._~"           // unreserved
+                              "!$&'()*+,;="    // sub-delims
+                              ":@"             // pchar extras
+                              "/"              // NSS = pchar *(pchar / "/")
+                              "?#").flip());   // rq-components / fragment markers
+         return urnEncodingTable;
       }
 
       static EncodingTable& getLocalNumberTable()

--- a/resip/stack/test/CMakeLists.txt
+++ b/resip/stack/test/CMakeLists.txt
@@ -87,6 +87,7 @@ add_custom_command ( TARGET RFC4475TortureTests POST_BUILD
    COMMAND_EXPAND_LISTS
 )
 manual_test(limpc limpc.cxx)
+test(testAor testAor.cxx)
 test(testAppTimer testAppTimer.cxx)
 test(testApplicationSip testApplicationSip.cxx TestSupport.cxx)
 manual_test(testClient testClient.cxx)

--- a/resip/stack/test/testAor.cxx
+++ b/resip/stack/test/testAor.cxx
@@ -41,6 +41,28 @@ main(int argc, char* argv[])
    {
       Aor aor;
    }
+
+   // urn: (RFC 8141): stored as an opaque NID:NSS blob in user(), no
+   // host/port. Regression test for mPort/mOldPort being left
+   // uninitialized on this early-return path (found in review): call
+   // value() twice to catch a stale/garbage cached value.
+   {
+      Aor aor("urn:service:sos");
+      assert(aor.scheme() == "urn");
+      assert(aor.user() == "service:sos");
+      assert(aor.host().empty());
+      assert(aor.port() == 0);
+      assert(aor.value() == "urn:service:sos");
+      assert(aor.value() == "urn:service:sos"); // second call: cache must agree
+   }
+
+   // ';' is valid NSS content (RFC 8141) and must not be treated as a
+   // delimiter here.
+   {
+      Aor aor("urn:example:a;b;c");
+      assert(aor.user() == "example:a;b;c");
+      assert(aor.value() == "urn:example:a;b;c");
+   }
 }
 
 /* ====================================================================

--- a/resip/stack/test/testUri.cxx
+++ b/resip/stack/test/testUri.cxx
@@ -1181,6 +1181,198 @@ main(int argc, char* argv[])
       assert(!(defaultNameAddr == allContactsNameAddr));
    }
 
+   // ---------------------------------------------------------------------
+   // urn: scheme support (RFC 8141), stored as an opaque NID:NSS blob with
+   // its own ABNF distinct from sip:/sips: (RFC 3261) and tel: (RFC 3966).
+   // ---------------------------------------------------------------------
+
+   // Basic parse without angle brackets (as in a Request-URI).
+   {
+      Uri uri("urn:service:sos");
+      assert(uri.scheme() == "urn");
+      assert(uri.user() == "service:sos");
+      assert(uri.host().empty());
+      assert(uri.port() == 0);
+      assert(uri.password().empty());
+   }
+
+   // Round-trip: ':' must not be escaped (unlike the sip:/sips: table).
+   {
+      Uri uri("urn:service:sos");
+      assert(Data::from(uri) == "urn:service:sos");
+   }
+
+   // Same urn: inside a NameAddr with angle brackets and a tag (as in a
+   // real To/From): must parse (isWellFormed()) without confusing the
+   // tag's ';' with part of the URI.
+   {
+      NameAddr na("<urn:service:sos>;tag=abc123");
+      assert(na.isWellFormed());
+      assert(na.uri().scheme() == "urn");
+      assert(na.uri().user() == "service:sos");
+      assert(na.param(p_tag) == "abc123");
+      assert(Data::from(na.uri()) == "urn:service:sos");
+   }
+
+   // ';' is a valid sub-delim inside a urn: NSS (RFC 8141) and must NOT
+   // be treated as a delimiter (unlike tel:, RFC 3966). Must be preserved
+   // as-is, even with several ';' in a row.
+   {
+      NameAddr na("<urn:example:a;b;c>;tag=xyz");
+      assert(na.isWellFormed());
+      assert(na.uri().user() == "example:a;b;c");
+      assert(Data::from(na.uri()) == "urn:example:a;b;c");
+   }
+
+   // A full Request-Line with urn: (no angle brackets) must parse too.
+   {
+      const Data msgText(
+         "INVITE urn:service:sos SIP/2.0\r\n"
+         "Via: SIP/2.0/UDP host.example.com;branch=z9hG4bK1234\r\n"
+         "Max-Forwards: 70\r\n"
+         "To: <urn:service:sos>\r\n"
+         "From: <sip:caller@example.com>;tag=1234\r\n"
+         "Call-ID: urntest123@example.com\r\n"
+         "CSeq: 1 INVITE\r\n"
+         "Content-Length: 0\r\n"
+         "\r\n");
+      unique_ptr<SipMessage> msg(SipMessage::make(msgText));
+      assert(msg.get());
+      assert(msg->header(h_RequestLine).uri().scheme() == "urn");
+      assert(msg->header(h_RequestLine).uri().user() == "service:sos");
+      assert(msg->header(h_To).uri().scheme() == "urn");
+      assert(msg->header(h_To).uri().user() == "service:sos");
+   }
+
+   // %XX decoding in the NSS, same as for sip:/sips: user: internal value
+   // is decoded, and re-encoding restores the original escaping.
+   {
+      NameAddr na("<urn:example:a%20b>"); // %20 = space
+      assert(na.isWellFormed());
+      assert(na.uri().user() == "example:a b");
+      assert(Data::from(na.uri()) == "urn:example:a%20b");
+   }
+   {
+      NameAddr na("<urn:example:a%23b>"); // %23 = '#'
+      assert(na.isWellFormed());
+      assert(na.uri().user() == "example:a#b");
+      assert(Data::from(na.uri()) == "urn:example:a%23b");
+   }
+
+   // Programmatic construction: only space must be escaped (not pchar,
+   // no structural role). ':', '@', ';' and the rest of sub-delims must
+   // not (RFC 8141 pchar), and neither must '?'/'#' -- although not
+   // pchar, they mark rq-components/fragment in a real URN and escaping
+   // them would break round-trip (see the next two blocks).
+   {
+      Uri uri;
+      uri.scheme() = "urn";
+      uri.user() = Data("a b#c?d:e@f;g");
+      assert(Data::from(uri) == "urn:a%20b#c?d:e@f;g");
+   }
+
+   // Round-trip of a real r-component (RFC 8141: "?+"), no pct-encoding:
+   // must come back unchanged, '?' and '+' unescaped.
+   {
+      Uri uri("urn:example:nss?+rcomponent");
+      assert(uri.user() == "example:nss?+rcomponent");
+      assert(Data::from(uri) == "urn:example:nss?+rcomponent");
+   }
+
+   // Round-trip of a real fragment (RFC 8141: '#'): must come back
+   // unchanged, '#' unescaped.
+   {
+      Uri uri("urn:example:nss#fragment");
+      assert(uri.user() == "example:nss#fragment");
+      assert(Data::from(uri) == "urn:example:nss#fragment");
+   }
+
+   // Critical distinction: an ESCAPED '#' ("%23", '#' as NSS data) and a
+   // LITERAL '#' (the real fragment separator) decode to the same
+   // logical value via user() ("example:a#b" either way), but must
+   // re-serialize each in its original form -- otherwise a received
+   // '%23' would silently turn into a real fragment separator on
+   // re-transmission, changing the URN's structural meaning.
+   {
+      Uri uriEscaped("urn:example:a%23b");
+      Uri uriLiteral("urn:example:a#b");
+      assert(uriEscaped.user() == "example:a#b");
+      assert(uriLiteral.user() == "example:a#b");
+      assert(Data::from(uriEscaped) == "urn:example:a%23b");
+      assert(Data::from(uriLiteral) == "urn:example:a#b");
+   }
+
+   // getAor()/getAorNoPort()/getAOR(bool) must canonicalize via
+   // getUrnEncodingTable(), not dump mUser raw -- consistent with how
+   // this AOR path canonicalizes sip:/sips: user (see getAorInternal()).
+   {
+      Uri uri("urn:service:sos");
+      assert(uri.getAor() == "service:sos");
+      assert(uri.getAorNoPort() == "service:sos");
+      assert(uri.getAOR(false) == "urn:service:sos");
+
+      Uri uriSpace;
+      uriSpace.scheme() = "urn";
+      uriSpace.user() = Data("a b");
+      assert(uriSpace.getAor() == "a%20b");
+   }
+
+   // host()/port()/password()/param() on a urn: must not throw and must
+   // behave like tel: (defaults, no host semantics).
+   {
+      Uri uri("urn:service:sos");
+      bool threw = false;
+      try
+      {
+         Data h = uri.host();
+         int p = uri.port();
+         Data pw = uri.password();
+         bool hasTransport = uri.exists(p_transport);
+         (void)h; (void)p; (void)pw; (void)hasTransport;
+      }
+      catch (const BaseException&)
+      {
+         threw = true;
+      }
+      assert(!threw);
+      assert(uri.host().empty());
+      assert(uri.port() == 0);
+      assert(uri.password().empty());
+      assert(!uri.exists(p_transport));
+   }
+
+   // operator==: NID is case-insensitive, NSS is case-sensitive (RFC
+   // 8141), same NSS case rule as the sip:/sips: user part.
+   {
+      // Same NSS, NID differs only in case -> equal (NID case-insensitive).
+      Uri uri1("urn:EXAMPLE:abc");
+      Uri uri2("urn:example:abc");
+      assert(uri1 == uri2);
+
+      // Same NID, NSS differs only in case -> not equal (NSS case-sensitive).
+      Uri uri3("urn:example:ABC");
+      Uri uri4("urn:example:abc");
+      assert(!(uri3 == uri4));
+
+      Uri uri5("urn:example:ABC");
+      Uri uri6("urn:example:ABC");
+      assert(uri5 == uri6);
+   }
+
+   // No regression: sip: and tel: must behave exactly as before
+   // (their own escaping table still applies, not the new urn: one).
+   {
+      Uri uri("sip:alice@example.com:5060");
+      assert(Data::from(uri) == "sip:alice@example.com:5060");
+      assert(uri.host() == "example.com");
+      assert(uri.port() == 5060);
+   }
+   {
+      Uri uri("tel:+34911234567");
+      assert(Data::from(uri) == "tel:+34911234567");
+      assert(uri.host().empty());
+   }
+
    cerr << endl << "All OK" << endl;
    return 0;
 }

--- a/resip/stack/test/testUri.cxx
+++ b/resip/stack/test/testUri.cxx
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <iostream>
+#include <set>
 
 #include "TestSupport.hxx"
 #include "resip/stack/UnknownParameterType.hxx"
@@ -1224,6 +1225,39 @@ main(int argc, char* argv[])
       assert(Data::from(na.uri()) == "urn:example:a;b;c");
    }
 
+   // Regression test: a bare (unbracketed) urn: directly followed by a
+   // NameAddr parameter must NOT swallow it into the URI's user part --
+   // the ';' must be recognized as the tag separator, not NSS content.
+   // (RFC 3261 sec 20 allows omitting "<...>" here because urn:service:sos
+   // itself contains none of ',', '?', ';'.)
+   {
+      NameAddr na("urn:service:sos;tag=abc123");
+      assert(na.isWellFormed());
+      assert(na.uri().scheme() == "urn");
+      assert(na.uri().user() == "service:sos");
+      assert(na.param(p_tag) == "abc123");
+   }
+
+   // Regression test: a urn: Request-URI (no angle brackets -- Request-URIs
+   // are never bracketed) whose NSS legitimately contains ';' must NOT be
+   // truncated at the first one -- there are no NameAddr parameters that
+   // can follow a Request-URI, so ';'/'?'/',' are just NSS content here.
+   {
+      const Data msgText(
+         "INVITE urn:example:a;b;c SIP/2.0\r\n"
+         "Via: SIP/2.0/UDP host.example.com;branch=z9hG4bK1234\r\n"
+         "Max-Forwards: 70\r\n"
+         "To: <urn:example:a;b;c>\r\n"
+         "From: <sip:caller@example.com>;tag=1234\r\n"
+         "Call-ID: urntest124@example.com\r\n"
+         "CSeq: 1 INVITE\r\n"
+         "Content-Length: 0\r\n"
+         "\r\n");
+      unique_ptr<SipMessage> msg(SipMessage::make(msgText));
+      assert(msg.get());
+      assert(msg->header(h_RequestLine).uri().user() == "example:a;b;c");
+   }
+
    // A full Request-Line with urn: (no angle brackets) must parse too.
    {
       const Data msgText(
@@ -1357,6 +1391,56 @@ main(int argc, char* argv[])
       Uri uri5("urn:example:ABC");
       Uri uri6("urn:example:ABC");
       assert(uri5 == uri6);
+   }
+
+   // Regression test: operator<, the hash function and getAor() must all
+   // agree with operator== on NID case-insensitivity -- otherwise
+   // std::set<Uri>/HashMap<Uri,...> and registration/auth keys would
+   // treat two "equal" urn: Uris as distinct.
+   {
+      Uri uri1("urn:EXAMPLE:abc");
+      Uri uri2("urn:example:abc");
+      assert(uri1 == uri2);
+      assert(!(uri1 < uri2) && !(uri2 < uri1));
+      assert(std::hash<Uri>()(uri1) == std::hash<Uri>()(uri2));
+      assert(uri1.getAor() == uri2.getAor());
+
+      std::set<Uri> uriSet;
+      uriSet.insert(uri1);
+      uriSet.insert(uri2);
+      assert(uriSet.size() == 1);
+   }
+
+   // Malformed urn: NID/NSS must be rejected with a ParseException instead
+   // of silently reaching the application as if it were well-formed
+   // (RFC 8141 sec 2 NID grammar, sec 5.1 "urn" NID prohibition).
+   {
+      const char* badUrns[] = {
+         "urn:",                                // no NID at all
+         "urn:a",                                // no NID:NSS separator
+         "urn:a:nss",                             // NID too short (1 char)
+         "urn:-ab:nss",                           // NID starts with '-'
+         "urn:ab-:nss",                           // NID ends with '-'
+         "urn:a_b:nss",                           // '_' not allowed in NID
+         "urn:abcdefghijklmnopqrstuvwxyz01234567:nss", // NID > 32 chars
+         "urn:example:",                          // empty NSS
+         "urn:urn:nss",                           // NID must not be "urn"
+         "urn:URN:nss",                           // ...case-insensitively
+      };
+      for (const char* bad : badUrns)
+      {
+         bool threw = false;
+         try
+         {
+            Uri uri(bad);
+            uri.checkParsed();
+         }
+         catch (ParseException&)
+         {
+            threw = true;
+         }
+         assert(threw);
+      }
    }
 
    // No regression: sip: and tel: must behave exactly as before


### PR DESCRIPTION
**Motivation**

The urn: scheme (RFC 8141 ) is commonly used in IMS to request emergency services, where the UE requests for a specific service such as `urn:service:sos` (RFC 5031) and the network routes the call to the most appropriate PSAP. The UAC must place the URN in the Request-URI, and optionally in the To header, and all the B2BUAs and SIP proxies involved in the call path must be capable of handling it.

Since resiprocate/resip could not previously process SIP messages containing a URN in the URI because of resip::Uri had no notion of the urn: scheme, and DUM rejected such request-URIs, I have added some basic support for this feature for your review and consideration.

**Details**

- Add urn: (RFC 8141) scheme support to resip::Uri and registers urn in Symbols; 
- Add it's own ABNF EncodingTable. Parses/encodes it as an NID:NSS blob with its own ABNF, distinct from sip:/sips:/tel:; 
- operator== compares NID case-insensitively and NSS case-sensitively per RFC 8141 instead of a whole-string compare; 
- Reuses mUserRaw to preserve as-received escaping so literal vs. escaped #/? don't collapse on re-encode; 
- Adds unit tests for parsing, encoding and equality.
- Added the urn scheme to the MasterProfile in DUM and registers urn as a supported scheme so DialogUsageManager::validateRequestURI() no longer rejects an INVITE targeting a urn: URI with 416 Unsupported URI Scheme.
- Sanity checks before copying the user part from a urn to a sip Uri because of BaseCreator/Dialog assumed sip-like user-part semantics; since urn's ABNF differs, guards prevent copying an invalid user part when deriving a sip Uri from a urn Uri.
