### PR TITLE
Fix to CMakeList.txt for soci inclusion when reConServer is built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,7 +493,9 @@ endif()
 # Debian: libsoci-dev
 # FIXME - hardcoded
 # FIXME - MySQL, PostgreSQL
-if(USE_SOCI_POSTGRESQL OR USE_SOCI_MYSQL)
+# reConServer's B2BCallManager includes soci.h unconditionally, so soci_core
+# is needed whenever BUILD_RECONSERVER is on, even without a specific backend.
+if(USE_SOCI_POSTGRESQL OR USE_SOCI_MYSQL OR BUILD_RECONSERVER)
    find_library(SOCI_LIBRARIES soci_core REQUIRED)
    # FIXME include path
    set(SOCI_INCLUDE_DIRS "/usr/include/soci")


### PR DESCRIPTION
Hi, 
I realized that if you set -DUILD_RECONSERVER=ON without setting -DUSE_SOCI_POSTGRESQL=ON or  -DUSE_SOCI_MYSQL=ON, the build fails with a "2BCallManager.hxx:20:10: fatal error: soci.h: Not found ...", so I fixed the rules in CMakeList.txt to take in account the BUILD_RECONSERVER too.
Thank you
