### PR TITLE
Keep certificate serial numbers positive (RFC 5280 4.1.2.2)

### DIFF
--- a/resip/stack/makeCert.cxx
+++ b/resip/stack/makeCert.cxx
@@ -95,7 +95,9 @@ int makeSelfCert(X509 **cert, EVP_PKEY *privkey)   // should include a Uri type 
 
   //  RAND_bytes((char *) serial , 4);
   //serial = 1;
-  serial = Random::getCryptoRandom();  // get an int worth of randomness
+  // RFC 5280 4.1.2.2 wants a positive serial, and getCryptoRandom() fills a
+  // whole int from RAND_bytes, so it is negative about half the time.
+  serial = Random::getCryptoRandom() & 0x7FFFFFFF;
   ASN1_INTEGER_set(X509_get_serialNumber(selfcert),serial);
 
   X509_NAME_add_entry_by_txt( subject, "O",  MBSTRING_UTF8, (unsigned char *) domain.data(), domain.size(), -1, 0);

--- a/resip/stack/ssl/Security.cxx
+++ b/resip/stack/ssl/Security.cxx
@@ -1559,7 +1559,9 @@ BaseSecurity::generateUserCert (const Data& pAor, int expireDays, int keyLen )
    // set version to X509v3 (starts from 0)
    X509_set_version(cert, 2L);
    
-   int serial = Random::getCryptoRandom();  // get an int worth of randomness
+   // RFC 5280 4.1.2.2 wants a positive serial, and getCryptoRandom() fills a
+   // whole int from RAND_bytes, so it is negative about half the time.
+   int serial = Random::getCryptoRandom() & 0x7FFFFFFF;
    resip_assert(sizeof(int)==4);
    ASN1_INTEGER_set(X509_get_serialNumber(cert),serial);
    

--- a/resip/stack/test/CMakeLists.txt
+++ b/resip/stack/test/CMakeLists.txt
@@ -139,6 +139,7 @@ test(testWsCookieContext testWsCookieContext.cxx)
 if(OPENSSL_FOUND)
    test(testSocketFunc testSocketFunc.cxx)
    test(testSecurity testSecurity.cxx)
+   test(testCertSerial testCertSerial.cxx TestSupport.cxx)
 endif()
 
 # fuzzing targets

--- a/resip/stack/test/testCertSerial.cxx
+++ b/resip/stack/test/testCertSerial.cxx
@@ -1,8 +1,12 @@
 #include <cstdlib>
 #include <iostream>
 
+#ifdef USE_SSL
+
 #include <openssl/asn1.h>
 #include <openssl/bn.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
 #include <openssl/x509.h>
 
 #include "resip/stack/ssl/Security.hxx"
@@ -112,7 +116,7 @@ main(int, char**)
       security.generateUserCert(aor, 1 /* expireDays */, 1024 /* keyLen */);
       if (!security.hasUserCert(aor))
       {
-         cerr << "     konnte kein Zertifikat erzeugen fuer " << aor << endl;
+         cerr << "     could not generate a certificate for " << aor << endl;
          continue;
       }
       if (serialIsNegative(security.getUserCertDER(aor)))
@@ -121,10 +125,22 @@ main(int, char**)
       }
    }
 
-   cerr << "     " << negative << " von " << runs
-        << " erzeugten Zertifikaten mit negativer Seriennummer" << endl;
+   cerr << "     " << negative << " of " << runs
+        << " generated certificates had a negative serial" << endl;
    check("generateUserCert produces positive serials only", negative == 0);
 
    cerr << (failures == 0 ? "\nall checks passed\n" : "\nFAILURES\n");
    return failures == 0 ? 0 : -1;
 }
+
+#else // USE_SSL
+
+int
+main(int, char**)
+{
+   // The certificate serials this test exercises are only generated in
+   // SSL-enabled builds, so there is nothing to check here.
+   return 0;
+}
+
+#endif // USE_SSL

