### PR TITLE
Add ordered view over `SipMessage::KnownHeaders`

### DIFF
--- a/resip/stack/SipMessage.cxx
+++ b/resip/stack/SipMessage.cxx
@@ -29,9 +29,23 @@ using namespace std;
 void
 SipMessage::KnownHeaders::clear() noexcept
 {
-   for (iterator it = begin(), e = end(); it != e;)
+   if (mSize > 0)
    {
-      erase(it++);
+      for (reference elem : mHeaders)
+      {
+         if (elem.getType() != Headers::UNKNOWN)
+         {
+            elem.getValues()->clear();
+            elem.setType(Headers::UNKNOWN);
+         }
+      }
+
+      for (UsedBitMaskWord& word : mUsedBitMask)
+      {
+         word = 0u;
+      }
+
+      mSize = 0u;
    }
 }
 
@@ -46,7 +60,7 @@ SipMessage::KnownHeaders::clearAndDispose(Disposer&& disposer) noexcept
    }
 
    mHeaders.clear();
-   mSize = 0;
+   mSize = 0u;
    resetIndices();
 }
 
@@ -54,12 +68,17 @@ SipMessage::KnownHeaders::clearAndDispose(Disposer&& disposer) noexcept
 void
 SipMessage::KnownHeaders::erase(iterator it) noexcept
 {
-   resip_assert(it->getType() != Headers::UNKNOWN);
+   const Headers::Type type = it->getType();
+   resip_assert(type != Headers::UNKNOWN);
    resip_assert(it->getValues() != nullptr);
    resip_assert(mSize > 0);
 
    it->getValues()->clear();
    it->setType(Headers::UNKNOWN);
+
+   mUsedBitMask[static_cast<unsigned int>(type) / UsedBitMaskWordBits] &=
+      ~(static_cast<UsedBitMaskWord>(1u) << (static_cast<unsigned int>(type) % UsedBitMaskWordBits));
+
    --mSize;
 }
 
@@ -93,15 +112,25 @@ SipMessage::KnownHeaders::insert(Headers::Type type, ValuesFactory&& valuesFacto
       ++mSize;
    }
 
+   mUsedBitMask[static_cast<unsigned int>(type) / UsedBitMaskWordBits] |=
+      static_cast<UsedBitMaskWord>(1u) << (static_cast<unsigned int>(type) % UsedBitMaskWordBits);
+
    return iterator(mHeaders.begin() + pos, mHeaders.end());
 }
 
-/// Resets all header indices to `InvalidHeaderIndex`
+/// Resets all header indices to `InvalidHeaderIndex` and clears the "used" bit mask
 void
 SipMessage::KnownHeaders::resetIndices() noexcept
 {
    for (HeaderIndex& index : mHeaderIndices)
+   {
       index = InvalidHeaderIndex;
+   }
+
+   for (UsedBitMaskWord& word : mUsedBitMask)
+   {
+      word = 0u;
+   }
 }
 
 /// Finds header information, if present in the list. Returns `end()` if not found. Does not produce "unused" entries.
@@ -820,29 +849,11 @@ SipMessage::encode(EncodeStream& str, bool isSipFrag) const
 #endif
    }
 
-   // Iterate by header type enum value (not insertion order) so that headers are
-   // encoded in the deterministic, enum-declared order. See the comment in
-   // HeaderTypes.hxx: "The Type enum controls the order of output of the headers
-   // in the encoded SipMessage". The leading entries of that enum follow the
-   // recommendation in RFC 3261 section 7.3.1, that headers needed for proxy
-   // processing appear towards the top of the message to facilitate rapid parsing.
-   //
-   // !slg! Note this costs more than iterating mKnownHeaders directly: find() is
-   // O(1), but the loop still probes all Headers::MAX_HEADERS types no matter how
-   // few headers the message actually carries, whereas iterating the container
-   // visits only the headers that are present. Recovering the enum order without
-   // paying that is worth revisiting.
-   for (int t = 0; t < Headers::MAX_HEADERS; ++t)
+   for (KnownHeaders::OrderedView::const_reference info : mKnownHeaders.ordered())
    {
-      const Headers::Type type = static_cast<Headers::Type>(t);
-      if (type == Headers::ContentLength) // !dlb! hack...
+      if (info.getType() != Headers::ContentLength) // !dlb! hack...
       {
-         continue;
-      }
-      auto it = mKnownHeaders.find(type);
-      if (it != mKnownHeaders.end())
-      {
-         it->getValues()->encode(type, str);
+         info.getValues()->encode(info.getType(), str);
       }
    }
 
@@ -878,31 +889,21 @@ EncodeStream&
 SipMessage::encodeEmbedded(EncodeStream& str) const
 {
    bool first = true;
-   // Iterate by header type enum value (not insertion order) so that headers are
-   // encoded in the deterministic, enum-declared order. See encode() above, including
-   // the note about the cost of probing all Headers::MAX_HEADERS types.
-   for (int t = 0; t < Headers::MAX_HEADERS; ++t)
+   for (KnownHeaders::OrderedView::const_reference info : mKnownHeaders.ordered())
    {
-      const Headers::Type type = static_cast<Headers::Type>(t);
-      if (type == Headers::ContentLength)
+      if (info.getType() != Headers::ContentLength)
       {
-         continue;
+         if (first)
+         {
+            str << Symbols::QUESTION;
+            first = false;
+         }
+         else
+         {
+            str << Symbols::AMPERSAND;
+         }
+         info.getValues()->encodeEmbedded(Headers::getHeaderName(info.getType()), str);
       }
-      auto it = mKnownHeaders.find(type);
-      if (it == mKnownHeaders.end())
-      {
-         continue;
-      }
-      if (first)
-      {
-         str << Symbols::QUESTION;
-         first = false;
-      }
-      else
-      {
-         str << Symbols::AMPERSAND;
-      }
-      it->getValues()->encodeEmbedded(Headers::getHeaderName(type), str);
    }
 
    for (UnknownHeaders::const_iterator i = mUnknownHeaders.begin(); 

--- a/resip/stack/SipMessage.hxx
+++ b/resip/stack/SipMessage.hxx
@@ -3,10 +3,12 @@
 
 #include <sys/types.h>
 
+#include <cstddef>
 #include <list>
 #include <vector>
-#include <utility>
+#include <limits>
 #include <memory>
+#include <utility>
 #include <iterator>
 #include <type_traits>
 
@@ -21,12 +23,27 @@
 #include "resip/stack/MessageDecorator.hxx"
 #include "resip/stack/Cookie.hxx"
 #include "resip/stack/WsCookieContext.hxx"
+#include "rutil/ResipAssert.h"
 #include "rutil/BaseException.hxx"
 #include "rutil/Data.hxx"
 #include "rutil/DinkyPool.hxx"
 #include "rutil/StlPoolAllocator.hxx"
 #include "rutil/Timer.hxx"
 #include "rutil/HeapInstanceCounter.hxx"
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <intrin.h>
+#pragma intrinsic(_BitScanForward)
+#if defined(_M_X64) || defined(_M_ARM64)
+#pragma intrinsic(_BitScanForward64)
+#endif
+#if defined(_M_IX86) || defined(_M_X64)
+#pragma intrinsic(_tzcnt_u32)
+#endif
+#if defined(_M_X64)
+#pragma intrinsic(_tzcnt_u64)
+#endif
+#endif
 
 namespace resip
 {
@@ -176,6 +193,17 @@ class SipMessage : public TransactionMessage
        * by users (e.g. they are not found by searching or exposed during iteration). "Unused" elements can be
        * reused if the user attempts to insert an element with the matching header type. After that, the reused
        * element becomes publicly accessible again.
+       *
+       * The container can produce a read-only ordered view over its elements. When iterating over the view
+       * elements, headers are ordered by their types, i.e. `Headers::Type` enum values. The view does not
+       * expose "unused" elements. The view does not own or manage container elements and is invalidated
+       * on the parent container modifications.
+       *
+       * @note Ordering headers facilitates deterministic SIP message serialization. See the comment in
+       *       `HeaderTypes.hxx`: "The Type enum controls the order of output of the headers in the encoded
+       *       SipMessage". The leading entries of that enum follow the recommendation in RFC 3261 section 7.3.1,
+       *       that headers needed for proxy processing appear towards the top of the message to facilitate
+       *       rapid parsing.
        */
       class KnownHeaders
       {
@@ -185,6 +213,13 @@ class SipMessage : public TransactionMessage
             /// Header index value that indicates invalid index
             static constexpr HeaderIndex InvalidHeaderIndex = static_cast<HeaderIndex>(-1);
             static_assert(Headers::MAX_HEADERS <= InvalidHeaderIndex, "HeaderIndex type is too small to cover all SIP header types");
+
+            /// Type of the word to use for "used" bit mask. Chosen as the "natural" unsigned integer type for the current target.
+            using UsedBitMaskWord = std::size_t;
+            /// Number of bits in the "used" bit mask word
+            static constexpr unsigned int UsedBitMaskWordBits = static_cast<unsigned int>(std::numeric_limits<UsedBitMaskWord>::digits);
+            /// Number of words in the "used" bit mask
+            static constexpr unsigned int UsedBitMaskWordCount = (static_cast<unsigned int>(Headers::MAX_HEADERS) + UsedBitMaskWordBits - 1u) / UsedBitMaskWordBits;
 
          public:
             /// Publicly accessible information about a header
@@ -274,7 +309,7 @@ class SipMessage : public TransactionMessage
 
                   reference operator*() const noexcept { return *mIterator; }
                   pointer operator->() const noexcept { return mIterator.operator->(); }
-                  UsedIterator operator++() { increment(); return *this; }
+                  UsedIterator& operator++() { increment(); return *this; }
                   UsedIterator operator++(int) { UsedIterator copy(*this); increment(); return copy; }
 
                   friend bool operator==(UsedIterator const& left, UsedIterator const& right) noexcept { return left.mIterator == right.mIterator; }
@@ -308,6 +343,209 @@ class SipMessage : public TransactionMessage
             using difference_type = TypedHeaders::difference_type;
             using allocator_type = TypedHeaders::allocator_type;
 
+            /// Ordered view over headers. The headers are produced in the order of `Headers::Type` enum values.
+            class OrderedView
+            {
+                  friend class KnownHeaders;
+
+               public:
+                  using value_type = KnownHeaders::value_type;
+                  using reference = KnownHeaders::reference;
+                  using const_reference = KnownHeaders::const_reference;
+                  using pointer = KnownHeaders::pointer;
+                  using const_pointer = KnownHeaders::const_pointer;
+                  using size_type = KnownHeaders::size_type;
+                  using difference_type = KnownHeaders::difference_type;
+
+               private:
+                  /// Iterator type
+                  class Iterator
+                  {
+                        friend class OrderedView;
+
+                     public:
+                        using iterator_category = std::forward_iterator_tag;
+                        using difference_type = std::ptrdiff_t;
+                        using value_type = KnownHeaders::value_type;
+                        using reference = value_type const&;
+                        using pointer = const value_type*;
+
+                     private:
+                        using size_type = OrderedView::size_type;
+
+                     private:
+                        /// Pointer to the parent container
+                        const KnownHeaders* mKnownHeaders;
+                        /// Iterator position
+                        size_type mPos;
+
+                     public:
+                        constexpr Iterator() noexcept : mKnownHeaders(nullptr), mPos(0u) {}
+                        Iterator(Iterator const&) = default;
+
+                        /// Initializing constructor
+                        explicit constexpr Iterator(const KnownHeaders* knownHeaders, size_type pos) noexcept :
+                           mKnownHeaders(knownHeaders),
+                           mPos(pos)
+                        {
+                        }
+
+                        reference operator*() const noexcept { return dereference(); }
+                        pointer operator->() const noexcept { return &dereference(); }
+                        Iterator& operator++() { increment(); return *this; }
+                        Iterator operator++(int) { Iterator copy(*this); increment(); return copy; }
+
+                        friend bool operator==(Iterator const& left, Iterator const& right) noexcept
+                        {
+                           resip_assert(left.mKnownHeaders == right.mKnownHeaders);
+                           return left.mPos == right.mPos;
+                        }
+                        friend bool operator!=(Iterator const& left, Iterator const& right) noexcept
+                        {
+                           resip_assert(left.mKnownHeaders == right.mKnownHeaders);
+                           return left.mPos != right.mPos;
+                        }
+
+                     private:
+                        /// Obtains reference to the element
+                        reference dereference() const noexcept
+                        {
+                           resip_assert(mKnownHeaders != nullptr);
+                           return mKnownHeaders->mHeaders[mKnownHeaders->mHeaderIndices[mPos]];
+                        }
+
+                        /// Increments the iterator to the next used entry or end of the list
+                        void increment() noexcept
+                        {
+                           resip_assert(mPos < Headers::MAX_HEADERS);
+                           ++mPos;
+                           advanceToNextUsedEntry();
+                        }
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+// unary minus operator applied to unsigned type, result still unsigned
+#pragma warning(disable: 4146)
+#endif
+
+                        /// Advances to the next used entry in the list
+                        void advanceToNextUsedEntry() noexcept
+                        {
+                           resip_assert(mKnownHeaders != nullptr);
+
+                           size_type mask_pos = mPos / UsedBitMaskWordBits;
+                           size_type bit_pos = mPos % UsedBitMaskWordBits;
+                           for (; mask_pos < UsedBitMaskWordCount; ++mask_pos)
+                           {
+                              const UsedBitMaskWord mask =
+                                 mKnownHeaders->mUsedBitMask[mask_pos] & static_cast<UsedBitMaskWord>(-(static_cast<UsedBitMaskWord>(1u) << bit_pos));
+                              if (mask != 0u)
+                              {
+                                 bit_pos = countrZeroNz(mask);
+                                 break;
+                              }
+                              bit_pos = 0u;
+                           }
+
+                           mPos = mask_pos * UsedBitMaskWordBits + bit_pos;
+
+                           resip_assert(mPos < Headers::MAX_HEADERS || mPos == (static_cast<size_type>(UsedBitMaskWordCount) * UsedBitMaskWordBits));
+                        }
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
+
+                        /**
+                         * @brief Returns the number of trailing zero bits in a non-zero integer.
+                         *
+                         * This function is similar to C++20 `std::countr_zero`, except that it requires its input
+                         * argument to be non-zero. This allows it to compile to a single `bsf` instruction on x86
+                         * CPUs without BMI1, while `std::countr_zero` would require an extra branch.
+                         */
+#if defined(__GNUC__) || defined(__clang__)
+                        static unsigned int countrZeroNz(unsigned int bitmask) noexcept { return __builtin_ctz(bitmask); }
+                        static unsigned int countrZeroNz(unsigned long bitmask) noexcept { return __builtin_ctzl(bitmask); }
+                        static unsigned int countrZeroNz(unsigned long long bitmask) noexcept { return __builtin_ctzll(bitmask); }
+#elif defined(_MSC_VER)
+                        static unsigned int countrZeroNz(uint32_t bitmask) noexcept
+                        {
+                           // On modern CPUs, tzcnt is slightly faster than bsf. CPUs without BMI1 will execute tzcnt
+                           // and produce the same result as bsf for non-zero input.
+#if defined(_M_IX86) || defined(_M_X64)
+                           return static_cast<unsigned int>(_tzcnt_u32(bitmask));
+#else
+                           unsigned long res;
+                           _BitScanForward(&res, bitmask);
+                           return static_cast<unsigned int>(res);
+#endif
+                        }
+
+                        static unsigned int countrZeroNz(uint64_t bitmask) noexcept
+                        {
+#if defined(_M_X64)
+                           return static_cast<unsigned int>(_tzcnt_u64(bitmask));
+#elif defined(_M_ARM64)
+                           unsigned long res;
+                           _BitScanForward64(&res, bitmask);
+                           return static_cast<unsigned int>(res);
+#else
+                           unsigned int base_count = 0u;
+                           uint32_t bitmask32 = static_cast<uint32_t>(bitmask);
+                           if (bitmask32 == 0u)
+                           {
+                              base_count = 32u;
+                              bitmask32 = static_cast<uint32_t>(bitmask >> 32u);
+                           }
+                           return base_count + countrZeroNz(bitmask32);
+#endif
+                        }
+#else
+                        static unsigned int countrZeroNz(UsedBitMaskWord bitmask) noexcept
+                        {
+                           unsigned int res = 0u;
+                           for (unsigned int bits = UsedBitMaskWordBits >> 1u; bits > 0u && (bitmask & 1u) == 0u; bits >>= 1u)
+                           {
+                              if ((bitmask & ((static_cast<UsedBitMaskWord>(1u) << bits) - 1u)) == 0u)
+                              {
+                                 bitmask >>= bits;
+                                 res += bits;
+                              }
+                           }
+                           return res;
+                        }
+#endif
+                  };
+
+               public:
+                  using iterator = Iterator;
+                  using const_iterator = Iterator;
+
+               private:
+                  /// Pointer to the parent container
+                  const KnownHeaders* mKnownHeaders;
+
+               private:
+                  explicit OrderedView(KnownHeaders const& knownHeaders) noexcept : mKnownHeaders(&knownHeaders)
+                  {
+                  }
+
+               public:
+                  /// Returns `true` if the container is empty. Does not consider "unused" elements.
+                  bool empty() const noexcept { return mKnownHeaders->empty(); }
+                  /// Returns the number of elements in the container. Does not consider "unused" elements.
+                  size_type size() const noexcept { return mKnownHeaders->size(); }
+
+                  /// Iterator access
+                  const_iterator cbegin() const noexcept { return begin(); }
+                  const_iterator cend() const noexcept { return end(); }
+
+                  const_iterator begin() const noexcept { const_iterator it(mKnownHeaders, 0u); it.advanceToNextUsedEntry(); return it; }
+                  const_iterator end() const noexcept { return const_iterator(mKnownHeaders, static_cast<size_type>(UsedBitMaskWordCount) * UsedBitMaskWordBits); }
+            };
+
+            friend class OrderedView::Iterator;
+
          private:
             /// Information about headers
             TypedHeaders mHeaders;
@@ -315,13 +553,15 @@ class SipMessage : public TransactionMessage
             HeaderIndex mSize;
             /// Indices into `mHeaders`. If an element is `InvalidHeaderIndex` it means the corresponding header has no entry in the list.
             HeaderIndex mHeaderIndices[Headers::MAX_HEADERS];
+            /// Bit mask indicating non-"unused" elements in `mHeaders`. Bit positions correspond to `Headers::Type` enum values.
+            UsedBitMaskWord mUsedBitMask[UsedBitMaskWordCount];
 
          public:
-            KnownHeaders() noexcept : mSize(0) { resetIndices(); }
+            KnownHeaders() noexcept : mSize(0u) { resetIndices(); }
             explicit KnownHeaders(const allocator_type& alloc)
                noexcept(std::is_nothrow_constructible<TypedHeaders, const allocator_type&>::value) :
                mHeaders(alloc),
-               mSize(0)
+               mSize(0u)
             {
                resetIndices();
             }
@@ -331,7 +571,7 @@ class SipMessage : public TransactionMessage
             KnownHeaders& operator=(const KnownHeaders&) = delete;
 
             /// Returns `true` if the container is empty. Does not consider "unused" elements.
-            bool empty() const noexcept { return mSize == 0; }
+            bool empty() const noexcept { return mSize == 0u; }
             /// Returns the number of elements in the container. Does not consider "unused" elements.
             size_type size() const noexcept { return static_cast<size_type>(mSize); }
             /// Clears the container. Does not free `HeaderFieldValueList` objects but clears them and marks as "unused".
@@ -379,8 +619,11 @@ class SipMessage : public TransactionMessage
             template<typename ValuesFactory>
             iterator insert(Headers::Type type, ValuesFactory&& valuesFactory);
 
+            /// Returns an ordered view over the list of headers
+            OrderedView ordered() const noexcept { return OrderedView(*this); }
+
          private:
-            /// Resets all header indices to `InvalidHeaderIndex`
+            /// Resets all header indices to `InvalidHeaderIndex` and clears the "used" bit mask
             void resetIndices() noexcept;
       };
 


### PR DESCRIPTION
### Description

This PR implements an ordered view over known headers in a `SipMessage`. The view provides read-only access to headers in the order of `Headers::Type` enum values, which is useful for deterministic serialization of the message.

The view relies on the bit mask of non-"unused" entries in `KnownHeaders`. The bit mask is transparently maintained when elements are inserted and removed from the container. On iteration, the bit mask is scanned for set bits indicating valid headers.

This bit mask duplicates information that was already present in the `HeaderInfo` struct, as the special value of `mType == Headers::UNKNOWN`. The special value of `mType` and the associated logic is preserved to keep iteration over the unordered headers fast, as it keeps memory accesses localized in the `mHeaders` vector.

Use this ordered view in `SipMessage::encode` and `encodeEmbedded` instead of looping over all known header types. This significantly optimizes serialization performance.

### Background

I have implemented two versions of code that produces ordered headers in `encode` and `encodeEmbedded` that were discussed in comments to commit 7a9b42395df800b032904fbe2581ca91ed54ebb9. This PR represents @sgodin's idea of using a bit mask to optimize iteration over SIP headers in the ordered way, plus the ordered view as a way to expose this feature. The other idea, which is to order SIP headers in the container on insert, is implemented in https://github.com/Lastique/resiprocate/tree/feature/ordered_known_headers (specifically, the last two commits: [1](https://github.com/Lastique/resiprocate/commit/c73ee9706cf059338b25737ad378992878220145), [2](https://github.com/Lastique/resiprocate/commit/08f54a8a4e382601f0ef631647b4423ee7dd3070)).

I have benchmarked the two designs and have decided to submit the version with the bit mask as a PR after all. If the other version is still preferred, I can submit that as a separate PR instead.

Note that the "ordered insert" version has two commits. The first one makes all SIP header inserts via `SipMessage` API ordered. The second one adds unordered inserts and makes `MsgHeaderScanner` use that API to recover some lost deserialization performance from the first commit, which made all header inserts more expensive. This made `SipMessage` API contract more complex, as the user would have to sort headers if he used unordered APIs, before he uses ordered APIs. See the commit messages for more details.

### Benchmark

Benchmark code:

[resip_sipmessage_benchmark.cpp](https://github.com/user-attachments/files/31622397/resip_sipmessage_benchmark.cpp)

Compile with:

```
g++ -O3 -std=gnu++17 -o resip_sipmessage_benchmark resip_sipmessage_benchmark.cpp -lresip -lrutil
```

Add libresiprocate include and library paths, as needed.

The benchmark tests three operations:

- Deserialize SIP message
- Add a header to that message (which should roughly be in the middle of headers, if ordered by `Headers::Type`)
- Serialize that message

These operations are tested on two versions of an input SIP INVITE message: good and bad. The good one has headers already ordered by `Headers::Type`, the bad one has the reverse order. Otherwise, the messages are the same. For each operation, an average time over 100k operations was measured.

Five versions of libresiprocate were benchmarked:

- 1.14.0, which uses unordered SIP headers internally and on serialization.
- 7a9b42395df800b032904fbe2581ca91ed54ebb9, which changed serialization to loop over `Headers::MAX_HEADERS` instead of the headers present in the message.
- https://github.com/Lastique/resiprocate/commit/c73ee9706cf059338b25737ad378992878220145, which orders headers on insert, but does not yet optimize `MsgHeaderScanner`.
- https://github.com/Lastique/resiprocate/commit/08f54a8a4e382601f0ef631647b4423ee7dd3070, which is the full "ordered insert" version.
- This PR, which is the bit mask version.

Each libresiprocate version was compiled with:

```
cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TFM=0 -DBUILD_RECON=0 -DBUILD_REPRO=0 -DBUILD_RETURN=0 -DBUILD_REFLOW=0 -DBUILD_REND=0 -DBUILD_MEDIA=0 -DBUILD_PYTHON=0 -DBUILD_QPID_PROTON=0 -DUSE_MYSQL=0 -DASIO_INCLUDE_DIR=<asio include> -DBoost_INCLUDE_DIR=<boost include> -DSRTP2_INCLUDE_DIR=<libsrtp include> -DSRTP2_LIBRARY=srtp2 ..
make -j8
```

Test platform: Kubuntu 24.04, gcc 13.3.0, Intel Core i7-4700HQ.

Test results for good message (all numbers are nanoseconds per operation, lower is better):

|             | 1.14.0 | `MAX_HEADERS` loop | Ordered insert, no scanner | Ordered insert + scanner | Bitmask |
|-------------|--------|--------------------|----------------------------|--------------------------|---------|
| Deserialize |   3210 |               3116 |                       3152 |                     3323 |    3242 |
| Add header  |     55 |                 49 |                         64 |                       98 |      54 |
| Serialize   |   2049 |               2375 |                       2079 |                     2183 |    2160 |

Bad message:

|             | 1.14.0 | `MAX_HEADERS` loop | Ordered insert, no scanner | Ordered insert + scanner | Bitmask |
|-------------|--------|--------------------|----------------------------|--------------------------|---------|
| Deserialize |   3199 |               3089 |                       3119 |                     3275 |    3161 |
| Add header  |     55 |                 50 |                         63 |                       96 |      53 |
| Serialize   |   2048 |               2351 |                       2058 |                     2147 |    2093 |

A few notes on test results:

- The single header addition operation is rather fast on its own, so large swings from one run to another are possible. However, in general, I noticed that the "ordered insert" versions tend to produce larger times in this test (as expected).
- The full "ordered insert" version, with `MsgHeaderScanner` optimization, produced somewhat larger times than the one without the `MsgHeaderScanner` optimization, which is unexpected. The optimization only affected the deserialization, and I cannot explain the effect on the other two operations. I've also tested debug builds of libresiprocate, and there the results were as expected - the full "ordered insert" version is slightly faster in deserialize, more or less the same in the other two operations. Since the bitmask version is faster anyway, I did not investigate further.
- The effect of a bad input message is lower than I anticipated, almost nonexistent. It may be because the good message is tested first and the bad one after than, so it is possible that some caches are warm when the bad message is tested.
- The `MAX_HEADERS` loop is consistently and significantly slower in serialize than the other versions. The "ordered insert" versions have slower deserialize and header inserts than 1.14.0, but serialize is the same. The bitmask version is the same as 1.14.0 in deserialize and header inserts and slightly slower in serialize (definitely not as much as the `MAX_HEADERS` loop).