--- a/resip/stack/test/testCertSerial.cxx
+++ b/resip/stack/test/testCertSerial.cxx
@@ -1,0 +1,130 @@
+#include <cstdlib>
+#include <iostream>
+
+#include <openssl/asn1.h>
+#include <openssl/bn.h>
+#include <openssl/x509.h>
+
+#include "resip/stack/ssl/Security.hxx"
+#include "rutil/Data.hxx"
+#include "rutil/Log.hxx"
+
+using namespace resip;
+using namespace std;
+
+// RFC 5280 section 4.1.2.2: "The serial number MUST be a positive integer."
+//
+// The serial is drawn with Random::getCryptoRandom(), which fills a whole int
+// from RAND_bytes and is therefore negative about half the time, where the
+// getRandom() it replaced was always positive. ASN1_INTEGER_set() stores a
+// negative value as a negative INTEGER, so the certificate carries one.
+
+static int failures = 0;
+
+static void
+check(const char* what, bool cond)
+{
+   cerr << (cond ? "ok   " : "FAIL ") << what << endl;
+   if (!cond) ++failures;
+}
+
+// true when the serial of this DER encoded certificate is negative
+static bool
+serialIsNegative(const Data& der)
+{
+   const unsigned char* p = (const unsigned char*)der.data();
+   X509* cert = d2i_X509(0, &p, (long)der.size());
+   if (!cert) return false;
+   BIGNUM* bn = ASN1_INTEGER_to_BN(X509_get_serialNumber(cert), 0);
+   const bool negative = bn && BN_is_negative(bn);
+   if (bn) BN_free(bn);
+   X509_free(cert);
+   return negative;
+}
+
+int
+main(int, char**)
+{
+   Log::initialize(Log::Cout, Log::None, "testCertSerial");
+
+   Security security(BaseSecurity::StrongestSuite);
+
+   // The check has to be able to see a negative serial, otherwise "none were
+   // negative" below would also be the answer for a certificate the probe
+   // simply failed to read.
+   //
+   // The certificate for this has to be built from scratch rather than parsed
+   // and edited: i2d_X509() re-emits the DER it cached while parsing, so a
+   // serial written afterwards never reaches the encoding and the control would
+   // silently be looking at the original value instead of the one it set.
+   {
+      bool sawIt = false;
+      bool builtOne = false;
+
+      EVP_PKEY* key = EVP_PKEY_new();
+      RSA* rsa = RSA_new();
+      BIGNUM* e = BN_new();
+      BN_set_word(e, RSA_F4);
+      if (RSA_generate_key_ex(rsa, 1024, e, 0) == 1 &&
+          EVP_PKEY_set1_RSA(key, rsa) == 1)
+      {
+         X509* cert = X509_new();
+         X509_set_version(cert, 2L);
+         ASN1_INTEGER_set(X509_get_serialNumber(cert), -12345);
+         X509_gmtime_adj(X509_getm_notBefore(cert), 0);
+         X509_gmtime_adj(X509_getm_notAfter(cert), 60 * 60 * 24);
+         X509_set_pubkey(cert, key);
+
+         X509_NAME* name = X509_get_subject_name(cert);
+         X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                                    (const unsigned char*)"control", -1, -1, 0);
+         X509_set_issuer_name(cert, name);
+
+         if (X509_sign(cert, key, EVP_sha256()) > 0)
+         {
+            unsigned char* buf = 0;
+            const int len = i2d_X509(cert, &buf);
+            if (len > 0)
+            {
+               builtOne = true;
+               sawIt = serialIsNegative(Data((const char*)buf, len));
+               OPENSSL_free(buf);
+            }
+         }
+         X509_free(cert);
+      }
+      BN_free(e);
+      RSA_free(rsa);
+      EVP_PKEY_free(key);
+
+      check("control: a certificate with a negative serial could be built", builtOne);
+      check("control: a negative serial is detected", sawIt);
+   }
+
+   const int runs = 40;
+   int negative = 0;
+   for (int i = 0; i < runs; ++i)
+   {
+      Data aor("user");
+      aor += Data(i);
+      aor += "@example.org";
+
+      security.generateUserCert(aor, 1 /* expireDays */, 1024 /* keyLen */);
+      if (!security.hasUserCert(aor))
+      {
+         cerr << "     konnte kein Zertifikat erzeugen fuer " << aor << endl;
+         continue;
+      }
+      if (serialIsNegative(security.getUserCertDER(aor)))
+      {
+         ++negative;
+      }
+   }
+
+   cerr << "     " << negative << " von " << runs
+        << " erzeugten Zertifikaten mit negativer Seriennummer" << endl;
+   check("generateUserCert produces positive serials only", negative == 0);
+
+   cerr << (failures == 0 ? "\nall checks passed\n" : "\nFAILURES\n");
+   return failures == 0 ? 0 : -1;
+}


### PR DESCRIPTION
Follow-up to #480, with just the part you asked for.

## What is wrong

RFC 5280 section 4.1.2.2 requires the certificate serial number to be a
positive integer. `Random::getCryptoRandom()` fills a whole `int` from
`RAND_bytes`, so it is negative about half the time, where the `getRandom()`
it replaced in #433 never was.

Measured here: 49851 of 100000 draws are negative. Generating 40 certificates
through `generateUserCert` produced 29 whose serial `BN_is_negative` reports
as negative, and `openssl x509 -noout -text` prints them as
`Serial Number: -12345 (-0x3039)`.

Two sites draw the serial from `getCryptoRandom()`:

- `resip/stack/ssl/Security.cxx:1562` in `generateUserCert()`. This is the
  live one, reached from repro through `CertSubscriptionHandler`.
- `resip/stack/makeCert.cxx:98`. Same line, but the file appears in no
  `CMakeLists.txt` and carries its own `main()`, so this one is for
  consistency rather than impact. I mention it because you named it, and
  because leaving one of two identical lines behind is how this came about.

`reflow/FlowManager.cxx` and `resip/stack/test/makeSelfCert.cxx` also set a
serial, but both still use `getRandom()` and are therefore always positive.
Nothing to do there.

## Verification

From a clean checkout of master, Debug build with assertions on:

- before: `testCertSerial` reports 29 of 40 certificates with a negative
  serial and exits 255
- after: 0 of 40, exits 0
- suite: 69 of 69, in Debug and in RelWithDebInfo

The test carries its own control, which builds a certificate with a negative
serial from scratch and confirms the probe sees it. That control matters: my
first version parsed a real certificate and wrote a negative serial into it
afterwards, which `i2d_X509()` ignores because it re-emits the DER cached
during parsing. It passed while the fix was absent, for the wrong reason,
and failed once the fix was in.

I took the three things that went wrong last time seriously:

- Determinism: 25 consecutive runs, no failures. The mask makes the outcome
  independent of the draw, so there is no collision window.
- `-DWITH_SSL=OFF`: the test is registered inside the existing
  `if(OPENSSL_FOUND)` block next to `testSecurity`, so it is simply absent
  there. I could not run that configuration to completion, because an
  unmodified master already fails it with
  `SipStack.cxx:450:29: error: expected type-specifier before 'DtlsTransport'`.
  That is pre-existing and unrelated, but it means my check there is limited
  to "the test is not registered" rather than "the suite is green".
- MSVC `/sdl`: the build produces no deprecation warnings. The test uses the
  same OpenSSL calls `Security.cxx` already uses, and the project's
  `OPENSSL_API_COMPAT=0x10101000L` covers them.

Thanks for the detailed review on the previous one; it was a much better use
of your time than a merge would have been.
